### PR TITLE
chore(deps): bump @conduction/nextcloud-vue to ^1.0.0-beta.40

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
             "hasInstallScript": true,
             "license": "EUPL-1.2",
             "dependencies": {
-                "@conduction/nextcloud-vue": "^1.0.0-beta.30",
+                "@conduction/nextcloud-vue": "^1.0.0-beta.40",
                 "@fortawesome/fontawesome-svg-core": "^6.5.2",
                 "@fortawesome/free-solid-svg-icons": "^6.5.2",
                 "@nextcloud/axios": "~2.5.2",
@@ -2079,9 +2079,9 @@
             }
         },
         "node_modules/@conduction/nextcloud-vue": {
-            "version": "1.0.0-beta.30",
-            "resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-1.0.0-beta.30.tgz",
-            "integrity": "sha512-VrynA0mukFikJt4Ey9a3r42GqvdtUF5PeOaqs8SKrPmkPwfySQnIHgdzETer3w1Nm1rcVlnWCHWFmAXFXZROzw==",
+            "version": "1.0.0-beta.40",
+            "resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-1.0.0-beta.40.tgz",
+            "integrity": "sha512-tiC0MZT3mPupFRgB9F5p0FY6o50PDwc2seGcAKENO8aFpgCQOgudJs+s1FiprtEJ19RX6tMDByXeeD2Cxd9eyw==",
             "license": "EUPL-1.2",
             "dependencies": {
                 "@codemirror/autocomplete": "^6.0.0",
@@ -2094,12 +2094,14 @@
                 "@codemirror/search": "^6.0.0",
                 "@codemirror/state": "^6.0.0",
                 "@codemirror/view": "^6.0.0",
+                "@microsoft/fetch-event-source": "^2.0.1",
                 "@nextcloud/dialogs": "^7.3.0",
                 "@nextcloud/notify_push": "^1.0.0",
                 "@uiw/codemirror-theme-github": "^4.25.8",
                 "@vueuse/core": "^10.0.0",
                 "apexcharts": "^4.7.0",
                 "codemirror": "^6.0.0",
+                "dompurify": "^3.0.0",
                 "gridstack": "^10.3.1",
                 "leaflet": "^1.9.0",
                 "lodash": "^4.17.21",
@@ -2111,6 +2113,7 @@
                 "vue-template-compiler": "^2.7.16"
             },
             "peerDependencies": {
+                "@nextcloud/auth": "^2.0.0 || ^3.0.0",
                 "@nextcloud/axios": "^2.0.0",
                 "@nextcloud/capabilities": "^1.2.1",
                 "@nextcloud/l10n": "^2.0.0 || ^3.0.0",
@@ -4254,6 +4257,12 @@
             "resolved": "https://registry.npmjs.org/@mdi/js/-/js-7.4.47.tgz",
             "integrity": "sha512-KPnNOtm5i2pMabqZxpUz7iQf+mfrYZyKCZ8QNz85czgEt7cuHcGorWfdzUMWYA0SD+a6Hn4FmJ+YhzzzjkTZrQ==",
             "license": "Apache-2.0"
+        },
+        "node_modules/@microsoft/fetch-event-source": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/@microsoft/fetch-event-source/-/fetch-event-source-2.0.1.tgz",
+            "integrity": "sha512-W6CLUJ2eBMw3Rec70qrsEW0jOm/3twwJv21mrmj2yORiaVmVYGS4sSS5yUwvQc1ZlDLYGPnClVWmUUMagKNsfA==",
+            "license": "MIT"
         },
         "node_modules/@napi-rs/wasm-runtime": {
             "version": "0.2.12",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
         "extends @nextcloud/browserslist-config"
     ],
     "dependencies": {
-        "@conduction/nextcloud-vue": "^1.0.0-beta.30",
+        "@conduction/nextcloud-vue": "^1.0.0-beta.40",
         "@fortawesome/fontawesome-svg-core": "^6.5.2",
         "@fortawesome/free-solid-svg-icons": "^6.5.2",
         "@nextcloud/axios": "~2.5.2",


### PR DESCRIPTION
## What

zaakafhandelapp is already on the Tier-4 `CnAppRoot` manifest shell (`zaakafhandelapp-manifest-v1`, #189/#190/#192). This bumps `@conduction/nextcloud-vue` `^1.0.0-beta.30` → `^1.0.0-beta.40` so it picks up the manifest column abstractions and — the big one — the `CnIndexPage` store-backed self-fetch mode shipped in nc-vue #219/#221/#222/#223:

- **`CnIndexPage` self-fetch** — a manifest `type:"index"` page with `register` + `schema` and no `objects` prop now derives `${register}-${schema}`, registers it in the object store and drives the list via `useListView` (collection fetch, `_search`/`_order`/`_page`/`_limit`, facet filters, sidebar wiring). So the entity index pages **render their objects instead of an empty table**.
- `columns[].formatter` / `columns[].widget` / `columns[].aggregate` and `pages[].config.filter` are now available for the manifest pages (no per-page usages added here — that's a follow-up).

## Verification (local)

- `npm run build` ✓ against beta.40 — only the usual entrypoint-size warnings, no errors.
- Pre-existing jest failures (13 suites — stale `*.spec.ts` referencing the store modules deleted in the `feature/zaakafhandelapp-store-migration` PR #190, plus a `Do not know how to serialize a BigInt` test issue) are **unchanged** by this bump — not regressions, but worth a separate cleanup PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)