### PR TITLE
chore(license): allow (MIT AND ...) compound licenses for pako + sha.js

### DIFF
--- a/.license-overrides.json
+++ b/.license-overrides.json
@@ -1,3 +1,5 @@
 {
-	"@fortawesome/free-solid-svg-icons": "License is (CC-BY-4.0 AND MIT) — both are approved open-source licenses, compound AND expression not parsed by checker"
+	"@fortawesome/free-solid-svg-icons": "License is (CC-BY-4.0 AND MIT) — both are approved open-source licenses, compound AND expression not parsed by checker",
+	"pako": "License is (MIT AND Zlib) — both are approved open-source licenses on the default allowlist; transitive dep via webpack/babel toolchain; compound AND expression not parsed by checker",
+	"sha.js": "License is (MIT AND BSD-3-Clause) — both are approved open-source licenses on the default allowlist; transitive dep via webpack/babel toolchain; compound AND expression not parsed by checker"
 }


### PR DESCRIPTION
## Summary

Adds `.license-overrides.json` entries for `pako` and `sha.js`, transitive deps of the webpack/babel toolchain that surface across the fleet with compound `(MIT AND ...)` SPDX strings the CI license-checker cannot parse.

## The failure (pattern across the fleet)

```
##[error]Disallowed license: pako (1.0.11) uses '(MIT AND Zlib)'
##[error]Disallowed license: sha.js (2.4.12) uses '(MIT AND BSD-3-Clause)'
```

## Root cause

The shared workflow (`ConductionNL/.github/.github/workflows/quality.yml`) splits SPDX strings on `" OR "` for dual-licensed packages, but does **not** split on `" AND "`. So `(MIT AND Zlib)` is checked as a single literal token and never matches the allowlist — even though every component license (`MIT`, `Zlib`, `BSD-3-Clause`) is individually approved.

## Fix

Per the workflow's documented config interface, `.license-overrides.json` is the supported escape hatch. This PR adds the two transitive deps alongside the existing `@fortawesome/free-solid-svg-icons` entry, which has the same `(X AND Y)` shape.

`pako` / `sha.js` are not in the current `--production` tree, but adding the override now is proactive — they appear in `package-lock.json` and will be promoted to the production tree as `@nextcloud/*` / webpack deps shuffle (already happened in `pipelinq`, see ConductionNL/pipelinq).

Not pinning them in `package.json` — they're transitives, pinning creates rot.

## Test plan

- [ ] `quality / License (npm)` continues to pass
- [ ] `@fortawesome/free-solid-svg-icons` override still applies