### PR TITLE
chore: harmonize .gitignore with shared template

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,15 +1,43 @@
+# IDE
 /.idea/
 /*.iml
+*.Identifier
 
+# Dependencies
 /vendor/
 /vendor-bin/*/vendor/
-/composer.lock
+/node_modules/
 
+# Build artifacts
+/js/
+
+# Documentation
+/docs/node_modules/
+/docs/build/
+/docs/.docusaurus/
+/website/node_modules/
+/website/.docusaurus/
+
+# Testing & Quality
 /.php-cs-fixer.cache
 /tests/.phpunit.cache
+/.phpunit.cache/
+.phpunit.cache/
+.phpunit.result.cache
+/coverage/
+/coverage-frontend/
+/phpmetrics/
+/quality-reports/
+/phpqa/
 
-/node_modules/
+# Nextcloud
 /custom_apps/
 /custom-apps/
-/js/
-Zone.Identifier
+/config/
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Claude Code
+.claude/worktrees/


### PR DESCRIPTION
## Summary
- Harmonizes `.gitignore` with the shared cross-project template
- Adds missing patterns: docs build artifacts, phpmetrics, coverage, OS files, Claude Code worktrees
- Organizes entries into clear sections (IDE, Dependencies, Build, Docs, Testing, Nextcloud, OS)

Closes #180