### PR TITLE
chore(deps): preset lockfile 3.8.0 -> 3.9.0 (TechArticle gate)

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -2040,9 +2040,9 @@
       }
     },
     "node_modules/@conduction/docusaurus-preset": {
-      "version": "3.8.0",
-      "resolved": "https://registry.npmjs.org/@conduction/docusaurus-preset/-/docusaurus-preset-3.8.0.tgz",
-      "integrity": "sha512-aakDh5eyzA4qMhExiU+gOCVLviB/ol8UMulFHiFKz5lKGEf5AKPR7NDuE6rnBpS5qakGyiCwgLSojP3HnBROCA==",
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/@conduction/docusaurus-preset/-/docusaurus-preset-3.9.0.tgz",
+      "integrity": "sha512-WYzKUiF0VyRzhy0ChReAx/w/Dn0HfIKemtr0R+Skt+Q+2+ekA4yffZLJr4zCXexi6wW17XDqh+m9sqsXQqh3RQ==",
       "license": "EUPL-1.2",
       "bin": {
         "validate-ai-baseline": "bin/validate-ai-baseline.mjs"


### PR DESCRIPTION
Preset 3.9.0 adds a hard-fail validator gate for TechArticle JSON-LD on docs pages. Direct to documentation branch (zaakafhandelapp docs live there only).