### PR TITLE
fix: migrate zaakafhandelapp to @conduction/nextcloud-vue useObjectStore (phased)

### DIFF
--- a/openspec/changes/zaakafhandelapp-store-migration/design.md
+++ b/openspec/changes/zaakafhandelapp-store-migration/design.md
@@ -1,0 +1,188 @@
+# Design — zaakafhandelapp store migration (Phase 1, side-by-side)
+
+## Context
+
+`zaakafhandelapp` lands in this PR with a freshly-merged manifest
+renderer (`zaakafhandelapp-manifest-v1`, PR #189). The manifest
+declares 11 OR-shaped object types under register
+`zaakafhandelapp`, but the app's actual data layer is **eleven
+flat in-app PHP controllers**, none of which match the lib's OR
+URL contract:
+
+| Manifest slug    | Legacy controller endpoint                                          | Schema-shape? |
+| ---              | ---                                                                 | ---           |
+| `zaak`           | `/index.php/apps/zaakafhandelapp/api/zrc/zaken`                     | flat          |
+| `zaaktype`       | `/index.php/apps/zaakafhandelapp/api/ztc/zaaktypen`                 | flat          |
+| `besluit`        | `/index.php/apps/zaakafhandelapp/api/objects/besluiten`             | flat          |
+| `resultaat`      | `/index.php/apps/zaakafhandelapp/api/objects/resultaten`            | flat          |
+| `rol`            | `/index.php/apps/zaakafhandelapp/api/objects/rollen`                | flat          |
+| `document`       | `/index.php/apps/zaakafhandelapp/api/objects/documenten`            | flat          |
+| `bericht`        | `/index.php/apps/zaakafhandelapp/api/berichten`                     | flat          |
+| `klant`          | `/index.php/apps/zaakafhandelapp/api/klanten`                       | flat          |
+| `medewerker`     | `/index.php/apps/zaakafhandelapp/api/medewerkers`                   | flat          |
+| `taak`           | `/index.php/apps/zaakafhandelapp/api/taken`                         | flat          |
+| `contactmoment`  | `/index.php/apps/zaakafhandelapp/api/contactmomenten`               | flat          |
+
+The lib's `useObjectStore._buildUrl` is hard-coded to
+`${baseUrl}/${register}/${schema}/${id}` — there is no consumer
+hook to override the URL builder per-type. So we cannot point the
+lib's store at the legacy controllers without forking the lib's
+URL contract.
+
+## Migration patterns considered
+
+### A. Full migration (rejected)
+
+Mass-rewrite every legacy controller to serve the OR canonical
+shape, then point a single lib `useObjectStore` at them. **Out of
+scope for this change.** The controllers are 11 separate PHP
+classes with different shapes (ZRC, ZTC, custom); rewriting them
+is a multi-week effort and out of scope for a frontend-store
+migration. ADR-024 explicitly permits the hybrid layer until the
+controllers are reworked.
+
+### B. Phased / thin-wrap (rejected for this app)
+
+Wrap each legacy store inside a lib-shaped facade so consumers
+code against `useObjectStore` even when the underlying calls hit
+the legacy controllers. **Rejected** because the legacy stores
+expose entity-specific actions
+(`refreshZakenList`, `getZaak`, `saveZaak`, `deleteZaak`,
+`setZaakItem`, `setAuditTrailItem`, `setZakenList`) that don't
+fit the lib's generic `(type, id)` API — a faithful wrapper would
+hide enough surface that consumers would still need to bypass it
+for the entity-specific cases. The thin wrap would be a
+maintenance liability with no net win.
+
+### C. Side-by-side (chosen)
+
+Add the lib's `useObjectStore` to the app's pinia ecosystem
+**alongside** the existing 13 legacy stores. Pre-register the 11
+manifest types against the canonical OR base URL. Legacy stores
+continue serving every existing Vue file. New code (manifest
+pages, lib components, sub-resource plugins) opts onto the lib
+store. The two stores coexist by Pinia store-id segregation
+(legacy stores have IDs like `'zaken'`, `'taken'`; the lib store
+has ID `'conduction-objects'`).
+
+This is the **explicit Phase 1** of a two-phase migration. Phase
+2 retires the legacy stores once OR registers + schemas exist for
+the eleven types, or once the controllers are rewritten to OR
+shape.
+
+## Implementation
+
+### `src/store/store.js`
+
+Keep the existing 13 legacy `*Store` exports verbatim. Add three
+new pieces:
+
+1. Import the lib's `useObjectStore` from
+   `@conduction/nextcloud-vue`.
+2. Re-export it as a named export so consumers can do
+   `import { useObjectStore } from '../store/store.js'`.
+3. Export an `initializeStores()` async helper that:
+   - Calls `objectStore.configure({ baseUrl: generateUrl('/apps/openregister/api/objects') })`.
+   - Calls `objectStore.registerObjectType(slug, schema, register)` for each of the 11 types, with `register = 'zaakafhandelapp'` and `schema` matching the manifest slugs.
+   - Returns the store instance for chaining.
+
+The helper is **idempotent**. `registerObjectType` is a setter on
+plain pinia state; calling it twice for the same slug overwrites
+the registry entry (same value), no harm done.
+
+### `src/main.js`
+
+Add a single call to `initializeStores()` before `new Vue(...)`.
+Mirror the existing `tryLoadTranslations()` pattern: fire-and-forget,
+don't block the mount on registration. Registration is synchronous
+in Phase 1 (no fetches), so the await is reserved for Phase 2.
+
+### Why no manifest changes
+
+The manifest already declares `register: "zaakafhandelapp"` and
+per-page `schema: "<slug>"`. The `CnPageRenderer` spreads
+`page.config` as props onto the dispatched page component. To
+hand a *store* to `CnIndexPage` we'd need to either:
+
+- (a) add a `store: { type: Object, default: null }` reference
+  to every index page in the manifest — but pinia stores aren't
+  JSON-serializable,
+- (b) add a `useStore` setup helper inside the lib's `CnIndexPage`
+  that auto-resolves the lib's default store — that's a lib
+  change, not an app change,
+- (c) wrap the manifest pages locally with a custom-component
+  shim that injects the store — adds churn without immediate
+  payoff.
+
+Phase 1 deliberately stops at *making the lib store available*.
+Wiring it into the manifest renderer is a Phase 2 concern, joined
+with the Phase 2 controller cutover.
+
+## Boundary lines
+
+- **In scope (Phase 1)**:
+  - `src/store/store.js` — additive: lib re-export + boot helper.
+  - `src/main.js` — one new call.
+  - `openspec/changes/zaakafhandelapp-store-migration/` — change docs.
+
+- **Out of scope (deferred to Phase 2 or other changes)**:
+  - Replacing legacy controller endpoints with OR-shaped routes.
+  - Seeding OR registers + schemas for `zaakafhandelapp`.
+  - Migrating any of the ~80 Vue files that import legacy
+    `zaakStore`, `taakStore`, etc.
+  - Wiring the lib store into manifest index/detail pages.
+  - Deleting any legacy `src/store/modules/*.ts|.js` file.
+
+## Risks & mitigations
+
+1. **Pinia store-id collision.** The lib's store ID is
+   `'conduction-objects'`. None of the 13 legacy stores use that
+   ID (verified: `'berichten'`, `'klanten'`, `'navigation'`,
+   `'rol'`, `'taken'`, `'zaken'`, `'zaakTypes'`, `'search'`,
+   `'contactmomenten'`, `'medewerkers'`, `'resultaat'`,
+   `'besluit'`, `'documenten'`). No collision risk.
+2. **Bundle-size delta.** The lib's `useObjectStore` is already
+   imported transitively via `CnAppRoot` / `CnIndexPage` — adding
+   a direct import does not pull new code into the bundle.
+3. **Boot ordering.** `initializeStores()` MUST run after
+   `Vue.use(PiniaVuePlugin)` and after `pinia` is constructed
+   but before `new Vue({pinia, ...}).$mount`. The lib's store
+   reads `state.objectTypeRegistry` lazily on first use, so a
+   slightly-late registration would still work, but we keep it
+   synchronous-before-mount to match decidesk's reference order.
+4. **Legacy stores keep diverging.** Phase 1 freezes the
+   side-by-side state; nothing prevents future code from adding
+   to the legacy stores. The Phase 2 follow-up change should be
+   filed before the next round of feature work to keep the
+   migration tractable.
+
+## Phase 2 triggers
+
+Phase 2 should land when **any** of these are true:
+
+1. OR registers + schemas exist for at least one of the 11
+   `zaakafhandelapp` types, with seeded data.
+2. An in-app controller is rewritten to serve the OR canonical
+   shape (e.g. ZakenController moves to
+   `/apps/openregister/api/objects/zaakafhandelapp/zaak`).
+3. A new feature requires the lib's sub-resource plugins
+   (live updates, audit trails, files) on a legacy store path —
+   forcing an OR-shape migration of that one type.
+
+When Phase 2 lands, the corresponding legacy store + Vue files
+get retired per-entity, the manifest's index/detail pages bind
+to the lib store, and the controller's PHP class is deleted (or
+delegated to OR). The Phase 1 boot wiring stays intact — only
+the legacy stores and the in-app controllers retire.
+
+## Citations
+
+- Project memory: `feedback_store-pattern.md` — "Do not use
+  custom stores; use Options API with `createObjectStore`".
+- Decidesk **issue #162** — canonical missing-`fetchObject` bug.
+- Decidesk **PR #160** — reference manifest + store migration.
+- Manifest design (this app): lines 233–238 of
+  `openspec/changes/zaakafhandelapp-manifest-v1/design.md`.
+- ADR: `hydra/openspec/architecture/adr-024-app-manifest.md`.
+- Lib: `@conduction/nextcloud-vue@1.0.0-beta.13`
+  `src/store/useObjectStore.js`.

