### PR TITLE
ci: add branch-protection workflow

### DIFF
--- a/.github/workflows/branch-protection.yml
+++ b/.github/workflows/branch-protection.yml
@@ -1,0 +1,9 @@
+name: Branch Protection
+
+on:
+  pull_request:
+    branches: [main, beta]
+
+jobs:
+  check:
+    uses: ConductionNL/.github/.github/workflows/branch-protection.yml@main


### PR DESCRIPTION
## Summary
- Adds the shared branch-protection workflow from ConductionNL/.github
- Enforces: only `beta` or `hotfix/*` → `main`, only `development`/`main`/`hotfix/*` → `beta`