### PR TITLE
ci(docs): deploy from documentation branch

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -2,9 +2,9 @@ name: Documentation
 
 on:
   push:
-    branches: [development, documentation]
+    branches: [documentation]
   pull_request:
-    branches: [development, documentation]
+    branches: [documentation]
 
 jobs:
   deploy:


### PR DESCRIPTION
Docs deploy from documentation so the docs site can be updated independently of code CI/CD on development.