### PR TITLE
ci: add branch-protection workflow (re-target to documentation)

### DIFF
--- a/.github/workflows/branch-protection.yml
+++ b/.github/workflows/branch-protection.yml
@@ -1,0 +1,9 @@
+name: Branch Protection
+
+on:
+  pull_request:
+    branches: [main, beta]
+
+jobs:
+  check:
+    uses: ConductionNL/.github/.github/workflows/branch-protection.yml@main


### PR DESCRIPTION
Replaces #179, which targeted `main` from a non-policy branch (`ci/*` is not in the `development|documentation|hotfix/` allow-list). Same 9-line addition: pulls in the shared `ConductionNL/.github` branch-protection workflow. Lands on `documentation` and rides through to `main` via the standard release flow.