### PR TITLE
fix(docs): descriptive homepage title (#80)

### DIFF
--- a/docs/src/pages/index.js
+++ b/docs/src/pages/index.js
@@ -263,7 +263,7 @@ const WIDGETS = [
 export default function Home() {
   return (
     <Layout
-      title="Zaak Afhandel App"
+      title="Zaak Afhandel App, ZGW-aligned case handling for Nextcloud"
       description="Zaak Afhandel App brings ZGW-aligned case handling into Nextcloud — intake to closure for zaken, defined status workflows, the work queue, tasks, attached documents, and a record of every decision."
     >
       <main className="marketing-page">


### PR DESCRIPTION
Part of ConductionNL/.github#75 SEO epic and closes ConductionNL/.github#80. Single-prop edit.