### PR TITLE
fix: register webpack runtime + shared chunks so the Vue app mounts

### DIFF
--- a/templates/index.php
+++ b/templates/index.php
@@ -3,6 +3,20 @@
 use OCP\Util;
 
 $appId = OCA\ZaakAfhandelApp\AppInfo\Application::APP_ID;
+
+// webpack splitChunks (see webpack.config.js) emits a runtime chunk plus two
+// shared chunks (`shared-vendor`, `shared-nc-vue`). The main entry's bundle
+// tail wraps the Vue mount in `__webpack_require__.O(0, [shared chunks], …)`
+// which only fires once all listed chunks have registered themselves on
+// `self.webpackChunkzaakafhandelapp`. If we only `addScript` the main entry,
+// the shared chunks never load, the callback never fires, and the Vue app
+// silently fails to mount (issue: tutorial capture spec saw 0/52 real
+// screenshots, only NC chrome). Register every chunk produced by splitChunks
+// here, in dependency order. The runtime chunk owns `__webpack_require__.O`
+// and must load before consumers can drain their queues.
+Util::addScript($appId, $appId . '-runtime');
+Util::addScript($appId, $appId . '-shared-vendor');
+Util::addScript($appId, $appId . '-shared-nc-vue');
 Util::addScript($appId, $appId . '-main');
 Util::addStyle($appId, 'main');
 ?>


### PR DESCRIPTION
## Root cause

The webpack config (`webpack.config.js`) uses an aggressive `splitChunks` configuration that emits three chunks alongside the main entry:

- `zaakafhandelapp-runtime.js` (owns `__webpack_require__.O`)
- `zaakafhandelapp-shared-vendor.js`
- `zaakafhandelapp-shared-nc-vue.js`

`templates/index.php` previously only called `Util::addScript($appId, $appId . '-main')`. The compiled main entry's tail wraps the `new Vue({...}).\$mount('#content')` call in:

```js
__webpack_require__.O(0, ['zaakafhandelapp-shared-nc-vue', 'zaakafhandelapp-shared-vendor'], () => __webpack_require__(/*! main */ 25124))
```

That callback only fires once every listed chunk has pushed itself onto `self.webpackChunkzaakafhandelapp`. With only `main` loaded the queue never drained, the mount callback never fired, and the app silently rendered an empty page inside the existing `<div id="content">` wrapper — exactly the symptom #204's tutorial capture spec hit (`webpackChunkzaakafhandelapp` registered, but Vue never mounted; 0/52 real screenshots).

## Fix

Register every chunk produced by `splitChunks` in `templates/index.php`, in dependency order. The runtime chunk must load first since it defines `__webpack_require__.O`.

## Verification

Browser DevTools at `http://localhost:8080/index.php/apps/zaakafhandelapp/` after the fix:

- All four scripts load (runtime, shared-vendor, shared-nc-vue, main).
- `<div class="zaa-app-root">` is mounted under what was `<div id="content">`.
- The left sidebar renders all routes (Dashboard, Cases, Tasks, Customers, Employees, Contact moments, Messages, Roles, Search, Case types, Audit trail, Documentation, Settings).

Once merged, this unblocks #204's tutorial capture spec re-run.