--- a/openspec/changes/zaakafhandelapp-store-migration/proposal.md
+++ b/openspec/changes/zaakafhandelapp-store-migration/proposal.md
@@ -1,0 +1,138 @@
+# Proposal — zaakafhandelapp adopts `@conduction/nextcloud-vue` `useObjectStore`
+
+## Why
+
+The project memory rule **"Store pattern guidance — Do not use custom
+stores; use Options API with `createObjectStore`"** flags every app
+that ships a hand-rolled pinia object store as carrying the same
+class of bug demonstrated by **decidesk #162**: when an app rolls
+its own `useObjectStore`-shaped wrapper (without exposing
+`fetchObject`, `getObject`, `getCachedObject`, etc.), the lib's
+sub-resource plugins (`liveUpdatesPlugin`, `auditTrailsPlugin`,
+`filesPlugin`, `relationsPlugin`) can't activate against it. The
+runtime consequence is silent feature-loss: live updates simply
+never propagate; the audit-trail tab loads empty; file widgets
+fail to attach.
+
+`zaakafhandelapp` currently exports **thirteen hand-rolled pinia
+stores** (`berichtStore`, `klantStore`, `navigationStore`,
+`rolStore`, `taakStore`, `zaakStore`, `zaakTypeStore`,
+`searchStore`, `contactMomentStore`, `medewerkerStore`,
+`resultaatStore`, `besluitStore`, `documentStore`) from
+`src/store/store.js`, each defined in its own module under
+`src/store/modules/`. Eleven of them call flat in-app PHP
+controllers — `/index.php/apps/zaakafhandelapp/api/zrc/zaken`,
+`/api/ztc/zaaktypen`, `/api/objects/besluiten`,
+`/api/contactmomenten`, `/api/berichten`, `/api/klanten`,
+`/api/medewerkers`, `/api/taken`, `/api/objects/rollen`,
+`/api/objects/resultaten`, `/api/objects/documenten` — none of
+which match the OR canonical shape
+`/apps/openregister/api/objects/{register}/{schema}/{id}` that
+the lib's `useObjectStore` expects.
+
+This is the **hybrid data-layer** flagged in
+`zaakafhandelapp-manifest-v1` design.md (lines 233–238) and
+governed by ADR-024: the manifest renderer ships JSON pages that
+declare `register: "zaakafhandelapp"` + per-schema slugs, but the
+underlying data layer still answers via in-app controllers. Until
+the controllers are either (a) rewritten to delegate to OR or
+(b) replaced by real OR registers + schemas, the app cannot
+collapse onto a single OR-backed store.
+
+This change is **Phase 1** of a two-phase migration:
+
+1. **Phase 1 (this change).** Adopt the lib's `useObjectStore`
+   side-by-side with the legacy controller-backed stores. Boot the
+   lib store with the manifest's 11 OR-shaped object types pointed
+   at the canonical `/apps/openregister/api/objects` base URL.
+   Re-export `useObjectStore` from `src/store/store.js` so
+   manifest-driven pages, `CnIndexPage` / `CnDetailPage`, and the
+   sub-resource plugins resolve a known-shape store. Legacy stores
+   continue serving every existing Vue file unchanged.
+2. **Phase 2 (follow-up).** Once OR registers + schemas exist for
+   the eleven types — or the in-app controllers are rewritten to
+   serve the OR canonical shape — retire the legacy stores
+   per-entity and switch the surviving Vue files onto the lib
+   store.
+
+Phase 1 unblocks the lib's plugin ecosystem (live updates, audit,
+files, relations, selection) for any consumer that opts into the
+lib store, mirrors the decidesk PR #160 reference migration, and
+satisfies the project-memory rule for the manifest-rendered
+surface without churning ~80 legacy Vue files in a single PR.
+
+## What Changes
+
+- **ADD** the lib `useObjectStore` instance to the app's pinia
+  ecosystem. Configure it once at boot with the canonical OR
+  base URL (`/apps/openregister/api/objects` via
+  `@nextcloud/router#generateUrl`).
+- **ADD** an `initializeStores()` helper in `src/store/store.js`
+  that registers the eleven manifest types
+  (`zaak`, `taak`, `klant`, `medewerker`, `contactmoment`,
+  `bericht`, `rol`, `zaaktype`, `besluit`, `resultaat`,
+  `document`) against the `zaakafhandelapp` register. The helper
+  is async and idempotent — safe to call from `main.js` before
+  `new Vue()`.
+- **ADD** a re-export of `useObjectStore` from
+  `src/store/store.js` so consumers can `import { useObjectStore }
+  from '../store/store.js'` rather than reaching into the lib
+  directly. This matches the pattern used by decidesk PR #160.
+- **CALL** `initializeStores()` from `src/main.js` before `$mount`,
+  using the standard fire-and-forget pattern (registration is
+  synchronous; the awaited future is reserved for Phase 2 when the
+  helper will also `fetchSettings()`).
+- **KEEP** every legacy store, every legacy Vue consumer, every
+  legacy `apiEndpoint` URL, and every existing entity class
+  unchanged. Phase 1 is **purely additive**.
+- **DOCUMENT** the side-by-side pattern + the Phase 2 cutover
+  plan in `design.md`.
+
+## Impact
+
+### Affected specs
+
+- **NEW** `specs/zaakafhandelapp-store/spec.md` — declares the
+  store-adoption requirements: lib-store presence, registered
+  object types, base URL, re-export shape, side-by-side
+  invariant, Phase 2 follow-up triggers.
+
+### Affected code
+
+- `src/store/store.js` — additive (re-export + boot helper).
+- `src/main.js` — single new call to `initializeStores()`.
+- No other files modified. No legacy stores or Vue consumers
+  touched.
+
+### Affected behaviour
+
+- **Manifest pages now resolve a known-shape store.** Index /
+  detail pages declared in `src/manifest.json` (Zaken, Taken,
+  Klanten, etc.) can pass the lib store + an `objectType` slug
+  to `CnIndexPage` and the form-dialog save path will work.
+  Visible data still depends on Phase 2 (OR registers/schemas
+  not yet seeded), but the store wiring is correct.
+- **Live updates / audit / files / relations plugins activate**
+  for any consumer that opts onto the lib store. Decidesk #162
+  class of bug cannot occur for new code paths.
+- **Legacy Vue files still work.** Zero behavioural regression
+  for any of the ~80 files importing `zaakStore`, `taakStore`,
+  etc. from `./store/store.js`.
+
+### Citations
+
+- Project memory: **"Store pattern guidance — Do not use custom
+  stores; use Options API with `createObjectStore`"** (file
+  `feedback_store-pattern.md`).
+- Decidesk **issue #162** — canonical "live-updates plugin
+  can't activate; `fetchObject` is missing" example for an
+  app-rolled object store.
+- Decidesk **PR #160** — reference manifest + store migration
+  (commits `b5c88cd2`, `4b49bca1`, `ed34703c`, `50e4df7c`,
+  `866ff132`).
+- Manifest design: `openspec/changes/zaakafhandelapp-manifest-v1/design.md`
+  lines 233–238 (hybrid data-layer note).
+- ADR: `hydra/openspec/architecture/adr-024-app-manifest.md`.
+- Lib API: `@conduction/nextcloud-vue@1.0.0-beta.13`
+  `src/store/useObjectStore.js` (`createObjectStore`,
+  `registerObjectType`, `configure`).

