### PR TITLE
fix(docs): self-close img tags in legacy figures for MDX

### DIFF
--- a/docs/gebruikers/dashboard.md
+++ b/docs/gebruikers/dashboard.md
@@ -21,4 +21,4 @@ die snelkoppelingen biedt naar de volgende functies:
 * **Uw Zaken**: Directe toegang tot de lijst van toegewezen zaken.
 * **Uw Taken**: Overzicht van toegewezen taken.
 
-<figure><img src="../.gitbook/assets/image.png" alt=""><figcaption></figcaption></figure>
+<figure><img src="../.gitbook/assets/image.png" alt="" /><figcaption></figcaption></figure>

--- a/docs/gebruikers/toewijzen-van-taken.md
+++ b/docs/gebruikers/toewijzen-van-taken.md
@@ -11,7 +11,7 @@ description: >-
 * Wanneer er nog geen taken beschikbaar zijn, verschijnt een melding: _"Nog geen taak geselecteerd."_
 * Gebruikers kunnen via de knop **"Taak toevoegen"** direct een nieuwe taak aanmaken.
 
-<figure><img src="../.gitbook/assets/image (4).png" alt=""><figcaption><p>Takenmodal</p></figcaption></figure>
+<figure><img src="../.gitbook/assets/image (4).png" alt="" /><figcaption><p>Takenmodal</p></figcaption></figure>
 
 #### Functionaliteit en Velden in de Modal
 

--- a/docs/gebruikers/zaakafhandeling.md
+++ b/docs/gebruikers/zaakafhandeling.md
@@ -13,13 +13,13 @@ Voordat het mogelijk is om een zaak te maken, moet het zaaktype geconfigureerd z
 \
 
 
-<figure><img src="../.gitbook/assets/image (2).png" alt=""><figcaption></figcaption></figure>
+<figure><img src="../.gitbook/assets/image (2).png" alt="" /><figcaption></figcaption></figure>
 
 ## Het starten van een zaak
 
 Via de knop **+ Zaak Starten** (boven in het menu) of de centrale knop op de pagina kunnen gebruikers eenvoudig een nieuwe zaak starten.
 
-<figure><img src="../.gitbook/assets/image (1).png" alt=""><figcaption><p>Het starten van een zaak</p></figcaption></figure>
+<figure><img src="../.gitbook/assets/image (1).png" alt="" /><figcaption><p>Het starten van een zaak</p></figcaption></figure>
 
 Het modaal dat verschijnt na het klikken op **"Zaak starten"** biedt een interface waarmee gebruikers een nieuwe zaak kunnen starten. Het bevat waarschijnlijk een formulier waarin belangrijke gegevens over de zaak ingevuld moeten worden, zoals de naam van de zaak, het type, en eventuele aanvullende details.
 

--- a/docs/installatie/installeren-via-de-appstore.md
+++ b/docs/installatie/installeren-via-de-appstore.md
@@ -6,11 +6,11 @@ Let op! Je hebt hier een admin-account voor nodig. Dit werkt mogelijk niet met t
 
 * Navigeer naar jouw profiel log, rechts in de Nextcloud app. Klik erop en kies "Apps" .
 
-<figure><img src="../.gitbook/assets/image (3).png" alt=""><figcaption><p>App-menu</p></figcaption></figure>
+<figure><img src="../.gitbook/assets/image (3).png" alt="" /><figcaption><p>App-menu</p></figcaption></figure>
 
 * Kies vervolgens uit de navigatiebalk links "Organization", en scroll helemaal onderaan naar Zaakafhandelapp. Klik dan op Download en enable
 *
 
-    <figure><img src="../.gitbook/assets/image (1) (1).png" alt=""><figcaption></figcaption></figure>
+    <figure><img src="../.gitbook/assets/image (1) (1).png" alt="" /><figcaption></figcaption></figure>
 
 Met deze stappen ben je klaar om de Zaakafhandelapp te gebruiken. Als je nog vragen hebt of hulp nodig hebt, raadpleeg dan de [officiële Nextcloud documentatie](https://docs.nextcloud.com/) of stuur een mail naar support@conduction.nl.


### PR DESCRIPTION
Fixes the deploy that broke after the sync PR #210 merged. Legacy GitBook `<figure><img></figure>` syntax needs self-closing `<img />` to compile under MDX (Docusaurus). 6 occurrences across 4 files.