### PR TITLE
feat(manifest): render status/priority/channel columns as badges

### DIFF
--- a/src/manifest.json
+++ b/src/manifest.json
@@ -118,7 +118,7 @@
 			"config": {
 				"register": "zaakafhandelapp",
 				"schema": "zaak",
-				"columns": ["identificatie", "omschrijving", "zaaktype", "status", "uiterlijkeEinddatumAfdoening"],
+				"columns": ["identificatie", "omschrijving", "zaaktype", { "key": "status", "label": "Status", "widget": "badge" }, "uiterlijkeEinddatumAfdoening"],
 				"sidebar": { "enabled": true, "showMetadata": true }
 			}
 		},
@@ -151,7 +151,7 @@
 			"config": {
 				"register": "zaakafhandelapp",
 				"schema": "taak",
-				"columns": ["title", "status", "priority", "dueDate"],
+				"columns": ["title", { "key": "status", "label": "Status", "widget": "badge" }, { "key": "priority", "label": "Priority", "widget": "badge" }, "dueDate"],
 				"sidebar": { "enabled": true, "showMetadata": true }
 			}
 		},
@@ -229,7 +229,7 @@
 			"config": {
 				"register": "zaakafhandelapp",
 				"schema": "contactmoment",
-				"columns": ["onderwerp", "kanaal", "datum"],
+				"columns": ["onderwerp", { "key": "kanaal", "label": "Channel", "widget": "badge" }, "datum"],
 				"sidebar": { "enabled": true, "showMetadata": true }
 			}
 		},
@@ -255,7 +255,7 @@
 			"config": {
 				"register": "zaakafhandelapp",
 				"schema": "bericht",
-				"columns": ["onderwerp", "kanaal", "datum"],
+				"columns": ["onderwerp", { "key": "kanaal", "label": "Channel", "widget": "badge" }, "datum"],
 				"sidebar": { "enabled": true, "showMetadata": true }
 			}
 		},
@@ -333,7 +333,7 @@
 			"config": {
 				"register": "zaakafhandelapp",
 				"schema": "besluit",
-				"columns": ["identificatie", "datum", "status"],
+				"columns": ["identificatie", "datum", { "key": "status", "label": "Status", "widget": "badge" }],
 				"sidebar": { "enabled": true, "showMetadata": true }
 			}
 		},


### PR DESCRIPTION
Wires the built-in `widget:"badge"` (→ `CnStatusBadge`, nc-vue beta.40) on the obvious enum columns of the `type:"index"` pages: Zaken/Besluiten `status`, Taken `status`+`priority`, Contactmomenten/Berichten `kanaal`. Pure manifest change — `"badge"` resolves to the lib's built-in widget (no `cellWidgets` registry needed); object-shaped columns require a `label` so each carries one. Part of the fleet manifest-index wave (pipelinq #351, procest #436, scholiq #71); fuller formatter/widget wiring tracked in #202. Verified: `node tests/validate-manifest.js` PASS, `npm run build` ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)