### PR TITLE
feat(manifest): render date columns via the built-in date/datetime formatters

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
             "hasInstallScript": true,
             "license": "EUPL-1.2",
             "dependencies": {
-                "@conduction/nextcloud-vue": "^1.0.0-beta.40",
+                "@conduction/nextcloud-vue": "^1.0.0-beta.42",
                 "@fortawesome/fontawesome-svg-core": "^6.5.2",
                 "@fortawesome/free-solid-svg-icons": "^6.5.2",
                 "@nextcloud/axios": "~2.5.2",
@@ -2080,9 +2080,9 @@
             }
         },
         "node_modules/@conduction/nextcloud-vue": {
-            "version": "1.0.0-beta.40",
-            "resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-1.0.0-beta.40.tgz",
-            "integrity": "sha512-tiC0MZT3mPupFRgB9F5p0FY6o50PDwc2seGcAKENO8aFpgCQOgudJs+s1FiprtEJ19RX6tMDByXeeD2Cxd9eyw==",
+            "version": "1.0.0-beta.42",
+            "resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-1.0.0-beta.42.tgz",
+            "integrity": "sha512-6ITMUXPNdfmaitFIeDMk4VjffrNKfAM5kjFUFl/XtORz4A6nD0DpEIrxdtZF1ltODlQoI+d4ADijP8pEr02U6g==",
             "license": "EUPL-1.2",
             "dependencies": {
                 "@codemirror/autocomplete": "^6.0.0",
@@ -2105,6 +2105,7 @@
                 "dompurify": "^3.0.0",
                 "gridstack": "^10.3.1",
                 "leaflet": "^1.9.0",
+                "leaflet.markercluster": "^1.5.3",
                 "lodash": "^4.17.21",
                 "marked": "^15.0.0",
                 "style-mod": "^4.0.0",
@@ -14907,6 +14908,15 @@
             "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.9.4.tgz",
             "integrity": "sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA==",
             "license": "BSD-2-Clause"
+        },
+        "node_modules/leaflet.markercluster": {
+            "version": "1.5.3",
+            "resolved": "https://registry.npmjs.org/leaflet.markercluster/-/leaflet.markercluster-1.5.3.tgz",
+            "integrity": "sha512-vPTw/Bndq7eQHjLBVlWpnGeLa3t+3zGiuM7fJwCkiMFq+nmRuG3RI3f7f4N4TDX7T4NpbAXpR2+NTRSEGfCSeA==",
+            "license": "MIT",
+            "peerDependencies": {
+                "leaflet": "^1.3.1"
+            }
         },
         "node_modules/leven": {
             "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
         "extends @nextcloud/browserslist-config"
     ],
     "dependencies": {
-        "@conduction/nextcloud-vue": "^1.0.0-beta.40",
+        "@conduction/nextcloud-vue": "^1.0.0-beta.42",
         "@fortawesome/fontawesome-svg-core": "^6.5.2",
         "@fortawesome/free-solid-svg-icons": "^6.5.2",
         "@nextcloud/axios": "~2.5.2",

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -118,7 +118,7 @@
 			"config": {
 				"register": "zaakafhandelapp",
 				"schema": "zaak",
-				"columns": ["identificatie", "omschrijving", "zaaktype", { "key": "status", "label": "Status", "widget": "badge" }, "uiterlijkeEinddatumAfdoening"],
+				"columns": ["identificatie", "omschrijving", "zaaktype", { "key": "status", "label": "Status", "widget": "badge" }, { "key": "uiterlijkeEinddatumAfdoening", "label": "Deadline", "formatter": "date" }],
 				"sidebar": { "enabled": true, "showMetadata": true }
 			}
 		},
@@ -151,7 +151,7 @@
 			"config": {
 				"register": "zaakafhandelapp",
 				"schema": "taak",
-				"columns": ["title", { "key": "status", "label": "Status", "widget": "badge" }, { "key": "priority", "label": "Priority", "widget": "badge" }, "dueDate"],
+				"columns": ["title", { "key": "status", "label": "Status", "widget": "badge" }, { "key": "priority", "label": "Priority", "widget": "badge" }, { "key": "dueDate", "label": "Due", "formatter": "date" }],
 				"sidebar": { "enabled": true, "showMetadata": true }
 			}
 		},
@@ -229,7 +229,7 @@
 			"config": {
 				"register": "zaakafhandelapp",
 				"schema": "contactmoment",
-				"columns": ["onderwerp", { "key": "kanaal", "label": "Channel", "widget": "badge" }, "datum"],
+				"columns": ["onderwerp", { "key": "kanaal", "label": "Channel", "widget": "badge" }, { "key": "datum", "label": "Date", "formatter": "datetime" }],
 				"sidebar": { "enabled": true, "showMetadata": true }
 			}
 		},
@@ -255,7 +255,7 @@
 			"config": {
 				"register": "zaakafhandelapp",
 				"schema": "bericht",
-				"columns": ["onderwerp", { "key": "kanaal", "label": "Channel", "widget": "badge" }, "datum"],
+				"columns": ["onderwerp", { "key": "kanaal", "label": "Channel", "widget": "badge" }, { "key": "datum", "label": "Date", "formatter": "datetime" }],
 				"sidebar": { "enabled": true, "showMetadata": true }
 			}
 		},
@@ -333,7 +333,7 @@
 			"config": {
 				"register": "zaakafhandelapp",
 				"schema": "besluit",
-				"columns": ["identificatie", "datum", { "key": "status", "label": "Status", "widget": "badge" }],
+				"columns": ["identificatie", { "key": "datum", "label": "Date", "formatter": "date" }, { "key": "status", "label": "Status", "widget": "badge" }],
 				"sidebar": { "enabled": true, "showMetadata": true }
 			}
 		},


### PR DESCRIPTION
nc-vue beta.42 (#226) ships built-in `date` / `datetime` / `relative-time` formatters in `cnFormatters` so manifests can use them without a per-app `formatters.js`. Wires them on the obvious date columns:

- Zaken `uiterlijkeEinddatumAfdoening` → `formatter:"date"`
- Taken `dueDate` → `formatter:"date"`
- Contactmomenten / Berichten `datum` → `formatter:"datetime"`
- Besluiten `datum` → `formatter:"date"`

Plus the lib bump `^1.0.0-beta.40` → `^1.0.0-beta.42`. Verified: `node tests/validate-manifest.js` PASS, `npm run build` ✓.

Closes part of #202 (date-formatter slice). The remaining formatter work (a per-app `formatters.js` for status humanisers + aggregate columns) stays in #202.

🤖 Generated with [Claude Code](https://claude.com/claude-code)