### PR TITLE
fix: align webpack config and sidebar with shared patterns

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,6 +1,7 @@
 <template>
 	<NcContent app-name="zaakafhandelapp">
-		<MainMenu />
+		<MainMenu @open-settings="settingsOpen = true" />
+		<UserSettings :open="settingsOpen" @update:open="settingsOpen = $event" />
 		<RouterView />
 		<SideBars />
 
@@ -26,6 +27,7 @@ import { NcContent } from '@nextcloud/vue'
 import { CnObjectSidebar } from '@conduction/nextcloud-vue'
 import { RouterView } from 'vue-router'
 import MainMenu from './navigation/MainMenu.vue'
+import UserSettings from './views/settings/UserSettings.vue'
 import Modals from './modals/Modals.vue'
 import Dialogs from './dialogs/Dialogs.vue'
 import SideBars from './sidebars/SideBars.vue'
@@ -36,6 +38,7 @@ export default {
 		NcContent,
 		CnObjectSidebar,
 		MainMenu,
+		UserSettings,
 		RouterView,
 		Modals,
 		Dialogs,
@@ -43,6 +46,7 @@ export default {
 	},
 	data() {
 		return {
+			settingsOpen: false,
 			objectSidebarState: {
 				active: false,
 				open: true,

--- a/src/App.vue
+++ b/src/App.vue
@@ -3,6 +3,19 @@
 		<MainMenu />
 		<RouterView />
 		<SideBars />
+
+		<!-- Object sidebar (files/notes/tags/tasks/audit trail — controlled by CnDetailPage) -->
+		<CnObjectSidebar
+			v-if="objectSidebarState.active"
+			:object-type="objectSidebarState.objectType"
+			:object-id="objectSidebarState.objectId"
+			:title="objectSidebarState.title"
+			:subtitle="objectSidebarState.subtitle"
+			:register="objectSidebarState.register"
+			:schema="objectSidebarState.schema"
+			:hidden-tabs="objectSidebarState.hiddenTabs"
+			:open.sync="objectSidebarState.open" />
+
 		<Modals />
 		<Dialogs />
 	</NcContent>
@@ -10,6 +23,7 @@
 
 <script>
 import { NcContent } from '@nextcloud/vue'
+import { CnObjectSidebar } from '@conduction/nextcloud-vue'
 import { RouterView } from 'vue-router'
 import MainMenu from './navigation/MainMenu.vue'
 import Modals from './modals/Modals.vue'
@@ -20,11 +34,32 @@ export default {
 	name: 'App',
 	components: {
 		NcContent,
+		CnObjectSidebar,
 		MainMenu,
 		RouterView,
 		Modals,
 		Dialogs,
 		SideBars,
+	},
+	data() {
+		return {
+			objectSidebarState: {
+				active: false,
+				open: true,
+				objectType: '',
+				objectId: '',
+				title: '',
+				subtitle: '',
+				register: '',
+				schema: '',
+				hiddenTabs: [],
+			},
+		}
+	},
+	provide() {
+		return {
+			objectSidebarState: this.objectSidebarState,
+		}
 	},
 }
 </script>

--- a/src/navigation/MainMenu.vue
+++ b/src/navigation/MainMenu.vue
@@ -98,25 +98,13 @@ import { navigationStore } from '../store/store.js'
 		</NcAppNavigationList>
 
 		<NcAppNavigationSettings>
-			<router-link to="/zaaktypen">
-				<NcAppNavigationItem
-					:active="$route.path.startsWith('/zaaktypen')"
-					name="Zaak Typen">
-					<template #icon>
-						<AlphaTBoxOutline :size="20" />
-					</template>
-				</NcAppNavigationItem>
-			</router-link>
-			<router-link to="/auditTrail">
-				<NcAppNavigationItem
-					:active="$route.path.startsWith('/auditTrail')"
-					name="Audit trail">
-					<template #icon>
-						<SortVariantLock :size="20" />
-					</template>
-				</NcAppNavigationItem>
-			</router-link>
-			<Configuration />
+			<NcAppNavigationItem
+				:name="t('zaakafhandelapp', 'Settings')"
+				@click="$emit('open-settings')">
+				<template #icon>
+					<Cog :size="20" />
+				</template>
+			</NcAppNavigationItem>
 		</NcAppNavigationSettings>
 	</NcAppNavigation>
 </template>
@@ -130,24 +118,21 @@ import {
 	NcAppNavigationSettings,
 } from '@nextcloud/vue'
 
-// Configuration
-import Configuration from './Configuration.vue'
-
 // Icons
 import Finance from 'vue-material-design-icons/Finance.vue'
-import AlphaTBoxOutline from 'vue-material-design-icons/AlphaTBoxOutline.vue'
 import ChatOutline from 'vue-material-design-icons/ChatOutline.vue'
 import AccountGroupOutline from 'vue-material-design-icons/AccountGroupOutline.vue'
 import CalendarMonthOutline from 'vue-material-design-icons/CalendarMonthOutline.vue'
 import BriefcaseAccountOutline from 'vue-material-design-icons/BriefcaseAccountOutline.vue'
 import Plus from 'vue-material-design-icons/Plus.vue'
-import SortVariantLock from 'vue-material-design-icons/SortVariantLock.vue'
 import Magnify from 'vue-material-design-icons/Magnify.vue'
 import CardAccountPhoneOutline from 'vue-material-design-icons/CardAccountPhoneOutline.vue'
 import BadgeAccountOutline from 'vue-material-design-icons/BadgeAccountOutline.vue'
+import Cog from 'vue-material-design-icons/Cog.vue'
 
 export default {
 	name: 'MainMenu',
+	emits: ['open-settings'],
 	components: {
 		NcAppNavigation,
 		NcAppNavigationList,
@@ -157,15 +142,14 @@ export default {
 		// Icons
 		Magnify,
 		Finance,
-		AlphaTBoxOutline,
 		ChatOutline,
 		AccountGroupOutline,
 		CalendarMonthOutline,
 		BriefcaseAccountOutline,
 		Plus,
-		SortVariantLock,
-		Configuration,
 		CardAccountPhoneOutline,
+		BadgeAccountOutline,
+		Cog,
 	},
 }
 </script>

--- a/src/views/settings/UserSettings.vue
+++ b/src/views/settings/UserSettings.vue
@@ -1,0 +1,22 @@
+<!-- SPDX-License-Identifier: EUPL-1.2 -->
+<template>
+    <NcAppSettingsDialog
+        :open="open"
+        :show-navigation="false"
+        :name="t('zaakafhandelapp', 'Zaakafhandelapp settings')"
+        @update:open="$emit('update:open', $event)">
+        <NcAppSettingsSection id="general" :name="t('zaakafhandelapp', 'General')">
+            <template #icon><CogIcon :size="20" /></template>
+            <p>{{ t('zaakafhandelapp', 'User preferences will appear here.') }}</p>
+        </NcAppSettingsSection>
+    </NcAppSettingsDialog>
+</template>
+<script>
+import { NcAppSettingsDialog, NcAppSettingsSection } from '@nextcloud/vue'
+import CogIcon from 'vue-material-design-icons/Cog.vue'
+export default {
+    name: 'UserSettings',
+    components: { NcAppSettingsDialog, NcAppSettingsSection, CogIcon },
+    props: { open: { type: Boolean, default: false } },
+}
+</script>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,5 +1,6 @@
 const path = require('path')
 const webpackConfig = require('@nextcloud/webpack-vue-config')
+const NodePolyfillPlugin = require('node-polyfill-webpack-plugin')
 
 const buildMode = process.env.NODE_ENV
 const isDev = buildMode === 'development'
@@ -46,11 +47,16 @@ webpackConfig.entry = {
 	},
 }
 
-webpackConfig.resolve = {
-	extensions: ['.ts', '.js', '.vue', '.json'],
-	alias: {
-		'@': path.resolve(__dirname, 'src/'),
-	},
+webpackConfig.resolve = webpackConfig.resolve || {}
+webpackConfig.resolve.modules = [path.resolve(__dirname, 'node_modules'), 'node_modules']
+webpackConfig.resolve.alias = {
+	...(webpackConfig.resolve.alias || {}),
+	'@': path.resolve(__dirname, 'src/'),
 }
+
+webpackConfig.plugins = [
+	...(webpackConfig.plugins || []),
+	new NodePolyfillPlugin({ additionalAliases: ['process'] }),
+]
 
 module.exports = webpackConfig


### PR DESCRIPTION
Extend base webpack config instead of replacing it. Add NodePolyfillPlugin and CnObjectSidebar.