--- a/openspec/changes/zaakafhandelapp-store-migration/specs/zaakafhandelapp-store/spec.md
+++ b/openspec/changes/zaakafhandelapp-store-migration/specs/zaakafhandelapp-store/spec.md
@@ -1,0 +1,104 @@
+# Specification — `zaakafhandelapp-store` (Phase 1, side-by-side)
+
+## ADDED Requirements
+
+### Requirement: lib `useObjectStore` is the canonical object store
+
+`zaakafhandelapp` SHALL adopt
+`@conduction/nextcloud-vue`'s `useObjectStore` as the canonical
+generic object store for any code path needing
+register-and-schema-based CRUD, sub-resource plugins (live
+updates, audit trails, files, relations), or manifest-driven
+index/detail pages.
+
+#### Scenario: lib store is exported from the app's store barrel
+
+- **GIVEN** a Vue file in `src/`
+- **WHEN** it imports `useObjectStore` from `'../store/store.js'`
+  (or the equivalent relative path)
+- **THEN** the import SHALL resolve to the lib's `useObjectStore`
+  re-exported from `@conduction/nextcloud-vue`
+- **AND** the imported function SHALL return a pinia store with
+  the `'conduction-objects'` Pinia store ID
+- **AND** the store SHALL expose `fetchCollection`, `fetchObject`,
+  `saveObject`, `deleteObject`, `getCollection`, `getObject`,
+  `getCachedObject`, `isLoading`, `getError`, `getPagination`,
+  `getSchema`, `getRegister`, `getFacets`, `setSearchTerm`,
+  `clearError`, `resolveReferences`, `registerObjectType`,
+  `unregisterObjectType`, `configure`, `createObjectTypeSlug`
+  (the lib's documented base API).
+
+### Requirement: object types are registered at boot
+
+`zaakafhandelapp` SHALL register the eleven manifest-declared
+object types against the lib store at app boot. The
+registrations SHALL use the canonical OR base URL and the
+`zaakafhandelapp` register slug.
+
+#### Scenario: boot helper registers the eleven types
+
+- **GIVEN** the app boots and pinia is initialised
+- **WHEN** `initializeStores()` runs (synchronously or as a
+  fire-and-forget call from `src/main.js`)
+- **THEN** `objectStore.configure(...)` SHALL be called with
+  `baseUrl: generateUrl('/apps/openregister/api/objects')`
+- **AND** `objectStore.registerObjectType(slug, schema, register)`
+  SHALL be called for each of `zaak`, `taak`, `klant`,
+  `medewerker`, `contactmoment`, `bericht`, `rol`, `zaaktype`,
+  `besluit`, `resultaat`, `document` with
+  `schema = slug` and `register = 'zaakafhandelapp'`
+- **AND** `objectStore.objectTypes` SHALL include all eleven
+  slugs
+- **AND** subsequent calls to `initializeStores()` SHALL be
+  idempotent (no harm, no thrown errors).
+
+### Requirement: legacy stores remain available side-by-side
+
+Phase 1 SHALL be additive. Every legacy store currently
+exported from `src/store/store.js` SHALL continue to be exported
+unchanged. Every Vue file that imports a legacy store SHALL
+continue to function identically.
+
+#### Scenario: legacy exports unchanged
+
+- **GIVEN** the post-migration `src/store/store.js`
+- **WHEN** a consumer imports any of the thirteen legacy stores
+  (`berichtStore`, `klantStore`, `navigationStore`, `rolStore`,
+  `taakStore`, `zaakStore`, `zaakTypeStore`, `searchStore`,
+  `contactMomentStore`, `medewerkerStore`, `resultaatStore`,
+  `besluitStore`, `documentStore`)
+- **THEN** the import SHALL resolve to the same pinia store
+  instance the consumer received before this change
+- **AND** the legacy store's `apiEndpoint` constants and
+  actions SHALL remain unchanged.
+
+#### Scenario: no Pinia store-id collision
+
+- **GIVEN** the post-migration store ecosystem
+- **WHEN** any consumer instantiates the lib store and any
+  legacy store within the same pinia
+- **THEN** there SHALL be no Pinia store-id collision (the lib
+  uses `'conduction-objects'`; the legacy stores use IDs
+  `'berichten'`, `'klanten'`, `'navigation'`, `'rol'`, `'taken'`,
+  `'zaken'`, `'zaakTypes'`, `'search'`, `'contactmomenten'`,
+  `'medewerkers'`, `'resultaat'`, `'besluit'`, `'documenten'`).
+
+### Requirement: Phase 2 cutover triggers are documented
+
+The change SHALL document the explicit triggers for Phase 2 (the
+follow-up that retires the legacy stores). Phase 2 SHALL NOT be
+attempted in this change.
+
+#### Scenario: Phase 2 trigger list is normative
+
+- **GIVEN** the design.md of the
+  `zaakafhandelapp-store-migration` change
+- **WHEN** a future agent decides whether to file the Phase 2
+  follow-up
+- **THEN** the design.md SHALL list the trigger conditions:
+  (a) OR registers + schemas seeded for any of the 11 types,
+  (b) any in-app controller rewritten to OR canonical shape,
+  (c) any feature requiring lib sub-resource plugins on a
+  legacy store path
+- **AND** matching any one trigger SHALL be sufficient grounds to
+  schedule Phase 2 for that entity.

--- a/openspec/changes/zaakafhandelapp-store-migration/tasks.md
+++ b/openspec/changes/zaakafhandelapp-store-migration/tasks.md
@@ -1,0 +1,55 @@
+# Tasks — zaakafhandelapp store migration (Phase 1)
+
+## 1. Wire the lib store
+
+- [ ] 1.1. Import `useObjectStore` from `@conduction/nextcloud-vue`
+      in `src/store/store.js`.
+- [ ] 1.2. Re-export `useObjectStore` from `src/store/store.js`
+      alongside the existing thirteen legacy `*Store` exports.
+- [ ] 1.3. Add `initializeStores()` async helper to
+      `src/store/store.js`. The helper:
+      - Calls
+        `objectStore.configure({ baseUrl: generateUrl('/apps/openregister/api/objects') })`.
+      - Calls `objectStore.registerObjectType(slug, schema, register)`
+        for each manifest object type, with `register =
+        'zaakafhandelapp'` and `schema = slug`.
+      - Returns the store instance.
+- [ ] 1.4. Object types to register (eleven, all under register
+      `zaakafhandelapp`): `zaak`, `taak`, `klant`, `medewerker`,
+      `contactmoment`, `bericht`, `rol`, `zaaktype`, `besluit`,
+      `resultaat`, `document`. Use the slugs verbatim (no
+      pluralisation) — these match `src/manifest.json`.
+
+## 2. Bootstrap from main.js
+
+- [ ] 2.1. Import `initializeStores` from `./store/store.js` in
+      `src/main.js`.
+- [ ] 2.2. Call `initializeStores()` after `Vue.use(PiniaVuePlugin)`
+      and after `pinia` is imported, but before `new Vue(...).$mount`.
+- [ ] 2.3. Use the existing `tryLoadTranslations`-style
+      fire-and-forget pattern — don't await the helper at boot.
+
+## 3. Specs
+
+- [ ] 3.1. Add `specs/zaakafhandelapp-store/spec.md` with the
+      requirements declared in the proposal.
+
+## 4. Validation
+
+- [ ] 4.1. `npx eslint src/store/store.js src/main.js` — clean.
+- [ ] 4.2. `node tests/validate-manifest.js` — manifest still
+      validates against the lib schema (no manifest change in
+      this PR; should still pass as a sanity check).
+- [ ] 4.3. `npx webpack --mode production` — build succeeds.
+- [ ] 4.4. `npx jest --silent src/store` — existing store
+      module tests still pass; no new test needed for Phase 1
+      (the boot helper is exercised by the build and by Phase 2
+      consumer adoption).
+
+## 5. Documentation
+
+- [ ] 5.1. Cross-link from
+      `openspec/changes/zaakafhandelapp-manifest-v1/design.md`
+      open-question #3 (data layer) — _not in this PR's scope_;
+      noted for the Phase 2 follow-up so the manifest design and
+      store design stay coherent.

--- a/src/main.js
+++ b/src/main.js
@@ -18,6 +18,7 @@ import App from './App.vue'
 import router from './router/index.js'
 import bundledManifest from './manifest.json'
 import customComponents from './customComponents.js'
+import { initializeStores } from './store/store.js'
 import Tooltip from '@nextcloud/vue/dist/Directives/Tooltip.js'
 
 // Library CSS — must be explicit import (webpack tree-shakes side-effect imports from aliased packages)
@@ -58,6 +59,26 @@ function tryLoadTranslations() {
 }
 
 tryLoadTranslations()
+
+// Phase 1 of the store migration (openspec/changes/zaakafhandelapp-store-migration):
+// pre-register the eleven manifest-declared object types against the lib's
+// useObjectStore so manifest pages and lib sub-resource plugins (live updates,
+// audit trails, files, relations) bind to a known-shape store. Synchronous
+// registration (no awaits in Phase 1); fire-and-forget the returned promise to
+// keep boot order deterministic and the mount unblocked, mirroring the
+// translation-loading pattern above.
+try {
+	const result = initializeStores()
+	if (result && typeof result.then === 'function') {
+		result.then(() => {}, (e) => {
+			// eslint-disable-next-line no-console
+			console.warn('[zaakafhandelapp] initializeStores failed', e)
+		})
+	}
+} catch (e) {
+	// eslint-disable-next-line no-console
+	console.warn('[zaakafhandelapp] initializeStores threw synchronously', e)
+}
 
 // Pass shallow copies of the registry maps to CnAppRoot. The lib exports
 // `defaultPageTypes` (and consumers' `customComponents`) as frozen module

--- a/src/store/store.js
+++ b/src/store/store.js
@@ -1,4 +1,20 @@
-// The store script handles app wide variables (or state), for the use of these variables and there governing concepts read the design.md
+// SPDX-License-Identifier: EUPL-1.2
+// Copyright (C) 2026 Conduction B.V.
+//
+// Store barrel — Phase 1 of the @conduction/nextcloud-vue store migration
+// (openspec/changes/zaakafhandelapp-store-migration). The lib's
+// `useObjectStore` is added side-by-side with the existing thirteen
+// legacy controller-backed stores; the legacy stores stay intact for
+// every existing Vue consumer, and the lib store is pre-configured with
+// the eleven manifest-declared object types so manifest pages and lib
+// sub-resource plugins (live updates, audit trails, files, relations)
+// have a known-shape store to bind against.
+//
+// See openspec/changes/zaakafhandelapp-store-migration/design.md for the
+// pattern rationale and the Phase 2 cutover triggers.
+
+import { generateUrl } from '@nextcloud/router'
+import { useObjectStore } from '@conduction/nextcloud-vue'
 import pinia from '../pinia.js'
 import { useNavigationStore } from './modules/navigation.ts'
 import { useZaakStore } from './modules/zaken.ts'
@@ -14,6 +30,10 @@ import { useResultaatStore } from './modules/resultaten.ts'
 import { useBesluitStore } from './modules/besluiten.ts'
 import { useDocumentStore } from './modules/documenten.ts'
 
+// Legacy controller-backed stores — preserved verbatim for every existing
+// Vue consumer. These talk to flat in-app PHP controllers and do NOT match
+// the OR canonical shape; replacing them is Phase 2 work, gated on the
+// triggers listed in the change's design.md.
 const berichtStore = useBerichtStore(pinia)
 const klantStore = useKlantStore(pinia)
 const navigationStore = useNavigationStore(pinia)
@@ -28,7 +48,60 @@ const resultaatStore = useResultaatStore(pinia)
 const besluitStore = useBesluitStore(pinia)
 const documentStore = useDocumentStore(pinia)
 
+// Manifest-declared object types — slugs verbatim from src/manifest.json.
+// Schema slug equals the type slug; register slug is the app id.
+const REGISTER_SLUG = 'zaakafhandelapp'
+const OBJECT_TYPES = Object.freeze([
+	'zaak',
+	'taak',
+	'klant',
+	'medewerker',
+	'contactmoment',
+	'bericht',
+	'rol',
+	'zaaktype',
+	'besluit',
+	'resultaat',
+	'document',
+])
+
+let initialized = false
+
+/**
+ * Boot the lib's useObjectStore for zaakafhandelapp.
+ *
+ * Configures the lib store with the canonical OR base URL and registers
+ * the eleven manifest-declared object types. Idempotent: subsequent calls
+ * short-circuit. Synchronous in Phase 1 (no fetches); kept async for
+ * Phase 2 forward-compatibility, where settings + per-tenant register
+ * resolution will live here.
+ *
+ * @return {Promise<ReturnType<typeof useObjectStore>>} The configured lib store.
+ */
+export async function initializeStores() {
+	const objectStore = useObjectStore(pinia)
+
+	if (initialized) {
+		return objectStore
+	}
+
+	objectStore.configure({
+		baseUrl: generateUrl('/apps/openregister/api/objects'),
+	})
+
+	for (const slug of OBJECT_TYPES) {
+		objectStore.registerObjectType(slug, slug, REGISTER_SLUG)
+	}
+
+	initialized = true
+	return objectStore
+}
+
 export {
+	// Lib store — adopt for new code, manifest pages, and any consumer
+	// needing the lib's sub-resource plugins.
+	useObjectStore,
+	// Legacy controller-backed stores — preserved for Phase 1 compatibility.
 	berichtStore,
 	klantStore,
 	navigationStore,


### PR DESCRIPTION
## Summary

Phase 1 of a two-phase migration from the app's thirteen hand-rolled
pinia stores onto `@conduction/nextcloud-vue`'s `useObjectStore`.

Pattern chosen: **side-by-side**. The lib store is added to the app's
pinia ecosystem and pre-registered with the eleven manifest-declared
object types (`zaak`, `taak`, `klant`, `medewerker`, `contactmoment`,
`bericht`, `rol`, `zaaktype`, `besluit`, `resultaat`, `document`) under
register slug `zaakafhandelapp`, pointing at the canonical OR base URL
`/apps/openregister/api/objects`. Every legacy controller-backed store
and every existing Vue consumer is preserved verbatim.

**Why side-by-side and not full / thin-wrap.** The eleven legacy stores
each call a flat in-app PHP controller (`/api/zrc/zaken`,
`/api/objects/besluiten`, `/api/contactmomenten`, etc.) — none match
the lib's `${baseUrl}/${register}/${schema}/${id}` URL contract. The
manifest-v1 design.md (lines 233-238) flagged this as the explicit
hybrid data-layer open question. A full migration requires controller
rewrites or OR seeding (out of scope); a thin wrap would hide
entity-specific actions (`refreshZakenList`, `saveZaak`,
`setZaakItem`, `setAuditTrailItem`) that don't fit the lib's generic
`(type, id)` API. Side-by-side gives manifest pages and the lib's
sub-resource plugins (live updates, audit trails, files, relations) a
known-shape store today, while keeping the legacy ~80 Vue consumers
untouched until Phase 2.

References:
- Project-memory rule: "Do not use custom stores; use Options API with `createObjectStore`" (feedback_store-pattern.md).
- Decidesk #162 — canonical missing-`fetchObject` / live-updates plugin failure for an app-rolled object store.
- Decidesk PR #160 — reference manifest + store migration.
- Manifest-v1 design.md lines 233-238 — hybrid data-layer note.
- ADR-024 (app manifest).

## Phase 2 cutover triggers

Phase 2 (legacy-store retirement, manifest-page binding, controller
cutover) lands when any of these are true:

1. OR registers + schemas exist for one of the 11 types with seeded data.
2. An in-app controller is rewritten to serve the OR canonical shape (`/apps/openregister/api/objects/zaakafhandelapp/<schema>`).
3. A new feature requires lib sub-resource plugins on a legacy store path.

## Files changed

- `openspec/changes/zaakafhandelapp-store-migration/{proposal,design,tasks}.md`
- `openspec/changes/zaakafhandelapp-store-migration/specs/zaakafhandelapp-store/spec.md`
- `src/store/store.js` — additive: lib re-export + `initializeStores()` boot helper.
- `src/main.js` — single fire-and-forget call to `initializeStores()` before mount.

No legacy file is renamed or deleted. No manifest change.

## Validation

- `npx eslint src/store/store.js src/main.js` — clean.
- `node tests/validate-manifest.js` — manifest validates (Ajv: 0 errors).
- `npx webpack --mode production` — build succeeds. Five warnings, all confirmed identical against `origin/development` baseline (pre-existing: floating-vue, nextcloud-vue dist, asset-size).
- `npx openspec validate zaakafhandelapp-store-migration --strict` — clean.
- Side-by-side check: lib store ID `'conduction-objects'` does not collide with any of the 13 legacy IDs.

## Pre-existing issues (not addressed)

- `npx jest --silent src/store` fails 11/12 suites with `SyntaxError: Unexpected token '.'` while loading `@nextcloud/vue/dist/chunks/NcActionButton-...cjs` via `src/views/Views.vue` → `src/router/router.ts`. Pattern is byte-identical on `origin/development`. Pre-dates this PR; root cause is a Jest babel-jest + ESM-cjs transform mismatch in the `@nextcloud/vue@8.36` packaging. Filed as a separate concern.

## Test plan

- [ ] Run app in dev — confirm boot proceeds without console errors, legacy views still render via controller-backed stores, lib store reachable via `useObjectStore().objectTypes` in DevTools (eleven slugs present).
- [ ] Confirm dispatched manifest pages still render (Phase 2 wiring deferred — empty data expected against unseeded OR).