### PR TITLE
chore: sync canonical root configs + mechanical phpmd cleanup

### DIFF
--- a/lib/Controller/BesluitenController.php
+++ b/lib/Controller/BesluitenController.php
@@ -76,9 +76,6 @@ class BesluitenController extends Controller
      */
     public function index(CallService $callService): JSONResponse
     {
-        // Latere zorg
-        $query = $this->request->getParams();
-
         $results = $callService->index(source: 'brc', endpoint: 'besluiten');
         return new JSONResponse($results);
     }//end index()
@@ -93,9 +90,6 @@ class BesluitenController extends Controller
      */
     public function show(string $id, CallService $callService): JSONResponse
     {
-        // Latere zorg
-        $query = $this->request->getParams();
-
         $results = $callService->show(source: 'brc', endpoint: 'besluiten', id: $id);
         return new JSONResponse($results);
     }//end show()

--- a/lib/Controller/ResultatenController.php
+++ b/lib/Controller/ResultatenController.php
@@ -75,9 +75,6 @@ class ResultatenController extends Controller
      */
     public function index(CallService $callService): JSONResponse
     {
-        // Latere zorg
-        $query = $this->request->getParams();
-
         $results = $callService->index(source: 'zrc', endpoint: 'resultaten');
         return new JSONResponse($results);
     }//end index()
@@ -92,9 +89,6 @@ class ResultatenController extends Controller
      */
     public function show(string $id, CallService $callService): JSONResponse
     {
-        // Latere zorg
-        $query = $this->request->getParams();
-
         $results = $callService->show(source: 'zrc', endpoint: 'resultaten', id: $id);
         return new JSONResponse($results);
     }//end show()

--- a/lib/Controller/StatusenController.php
+++ b/lib/Controller/StatusenController.php
@@ -75,9 +75,6 @@ class StatusenController extends Controller
      */
     public function index(CallService $callService): JSONResponse
     {
-        // Latere zorg
-        $query = $this->request->getParams();
-
         $results = $callService->index(source: 'zrc', endpoint: 'statussen');
         return new JSONResponse($results);
     }//end index()
@@ -92,9 +89,6 @@ class StatusenController extends Controller
      */
     public function show(string $id, CallService $callService): JSONResponse
     {
-        // Latere zorg
-        $query = $this->request->getParams();
-
         $results = $callService->show(source: 'zrc', endpoint: 'statussen', id: $id);
         return new JSONResponse($results);
     }//end show()

--- a/lib/Controller/ZaakEigenschappenController.php
+++ b/lib/Controller/ZaakEigenschappenController.php
@@ -72,9 +72,6 @@ class ZaakEigenschappenController extends Controller
      */
     public function index(CallService $callService, string $zaakId): JSONResponse
     {
-        // Latere zorg
-        $query = $this->request->getParams();
-
         $results = $callService->index(source: 'zrc', endpoint: "zaken/$zaakId/zaakeigenschappen");
         return new JSONResponse($results);
     }//end index()
@@ -89,9 +86,6 @@ class ZaakEigenschappenController extends Controller
      */
     public function show(string $id, CallService $callService, string $zaakId): JSONResponse
     {
-        // Latere zorg
-        $query = $this->request->getParams();
-
         $results = $callService->show(source: 'zrc', endpoint: "zaken/$zaakId/zaakeigenschappen", id: $id);
         return new JSONResponse($results);
     }//end show()

--- a/lib/Controller/ZaakInformatieObjectenController.php
+++ b/lib/Controller/ZaakInformatieObjectenController.php
@@ -72,9 +72,6 @@ class ZaakInformatieObjectenController extends Controller
      */
     public function index(CallService $callService): JSONResponse
     {
-        // Latere zorg
-        $query = $this->request->getParams();
-
         $results = $callService->index(source: 'zrc', endpoint: 'zaakinformatieobjecten');
         return new JSONResponse($results);
     }//end index()
@@ -89,9 +86,6 @@ class ZaakInformatieObjectenController extends Controller
      */
     public function show(string $id, CallService $callService): JSONResponse
     {
-        // Latere zorg
-        $query = $this->request->getParams();
-
         $results = $callService->show(source: 'zrc', endpoint: 'zaakinformatieobjecten', id: $id);
         return new JSONResponse($results);
     }//end show()

--- a/lib/Controller/ZaakObjectenController.php
+++ b/lib/Controller/ZaakObjectenController.php
@@ -72,9 +72,6 @@ class ZaakObjectenController extends Controller
      */
     public function index(CallService $callService): JSONResponse
     {
-        // Latere zorg
-        $query = $this->request->getParams();
-
         $results = $callService->index(source: 'zrc', endpoint: 'zaakobjecten');
         return new JSONResponse($results);
     }//end index()
@@ -89,9 +86,6 @@ class ZaakObjectenController extends Controller
      */
     public function show(string $id, CallService $callService): JSONResponse
     {
-        // Latere zorg
-        $query = $this->request->getParams();
-
         $results = $callService->show(source: 'zrc', endpoint: 'zaakobjecten', id: $id);
         return new JSONResponse($results);
     }//end show()

--- a/phpcs-custom-sniffs/CustomSniffs/Sniffs/Commenting/SpecTagSniff.php
+++ b/phpcs-custom-sniffs/CustomSniffs/Sniffs/Commenting/SpecTagSniff.php
@@ -1,0 +1,377 @@
+<?php
+/**
+ * Warn when a PHP class or public method lacks an @spec PHPDoc tag.
+ *
+ * ConductionNL ADR-003 (Backend rules) mandates that every class and public
+ * method MUST have one or more @spec PHPDoc tags linking back to the OpenSpec
+ * change that caused the code to exist:
+ *
+ *     @spec openspec/changes/{change-name}/tasks.md#task-N
+ *
+ * This sniff emits warnings (not errors) so that CI surfaces the gap without
+ * blocking merges while teams backfill coverage. Tests files and magic
+ * methods are skipped, as are private/protected methods — the ADR only
+ * mandates @spec for classes and public methods.
+ *
+ * @author  Conduction
+ * @package CustomSniffs
+ */
+
+namespace CustomSniffs\Sniffs\Commenting;
+
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Files\File;
+
+/**
+ * SpecTagSniff — warns when @spec PHPDoc tag is missing on classes / public methods.
+ */
+class SpecTagSniff implements Sniff
+{
+
+
+    /**
+     * PHP magic methods that are exempt from the @spec requirement.
+     *
+     * @var array<string>
+     */
+    private const MAGIC_METHODS = [
+        '__construct',
+        '__destruct',
+        '__get',
+        '__set',
+        '__call',
+        '__callstatic',
+        '__isset',
+        '__unset',
+        '__tostring',
+        '__invoke',
+        '__clone',
+        '__sleep',
+        '__wakeup',
+        '__serialize',
+        '__unserialize',
+        '__set_state',
+        '__debuginfo',
+    ];
+
+
+    /**
+     * Returns tokens this sniff listens for.
+     *
+     * @return array<int>
+     */
+    public function register(): array
+    {
+        return [T_CLASS, T_FUNCTION];
+
+    }//end register()
+
+
+    /**
+     * Process a T_CLASS or T_FUNCTION token.
+     *
+     * @param File $phpcsFile The file being scanned.
+     * @param int  $stackPtr  Position of the token.
+     *
+     * @return void
+     */
+    public function process(File $phpcsFile, $stackPtr): void
+    {
+        // Skip test files.
+        if ($this->isTestFile(phpcsFile: $phpcsFile) === true) {
+            return;
+        }
+
+        $tokens = $phpcsFile->getTokens();
+        $code   = $tokens[$stackPtr]['code'];
+
+        if ($code === T_CLASS) {
+            $this->processClass(phpcsFile: $phpcsFile, stackPtr: $stackPtr);
+            return;
+        }
+
+        if ($code === T_FUNCTION) {
+            $this->processFunction(phpcsFile: $phpcsFile, stackPtr: $stackPtr);
+            return;
+        }
+
+    }//end process()
+
+
+    /**
+     * Check a class declaration for an @spec docblock tag.
+     *
+     * Skips anonymous classes (no name follows the T_CLASS keyword).
+     *
+     * @param File $phpcsFile The file being scanned.
+     * @param int  $stackPtr  Position of the T_CLASS token.
+     *
+     * @return void
+     */
+    private function processClass(File $phpcsFile, int $stackPtr): void
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        // Anonymous classes — $var = new class { ... } — have no name; skip.
+        $namePtr = $phpcsFile->findNext(T_STRING, ($stackPtr + 1), null, false, null, true);
+        if ($namePtr === false) {
+            return;
+        }
+
+        // Sanity: name should be on the same line or within a short window.
+        $openBracePtr = $phpcsFile->findNext(T_OPEN_CURLY_BRACKET, ($stackPtr + 1));
+        if ($openBracePtr !== false && $namePtr > $openBracePtr) {
+            return;
+        }
+
+        $className = $tokens[$namePtr]['content'];
+
+        if ($this->hasSpecTag(phpcsFile: $phpcsFile, stackPtr: $stackPtr) === true) {
+            return;
+        }
+
+        $message = 'Class %s is missing @spec PHPDoc tag — link back to openspec/changes/{name}/tasks.md#task-N';
+        $phpcsFile->addWarning($message, $stackPtr, 'MissingClassSpec', [$className]);
+
+    }//end processClass()
+
+
+    /**
+     * Check a function declaration for an @spec docblock tag.
+     *
+     * Only flags public methods declared inside a class. Global functions,
+     * private/protected methods, and magic methods are skipped.
+     *
+     * @param File $phpcsFile The file being scanned.
+     * @param int  $stackPtr  Position of the T_FUNCTION token.
+     *
+     * @return void
+     */
+    private function processFunction(File $phpcsFile, int $stackPtr): void
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        // Must be inside a class scope.
+        $className = $this->getEnclosingClassName(phpcsFile: $phpcsFile, stackPtr: $stackPtr);
+        if ($className === null) {
+            return;
+        }
+
+        // Get method name.
+        $namePtr = $phpcsFile->findNext(T_STRING, ($stackPtr + 1));
+        if ($namePtr === false) {
+            return;
+        }
+
+        $methodName = $tokens[$namePtr]['content'];
+
+        // Skip magic methods.
+        if (in_array(strtolower($methodName), self::MAGIC_METHODS, true) === true) {
+            return;
+        }
+
+        // Determine visibility: default is public when no modifier present.
+        if ($this->isPublicMethod(phpcsFile: $phpcsFile, stackPtr: $stackPtr) === false) {
+            return;
+        }
+
+        if ($this->hasSpecTag(phpcsFile: $phpcsFile, stackPtr: $stackPtr) === true) {
+            return;
+        }
+
+        $message = 'Public method %s::%s() is missing @spec PHPDoc tag';
+        $phpcsFile->addWarning($message, $stackPtr, 'MissingMethodSpec', [$className, $methodName]);
+
+    }//end processFunction()
+
+
+    /**
+     * Check whether the docblock directly preceding $stackPtr contains an @spec tag.
+     *
+     * Walks backwards from the token skipping whitespace, attribute tokens, and
+     * visibility/abstract/final/static modifiers. If the next non-skipped token
+     * is the close of a doc comment, scan the block for @spec.
+     *
+     * @param File $phpcsFile The file being scanned.
+     * @param int  $stackPtr  Position of the class/function token.
+     *
+     * @return bool True when an @spec tag is present.
+     */
+    private function hasSpecTag(File $phpcsFile, int $stackPtr): bool
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        $skip = [
+            T_WHITESPACE,
+            T_ABSTRACT,
+            T_FINAL,
+            T_STATIC,
+            T_PUBLIC,
+            T_PROTECTED,
+            T_PRIVATE,
+            T_READONLY,
+            T_ATTRIBUTE,
+            T_ATTRIBUTE_END,
+        ];
+
+        $ptr = ($stackPtr - 1);
+        while ($ptr >= 0) {
+            $code = $tokens[$ptr]['code'];
+
+            // Skip over attribute blocks (PHP 8 #[Attribute]) in full.
+            if ($code === T_ATTRIBUTE_END && isset($tokens[$ptr]['attribute_opener']) === true) {
+                $ptr = ($tokens[$ptr]['attribute_opener'] - 1);
+                continue;
+            }
+
+            if (in_array($code, $skip, true) === true) {
+                $ptr--;
+                continue;
+            }
+
+            break;
+        }
+
+        if ($ptr < 0) {
+            return false;
+        }
+
+        if ($tokens[$ptr]['code'] !== T_DOC_COMMENT_CLOSE_TAG) {
+            return false;
+        }
+
+        if (isset($tokens[$ptr]['comment_opener']) === false) {
+            return false;
+        }
+
+        $opener = $tokens[$ptr]['comment_opener'];
+        for ($i = $opener; $i <= $ptr; $i++) {
+            if ($tokens[$i]['code'] === T_DOC_COMMENT_TAG
+                && strtolower($tokens[$i]['content']) === '@spec'
+            ) {
+                return true;
+            }
+        }
+
+        return false;
+
+    }//end hasSpecTag()
+
+
+    /**
+     * Determine if the function at $stackPtr is a public method.
+     *
+     * Methods default to public when no visibility modifier is present.
+     *
+     * @param File $phpcsFile The file being scanned.
+     * @param int  $stackPtr  Position of the T_FUNCTION token.
+     *
+     * @return bool True when the method is public (explicit or default).
+     */
+    private function isPublicMethod(File $phpcsFile, int $stackPtr): bool
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        $ptr = ($stackPtr - 1);
+        while ($ptr >= 0) {
+            $code = $tokens[$ptr]['code'];
+            if ($code === T_PUBLIC) {
+                return true;
+            }
+
+            if ($code === T_PROTECTED || $code === T_PRIVATE) {
+                return false;
+            }
+
+            if ($code === T_WHITESPACE
+                || $code === T_ABSTRACT
+                || $code === T_FINAL
+                || $code === T_STATIC
+                || $code === T_READONLY
+            ) {
+                $ptr--;
+                continue;
+            }
+
+            // Skip attributes in full.
+            if ($code === T_ATTRIBUTE_END && isset($tokens[$ptr]['attribute_opener']) === true) {
+                $ptr = ($tokens[$ptr]['attribute_opener'] - 1);
+                continue;
+            }
+
+            if ($code === T_DOC_COMMENT_CLOSE_TAG
+                || $code === T_COMMENT
+                || $code === T_OPEN_CURLY_BRACKET
+                || $code === T_CLOSE_CURLY_BRACKET
+                || $code === T_SEMICOLON
+            ) {
+                // No visibility modifier found — default public.
+                return true;
+            }
+
+            $ptr--;
+        }
+
+        return true;
+
+    }//end isPublicMethod()
+
+
+    /**
+     * Return the name of the class/interface/trait/enum enclosing $stackPtr, or null.
+     *
+     * @param File $phpcsFile The file being scanned.
+     * @param int  $stackPtr  Position of the token to inspect.
+     *
+     * @return string|null The enclosing class name, or null when at file scope.
+     */
+    private function getEnclosingClassName(File $phpcsFile, int $stackPtr): ?string
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        if (isset($tokens[$stackPtr]['conditions']) === false) {
+            return null;
+        }
+
+        // Walk the conditions chain looking for the innermost class-like scope.
+        $classLike = [T_CLASS, T_INTERFACE, T_TRAIT, T_ENUM, T_ANON_CLASS];
+
+        foreach (array_reverse($tokens[$stackPtr]['conditions'], true) as $scopePtr => $scopeCode) {
+            if (in_array($scopeCode, $classLike, true) === true) {
+                $namePtr = $phpcsFile->findNext(T_STRING, ($scopePtr + 1));
+                if ($namePtr === false) {
+                    return '{anonymous}';
+                }
+
+                // Sanity: ensure the name is before the opening brace for that class.
+                if (isset($tokens[$scopePtr]['scope_opener']) === true
+                    && $namePtr > $tokens[$scopePtr]['scope_opener']
+                ) {
+                    return '{anonymous}';
+                }
+
+                return $tokens[$namePtr]['content'];
+            }
+        }
+
+        return null;
+
+    }//end getEnclosingClassName()
+
+
+    /**
+     * Check whether the currently-scanned file is a test file.
+     *
+     * @param File $phpcsFile The file being scanned.
+     *
+     * @return bool True for files under /tests/ or /Tests/.
+     */
+    private function isTestFile(File $phpcsFile): bool
+    {
+        $path = str_replace('\\', '/', $phpcsFile->getFilename());
+        return (stripos($path, '/tests/') !== false);
+
+    }//end isTestFile()
+
+
+}//end class

--- a/phpcs-custom-sniffs/CustomSniffs/Sniffs/Functions/NamedParametersSniff.php
+++ b/phpcs-custom-sniffs/CustomSniffs/Sniffs/Functions/NamedParametersSniff.php
@@ -134,11 +134,6 @@ class NamedParametersSniff implements Sniff
     /**
      * Determine if the function/method call at $stackPtr is to our own code.
      *
-     * Matches:
-     * - $this->method()
-     * - self::method() / static::method() / parent::method()
-     * - new OurClass() where OurClass is from the same app namespace
-     *
      * @param File $phpcsFile The file being scanned.
      * @param int  $stackPtr  Position of the T_STRING (function/method name).
      *
@@ -198,8 +193,6 @@ class NamedParametersSniff implements Sniff
     /**
      * Check if the class at $classNamePtr is from the same app namespace as the current file.
      *
-     * Compares the class's use-import path against the file's OCA\AppName\ prefix.
-     *
      * @param File $phpcsFile    The file being scanned.
      * @param int  $classNamePtr Position of the class name token.
      *
@@ -210,13 +203,11 @@ class NamedParametersSniff implements Sniff
         $tokens    = $phpcsFile->getTokens();
         $className = $tokens[$classNamePtr]['content'];
 
-        // Find the file's namespace declaration.
         $appPrefix = $this->getAppNamespacePrefix(phpcsFile: $phpcsFile);
         if ($appPrefix === null) {
             return false;
         }
 
-        // Scan use-statements for an import matching this class name from our namespace.
         for ($i = 0; $i < $phpcsFile->numTokens; $i++) {
             if ($tokens[$i]['code'] === T_USE) {
                 $usePath = $this->getUseStatementPath(phpcsFile: $phpcsFile, usePtr: $i);
@@ -224,7 +215,6 @@ class NamedParametersSniff implements Sniff
                     continue;
                 }
 
-                // Extract the imported short name (last segment).
                 $segments     = explode(separator: '\\', string: $usePath);
                 $importedName = end($segments);
 
@@ -235,7 +225,6 @@ class NamedParametersSniff implements Sniff
                 }
             }//end if
 
-            // Stop scanning after the class declaration.
             if (in_array($tokens[$i]['code'], [T_CLASS, T_INTERFACE, T_TRAIT, T_ENUM], true) === true) {
                 break;
             }
@@ -247,7 +236,7 @@ class NamedParametersSniff implements Sniff
 
 
     /**
-     * Get the app namespace prefix (e.g., "OCA\MyDash") from the file's namespace declaration.
+     * Get the app namespace prefix (e.g., "OCA\MyApp") from the file's namespace declaration.
      *
      * @param File $phpcsFile The file being scanned.
      *
@@ -268,7 +257,6 @@ class NamedParametersSniff implements Sniff
                     $j++;
                 }
 
-                // Extract first two segments: OCA\AppName.
                 $parts = explode(separator: '\\', string: $namespace);
                 if (count($parts) >= 2) {
                     return $parts[0].'\\'.$parts[1];
@@ -302,7 +290,6 @@ class NamedParametersSniff implements Sniff
                 break;
             }
 
-            // Stop at 'as' keyword (aliases) — use the path before it.
             if ($code === T_AS) {
                 break;
             }
@@ -323,9 +310,6 @@ class NamedParametersSniff implements Sniff
     /**
      * Check if the arguments between $openParen and $closeParen contain any unnamed arguments.
      *
-     * An argument is "named" if its first significant token is followed by T_COLON.
-     * Handles nested parentheses, brackets, and braces correctly.
-     *
      * @param File $phpcsFile  The file being scanned.
      * @param int  $openParen  Position of the opening parenthesis.
      * @param int  $closeParen Position of the closing parenthesis.
@@ -334,16 +318,15 @@ class NamedParametersSniff implements Sniff
      */
     private function hasUnnamedArguments(File $phpcsFile, int $openParen, int $closeParen): bool
     {
-        $tokens         = $phpcsFile->getTokens();
-        $parenDepth     = 0;
-        $bracketDepth   = 0;
-        $braceDepth     = 0;
+        $tokens          = $phpcsFile->getTokens();
+        $parenDepth      = 0;
+        $bracketDepth    = 0;
+        $braceDepth      = 0;
         $atArgumentStart = true;
 
         for ($i = ($openParen + 1); $i < $closeParen; $i++) {
             $code = $tokens[$i]['code'];
 
-            // Track nesting depth.
             if ($code === T_OPEN_PARENTHESIS) {
                 $parenDepth++;
             } elseif ($code === T_CLOSE_PARENTHESIS) {
@@ -358,18 +341,15 @@ class NamedParametersSniff implements Sniff
                 $braceDepth--;
             }
 
-            // Only examine tokens at the top level of the argument list.
             if ($parenDepth > 0 || $bracketDepth > 0 || $braceDepth > 0) {
                 continue;
             }
 
-            // Comma at top level → next argument starts.
             if ($code === T_COMMA) {
                 $atArgumentStart = true;
                 continue;
             }
 
-            // Skip whitespace and comments at argument start.
             if ($atArgumentStart === true
                 && in_array($code, [T_WHITESPACE, T_COMMENT, T_DOC_COMMENT], true) === true
             ) {
@@ -379,12 +359,10 @@ class NamedParametersSniff implements Sniff
             if ($atArgumentStart === true) {
                 $atArgumentStart = false;
 
-                // Skip spread operator (...$args).
                 if ($code === T_ELLIPSIS) {
                     continue;
                 }
 
-                // Check if this argument is named: token followed by ':'.
                 $nextNonWs = $phpcsFile->findNext(
                     types: [T_WHITESPACE, T_COMMENT, T_DOC_COMMENT],
                     start: ($i + 1),

--- a/phpcs-custom-sniffs/CustomSniffs/Sniffs/Nextcloud/NoLegacyServerAccessorsSniff.php
+++ b/phpcs-custom-sniffs/CustomSniffs/Sniffs/Nextcloud/NoLegacyServerAccessorsSniff.php
@@ -1,0 +1,180 @@
+<?php
+/**
+ * Forbid the legacy named accessors on \OC::$server that were removed in Nextcloud 34.
+ *
+ * Flags patterns like:
+ *   \OC::$server->getDatabaseConnection()
+ *   \OC::$server->getSystemConfig()
+ *   \OC::$server->getLogger()
+ *
+ * These named accessors were removed in Nextcloud 34. The replacement pattern
+ * is constructor dependency injection of the equivalent OCP interface.
+ *
+ * PSR-11 lookups such as \OC::$server->get(SomeClass::class) are NOT flagged
+ * here; service-locator deprecation is tracked separately (design.md, D4).
+ *
+ * @author  Conduction
+ * @package CustomSniffs
+ */
+
+namespace CustomSniffs\Sniffs\Nextcloud;
+
+use PHP_CodeSniffer\Sniffs\Sniff;
+use PHP_CodeSniffer\Files\File;
+
+/**
+ * NoLegacyServerAccessorsSniff — forbids removed \OC::$server->getX() accessors.
+ */
+class NoLegacyServerAccessorsSniff implements Sniff
+{
+
+
+    /**
+     * Map of known named accessors to their approved OCP replacement interface.
+     *
+     * Covers the accessors that still appeared in this codebase plus the most
+     * frequently used Nextcloud 34 removals. The error message interpolates the
+     * accessor name and the replacement from this table so engineers see the
+     * intended DI target at the violation site.
+     *
+     * @var array<string, string>
+     */
+    private const REPLACEMENTS = [
+        'getSystemConfig'           => '\OCP\IConfig',
+        'getConfig'                 => '\OCP\IConfig',
+        'getDatabaseConnection'     => '\OCP\IDBConnection',
+        'getLogger'                 => '\Psr\Log\LoggerInterface',
+        'getL10NFactory'            => '\OCP\L10N\IFactory',
+        'getL10N'                   => '\OCP\IL10N (via \OCP\L10N\IFactory)',
+        'getUserSession'            => '\OCP\IUserSession',
+        'getUserManager'            => '\OCP\IUserManager',
+        'getGroupManager'           => '\OCP\IGroupManager',
+        'getURLGenerator'           => '\OCP\IURLGenerator',
+        'getRequest'                => '\OCP\IRequest',
+        'getRootFolder'             => '\OCP\Files\IRootFolder',
+        'getAppManager'             => '\OCP\App\IAppManager',
+        'getSession'                => '\OCP\ISession',
+        'getMemCacheFactory'        => '\OCP\ICacheFactory',
+        'getEventDispatcher'        => '\OCP\EventDispatcher\IEventDispatcher',
+        'getNotificationManager'    => '\OCP\Notification\IManager',
+        'getTempManager'            => '\OCP\ITempManager',
+        'getMimeTypeDetector'       => '\OCP\Files\IMimeTypeDetector',
+        'getMimeTypeLoader'         => '\OCP\Files\IMimeTypeLoader',
+        'getActivityManager'        => '\OCP\Activity\IManager',
+        'getDateTimeFormatter'      => '\OCP\IDateTimeFormatter',
+        'getDateTimeZone'           => '\OCP\IDateTimeZone',
+        'getTrustedDomainHelper'    => '\OCP\Security\ITrustedDomainHelper',
+        'getRegisteredAppContainer' => 'explicit constructor injection of the specific service',
+    ];
+
+    /**
+     * Returns tokens this sniff listens for.
+     *
+     * Anchors on T_DOUBLE_COLON so we can reconstruct the full pattern
+     * \OC :: $server -> getX ( in a single process() call.
+     *
+     * @return array<int>
+     */
+    public function register(): array
+    {
+        return [T_DOUBLE_COLON];
+
+    }//end register()
+
+    /**
+     * Process a T_DOUBLE_COLON token — flag if part of \OC::$server->getX().
+     *
+     * @param File $phpcsFile The file being scanned.
+     * @param int  $stackPtr  Position of the T_DOUBLE_COLON token.
+     *
+     * @return void
+     */
+    public function process(File $phpcsFile, $stackPtr): void
+    {
+        $tokens = $phpcsFile->getTokens();
+
+        // Previous non-whitespace token must be T_STRING "OC".
+        $prev = $phpcsFile->findPrevious(
+            types: [T_WHITESPACE],
+            start: ($stackPtr - 1),
+            end: null,
+            exclude: true
+        );
+        if ($prev === false
+            || $tokens[$prev]['code'] !== T_STRING
+            || $tokens[$prev]['content'] !== 'OC'
+        ) {
+            return;
+        }
+
+        // Next non-whitespace token must be T_VARIABLE "$server".
+        $afterColon = $phpcsFile->findNext(
+            types: [T_WHITESPACE],
+            start: ($stackPtr + 1),
+            end: null,
+            exclude: true
+        );
+        if ($afterColon === false
+            || $tokens[$afterColon]['code'] !== T_VARIABLE
+            || $tokens[$afterColon]['content'] !== '$server'
+        ) {
+            return;
+        }
+
+        // Expect T_OBJECT_OPERATOR '->'.
+        $arrow = $phpcsFile->findNext(
+            types: [T_WHITESPACE],
+            start: ($afterColon + 1),
+            end: null,
+            exclude: true
+        );
+        if ($arrow === false || $tokens[$arrow]['code'] !== T_OBJECT_OPERATOR) {
+            return;
+        }
+
+        // Expect T_STRING method name.
+        $methodPtr = $phpcsFile->findNext(
+            types: [T_WHITESPACE],
+            start: ($arrow + 1),
+            end: null,
+            exclude: true
+        );
+        if ($methodPtr === false || $tokens[$methodPtr]['code'] !== T_STRING) {
+            return;
+        }
+
+        // Must be followed by ( to be a call.
+        $openParen = $phpcsFile->findNext(
+            types: [T_WHITESPACE],
+            start: ($methodPtr + 1),
+            end: null,
+            exclude: true
+        );
+        if ($openParen === false || $tokens[$openParen]['code'] !== T_OPEN_PARENTHESIS) {
+            return;
+        }
+
+        $methodName = $tokens[$methodPtr]['content'];
+
+        // PSR-11 ->get(...) is deferred (D4 in design.md) — not flagged here.
+        if ($methodName === 'get') {
+            return;
+        }
+
+        // Only flag named accessors: getX where X starts with an uppercase letter.
+        if (preg_match(pattern: '/^get[A-Z]/', subject: $methodName) !== 1) {
+            return;
+        }
+
+        $replacement = self::REPLACEMENTS[$methodName] ?? 'the corresponding OCP interface';
+
+        $error = 'Named accessor \\OC::$server->%s() is removed in Nextcloud 34. Inject %s via the constructor instead.';
+        $phpcsFile->addError(
+            $error,
+            $stackPtr,
+            'LegacyNamedAccessor',
+            [$methodName, $replacement]
+        );
+
+    }//end process()
+}//end class

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,57 +1,26 @@
 <?xml version="1.0"?>
 <ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="PHP_CodeSniffer" xsi:noNamespaceSchemaLocation="phpcs.xsd">
-    <description>Coding standard for ZaakAfhandelApp, based on the Conduction/OpenRegister standard.</description>
+    <description>Coding standard for ZaakafhandelApp, based on the Conduction/OpenRegister standard.</description>
 
     <file>lib</file>
 
     <!-- Exclude external and vendor files -->
     <exclude-pattern>*/vendor/*</exclude-pattern>
+    <exclude-pattern>*/vendor-bin/*</exclude-pattern>
     <exclude-pattern>*/node_modules/*</exclude-pattern>
     <exclude-pattern>composer-setup.php</exclude-pattern>
+    <!-- Apps that ship a verbatim template snapshot under lib/Resources/template/ (e.g. openbuilt)
+         keep it out of lint scope; no-op for apps without the directory. -->
+    <exclude-pattern>lib/Resources/template/*</exclude-pattern>
+
+    <!-- Surface phpcs warnings (e.g. SpecTagSniff) in CI logs without failing the build. -->
+    <config name="ignore_warnings_on_exit" value="1"/>
 
     <arg name="basepath" value="."/>
     <arg name="colors"/>
     <arg name="parallel" value="75"/>
     <arg name="extensions" value="php"/>
     <arg value="p"/>
-
-    <!-- Advisory warnings surface in reports but must not fail the run. -->
-    <config name="ignore_warnings_on_exit" value="1"/>
-
-    <!-- LEGACY DEBT (tracked in ConductionNL/zaakafhandelapp#201): this app pre-dates the
-         tightened Conduction PHPCS commenting / named-parameter rules. Until a dedicated
-         docblock + named-args cleanup lands, the following sniffs are demoted from errors
-         to advisory warnings so the structural rules (spacing, control structures, banned
-         functions, etc.) still gate the build. Promote these back to errors after #201. -->
-    <rule ref="PEAR.Commenting.FunctionComment">
-        <type>warning</type>
-    </rule>
-    <rule ref="PEAR.Commenting.FileComment">
-        <type>warning</type>
-    </rule>
-    <rule ref="Generic.Commenting.DocComment">
-        <type>warning</type>
-    </rule>
-    <rule ref="Squiz.Commenting.VariableComment">
-        <type>warning</type>
-    </rule>
-    <rule ref="Squiz.Commenting.FunctionComment">
-        <type>warning</type>
-    </rule>
-    <rule ref="Squiz.Commenting.InlineComment">
-        <type>warning</type>
-    </rule>
-    <rule ref="Generic.Files.LineLength">
-        <type>warning</type>
-    </rule>
-    <!-- Stylistic; the legacy code uses ternaries / implicit-truthy checks throughout.
-         Demoted under #201 — a "rewrite ternaries / explicit comparisons" pass restores them. -->
-    <rule ref="Squiz.PHP.DisallowInlineIf">
-        <type>warning</type>
-    </rule>
-    <rule ref="Squiz.Operators.ComparisonOperatorUsage">
-        <type>warning</type>
-    </rule>
 
     <!-- Don't hide tokenizer exceptions -->
     <rule ref="Internal.Tokenizer.Exception">
@@ -250,6 +219,52 @@
          LEGACY DEBT (#201): demoted to a warning for this app until the named-args
          cleanup lands; promote back to <type>error</type> afterwards. -->
     <rule ref="./phpcs-custom-sniffs/CustomSniffs/Sniffs/Functions/NamedParametersSniff.php">
+        <type>warning</type>
+    </rule>
+
+    <!-- Block calls to \OC::$server->getX() / \OC::$server->query() removed in Nextcloud 34. -->
+    <rule ref="./phpcs-custom-sniffs/CustomSniffs/Sniffs/Nextcloud/NoLegacyServerAccessorsSniff.php">
+        <type>error</type>
+    </rule>
+
+    <!-- Warn when a class or public method is missing the @spec PHPDoc tag (hydra ADR-003).
+         Emitted as warnings (not errors) so CI surfaces the gap but doesn't block merges. -->
+    <rule ref="./phpcs-custom-sniffs/CustomSniffs/Sniffs/Commenting/SpecTagSniff.php">
+        <type>warning</type>
+    </rule>
+
+    <!-- LEGACY DEBT (tracked in ConductionNL/zaakafhandelapp#201): this app pre-dates the
+         tightened Conduction PHPCS commenting / named-parameter rules. Until a dedicated
+         docblock + named-args cleanup lands, the following sniffs are demoted from errors
+         to advisory warnings so the structural rules (spacing, control structures, banned
+         functions, etc.) still gate the build. Promote these back to errors after #201. -->
+    <rule ref="PEAR.Commenting.FunctionComment">
+        <type>warning</type>
+    </rule>
+    <rule ref="PEAR.Commenting.FileComment">
+        <type>warning</type>
+    </rule>
+    <rule ref="Generic.Commenting.DocComment">
+        <type>warning</type>
+    </rule>
+    <rule ref="Squiz.Commenting.VariableComment">
+        <type>warning</type>
+    </rule>
+    <rule ref="Squiz.Commenting.FunctionComment">
+        <type>warning</type>
+    </rule>
+    <rule ref="Squiz.Commenting.InlineComment">
+        <type>warning</type>
+    </rule>
+    <rule ref="Generic.Files.LineLength">
+        <type>warning</type>
+    </rule>
+    <!-- Stylistic; the legacy code uses ternaries / implicit-truthy checks throughout.
+         Demoted under #201 — a "rewrite ternaries / explicit comparisons" pass restores them. -->
+    <rule ref="Squiz.PHP.DisallowInlineIf">
+        <type>warning</type>
+    </rule>
+    <rule ref="Squiz.Operators.ComparisonOperatorUsage">
         <type>warning</type>
     </rule>
 

--- a/phpmd.xml
+++ b/phpmd.xml
@@ -1,16 +1,18 @@
 <?xml version="1.0"?>
-<ruleset name="ZaakAfhandelApp Rules"
+<ruleset name="ZaakafhandelApp Nextcloud Rules"
     xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"
     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0
                         http://pmd.sourceforge.net/ruleset_xml_schema.xsd">
 
     <description>
-        Custom ruleset for ZaakAfhandelApp Nextcloud.
+        This is a custom ruleset for ZaakafhandelApp Nextcloud.
     </description>
 
     <!-- Clean Code Rules -->
+    <rule ref="rulesets/cleancode.xml/BooleanArgumentFlag"/>
     <rule ref="rulesets/cleancode.xml/ElseExpression"/>
+    <rule ref="rulesets/cleancode.xml/StaticAccess"/>
     <rule ref="rulesets/cleancode.xml/IfStatementAssignment"/>
     <rule ref="rulesets/cleancode.xml/DuplicatedArrayKey"/>
     <rule ref="rulesets/cleancode.xml/MissingImport"/>
@@ -18,26 +20,10 @@
     <rule ref="rulesets/cleancode.xml/ErrorControlOperator"/>
 
     <!-- Code Size Rules -->
-    <rule ref="rulesets/codesize.xml/CyclomaticComplexity">
-        <properties>
-            <property name="reportLevel" value="15" />
-        </properties>
-    </rule>
-    <rule ref="rulesets/codesize.xml/NPathComplexity">
-        <properties>
-            <property name="minimum" value="5000" />
-        </properties>
-    </rule>
-    <rule ref="rulesets/codesize.xml/ExcessiveMethodLength">
-        <properties>
-            <property name="minimum" value="200" />
-        </properties>
-    </rule>
-    <rule ref="rulesets/codesize.xml/ExcessiveClassLength">
-        <properties>
-            <property name="minimum" value="1500" />
-        </properties>
-    </rule>
+    <rule ref="rulesets/codesize.xml/CyclomaticComplexity"/>
+    <rule ref="rulesets/codesize.xml/NPathComplexity"/>
+    <rule ref="rulesets/codesize.xml/ExcessiveMethodLength"/>
+    <rule ref="rulesets/codesize.xml/ExcessiveClassLength"/>
     <rule ref="rulesets/codesize.xml/ExcessiveParameterList"/>
     <rule ref="rulesets/codesize.xml/ExcessivePublicCount"/>
     <rule ref="rulesets/codesize.xml/TooManyFields"/>
@@ -50,6 +36,10 @@
     <rule ref="rulesets/controversial.xml/CamelCaseClassName"/>
     <rule ref="rulesets/controversial.xml/CamelCasePropertyName"/>
     <rule ref="rulesets/controversial.xml/CamelCaseMethodName"/>
+    <!-- CamelCaseParameterName removed - we allow leading underscores on parameters (convention for unused/config params) -->
+    <!-- <rule ref="rulesets/controversial.xml/CamelCaseParameterName"/> -->
+    <!-- CamelCaseVariableName removed - we allow leading underscores on variables (convention for unused loop vars) -->
+    <!-- <rule ref="rulesets/controversial.xml/CamelCaseVariableName"/> -->
 
     <!-- Design Rules -->
     <rule ref="rulesets/design.xml/ExitExpression"/>
@@ -65,6 +55,7 @@
     <!-- Naming Rules -->
     <rule ref="rulesets/naming.xml/LongClassName"/>
     <rule ref="rulesets/naming.xml/ShortClassName"/>
+    <!-- ShortVariable configured with allowlist of idiomatic short names -->
     <rule ref="rulesets/naming.xml/ShortVariable">
         <properties>
             <property name="minimum" value="3" />
@@ -81,4 +72,32 @@
     <rule ref="rulesets/unusedcode.xml/UnusedPrivateField"/>
     <rule ref="rulesets/unusedcode.xml/UnusedLocalVariable"/>
     <rule ref="rulesets/unusedcode.xml/UnusedPrivateMethod"/>
+    <rule ref="rulesets/unusedcode.xml/UnusedFormalParameter">
+        <exclude-pattern>*Migration*</exclude-pattern>
+    </rule>
+
+    <!-- LEGACY DEBT (tracked in ConductionNL/zaakafhandelapp#201): this app pre-dates the
+         tightened Conduction PHPMD code-size thresholds. The relaxations below match the
+         pre-canonical-sync ruleset so CI doesn't go red across the existing legacy code.
+         Promote these back to canonical defaults after #201 closes per-area. -->
+    <rule ref="rulesets/codesize.xml/CyclomaticComplexity">
+        <properties>
+            <property name="reportLevel" value="15"/>
+        </properties>
+    </rule>
+    <rule ref="rulesets/codesize.xml/NPathComplexity">
+        <properties>
+            <property name="minimum" value="5000"/>
+        </properties>
+    </rule>
+    <rule ref="rulesets/codesize.xml/ExcessiveMethodLength">
+        <properties>
+            <property name="minimum" value="200"/>
+        </properties>
+    </rule>
+    <rule ref="rulesets/codesize.xml/ExcessiveClassLength">
+        <properties>
+            <property name="minimum" value="1500"/>
+        </properties>
+    </rule>
 </ruleset>

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,0 +1,161 @@
+# PHPStan baseline for zaakafhandelapp.
+#
+# Generated post canonical root-config sync. Each entry below represents a
+# pre-existing finding that surfaced when the per-app PHPStan extensions were
+# replaced by the canonical config from nextcloud-app-template. They are
+# tracked for cleanup in https://github.com/ConductionNL/zaakafhandelapp/issues/201
+# (umbrella ticket for legacy lint debt).
+#
+# To regenerate after fixing entries:
+#   ./vendor/bin/phpstan analyse --memory-limit=1G --generate-baseline=phpstan-baseline.neon
+parameters:
+	ignoreErrors:
+		-
+			message: '#^Property OCA\\ZaakAfhandelApp\\Controller\\BesluitenController\:\:\$config is never read, only written\.$#'
+			identifier: property.onlyWritten
+			count: 1
+			path: lib/Controller/BesluitenController.php
+
+		-
+			message: '#^Property OCA\\ZaakAfhandelApp\\Controller\\DashboardController\:\:\$config is never read, only written\.$#'
+			identifier: property.onlyWritten
+			count: 1
+			path: lib/Controller/DashboardController.php
+
+		-
+			message: '#^Offset string does not exist on array\{\}\.$#'
+			identifier: offsetAccess.notFound
+			count: 2
+			path: lib/Controller/DocumentenController.php
+
+		-
+			message: '#^Property OCA\\ZaakAfhandelApp\\Controller\\DocumentenController\:\:\$config is never read, only written\.$#'
+			identifier: property.onlyWritten
+			count: 1
+			path: lib/Controller/DocumentenController.php
+
+		-
+			message: '#^Property OCA\\ZaakAfhandelApp\\Controller\\ResultatenController\:\:\$config is never read, only written\.$#'
+			identifier: property.onlyWritten
+			count: 1
+			path: lib/Controller/ResultatenController.php
+
+		-
+			message: '#^Property OCA\\ZaakAfhandelApp\\Controller\\RollenController\:\:\$config is never read, only written\.$#'
+			identifier: property.onlyWritten
+			count: 1
+			path: lib/Controller/RollenController.php
+
+		-
+			message: '#^Parameter \#1 \$data of class OCP\\AppFramework\\Http\\JSONResponse constructor contains unresolvable type\.$#'
+			identifier: argument.unresolvableType
+			count: 1
+			path: lib/Controller/SettingsController.php
+
+		-
+			message: '#^Property OCA\\ZaakAfhandelApp\\Controller\\StatusenController\:\:\$config is never read, only written\.$#'
+			identifier: property.onlyWritten
+			count: 1
+			path: lib/Controller/StatusenController.php
+
+		-
+			message: '#^Property OCA\\ZaakAfhandelApp\\Controller\\UsersController\:\:\$config is never read, only written\.$#'
+			identifier: property.onlyWritten
+			count: 1
+			path: lib/Controller/UsersController.php
+
+		-
+			message: '#^Property OCA\\ZaakAfhandelApp\\Controller\\ZaakAuditTrailController\:\:\$config is never read, only written\.$#'
+			identifier: property.onlyWritten
+			count: 1
+			path: lib/Controller/ZaakAuditTrailController.php
+
+		-
+			message: '#^Property OCA\\ZaakAfhandelApp\\Controller\\ZaakBesluitenController\:\:\$config is never read, only written\.$#'
+			identifier: property.onlyWritten
+			count: 1
+			path: lib/Controller/ZaakBesluitenController.php
+
+		-
+			message: '#^Property OCA\\ZaakAfhandelApp\\Controller\\ZaakEigenschappenController\:\:\$config is never read, only written\.$#'
+			identifier: property.onlyWritten
+			count: 1
+			path: lib/Controller/ZaakEigenschappenController.php
+
+		-
+			message: '#^Property OCA\\ZaakAfhandelApp\\Controller\\ZaakInformatieObjectenController\:\:\$config is never read, only written\.$#'
+			identifier: property.onlyWritten
+			count: 1
+			path: lib/Controller/ZaakInformatieObjectenController.php
+
+		-
+			message: '#^Property OCA\\ZaakAfhandelApp\\Controller\\ZaakObjectenController\:\:\$config is never read, only written\.$#'
+			identifier: property.onlyWritten
+			count: 1
+			path: lib/Controller/ZaakObjectenController.php
+
+		-
+			message: '#^Property OCA\\ZaakAfhandelApp\\Dashboard\\ContactmomentenWidget\:\:\$url is never read, only written\.$#'
+			identifier: property.onlyWritten
+			count: 1
+			path: lib/Dashboard/ContactmomentenWidget.php
+
+		-
+			message: '#^Property OCA\\ZaakAfhandelApp\\Dashboard\\OpenZakenWidget\:\:\$url is never read, only written\.$#'
+			identifier: property.onlyWritten
+			count: 1
+			path: lib/Dashboard/OpenZakenWidget.php
+
+		-
+			message: '#^Property OCA\\ZaakAfhandelApp\\Dashboard\\OrganisatiesWidget\:\:\$url is never read, only written\.$#'
+			identifier: property.onlyWritten
+			count: 1
+			path: lib/Dashboard/OrganisatiesWidget.php
+
+		-
+			message: '#^Property OCA\\ZaakAfhandelApp\\Dashboard\\PersonenWidget\:\:\$url is never read, only written\.$#'
+			identifier: property.onlyWritten
+			count: 1
+			path: lib/Dashboard/PersonenWidget.php
+
+		-
+			message: '#^Property OCA\\ZaakAfhandelApp\\Dashboard\\TakenWidget\:\:\$url is never read, only written\.$#'
+			identifier: property.onlyWritten
+			count: 1
+			path: lib/Dashboard/TakenWidget.php
+
+		-
+			message: '#^Property OCA\\ZaakAfhandelApp\\Dashboard\\ZakenWidget\:\:\$url is never read, only written\.$#'
+			identifier: property.onlyWritten
+			count: 1
+			path: lib/Dashboard/ZakenWidget.php
+
+		-
+			message: '#^Offset class\-string\<OCP\\EventDispatcher\\Event\> on array\{OCA\\OpenRegister\\Event\\ObjectCreatedEvent\: ''handleObjectCreated'', OCA\\OpenRegister\\Event\\ObjectUpdatedEvent\: ''handleObjectUpdated'', OCA\\OpenRegister\\Event\\ObjectDeletedEvent\: ''handleObjectDeleted'', OCA\\OpenRegister\\Event\\ObjectCreatingEvent\: ''handleObjectCreating'', OCA\\OpenRegister\\Event\\ObjectUpdatingEvent\: ''handleObjectUpdating''\} on left side of \?\? does not exist\.$#'
+			identifier: nullCoalesce.offset
+			count: 1
+			path: lib/EventListener/ZaakRegisterEventListener.php
+
+		-
+			message: '#^Strict comparison using \!\=\= between null and null will always evaluate to false\.$#'
+			identifier: notIdentical.alwaysFalse
+			count: 1
+			path: lib/EventListener/ZaakRegisterEventListener.php
+
+		-
+			message: '#^PHPDoc tag @param references unknown parameter\: \$objectService$#'
+			identifier: parameter.notFound
+			count: 1
+			path: lib/Service/ZGWArchiveDateService.php
+
+		-
+			message: '#^Method OCA\\ZaakAfhandelApp\\Service\\ZGWLogicService\:\:rewriteInternalReference\(\) should return string but returns OCA\\OpenRegister\\Db\\ObjectEntity\.$#'
+			identifier: return.type
+			count: 1
+			path: lib/Service/ZGWLogicService.php
+
+		-
+			message: '#^Property OCA\\ZaakAfhandelApp\\Settings\\ZaakAfhandelAppAdmin\:\:\$l is never read, only written\.$#'
+			identifier: property.onlyWritten
+			count: 1
+			path: lib/Settings/ZaakAfhandelAppAdmin.php

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,3 +1,9 @@
+includes:
+    # Per-app tracked lint debt lives here (auto-generated via `phpstan --generate-baseline`).
+    # Apps without debt ship an empty baseline file; canonical includes are otherwise byte-identical
+    # across the fleet.
+    - phpstan-baseline.neon
+
 parameters:
     level: 5
     paths:
@@ -6,29 +12,48 @@ parameters:
         - phpstan-bootstrap.php
     excludePaths:
         - vendor
+        - vendor-bin (?)
+        # Apps that ship a verbatim template snapshot under lib/Resources/template/ (e.g. openbuilt).
+        - lib/Resources/template (?)
     scanDirectories:
         - vendor/nextcloud/ocp
     reportUnmatchedIgnoredErrors: false
-    treatPhpDocTypesAsCertain: false
     ignoreErrors:
-        # Nextcloud internal classes that PHPStan might not recognize
+        # Nextcloud server internals (\OC, OC_App, OC\) not stubbed in nextcloud/ocp
         - '#Call to an undefined method OC::#'
         - '#Class OC not found#'
         - '#Access to static property \$server on an unknown class OC#'
-        - '#unknown class OC\\\\#'
-        - '#unknown class OCA\\\\DAV\\\\#'
+        - '#unknown class OC\\#'
+        - '#Caught class OC\\#'
         - '#unknown class OC_App#'
-        - '#Caught class OC\\\\#'
-        - '#Class OCA\\\\DAV\\\\#'
+        - '#Class OC_App not found#'
+        # OCA\DAV is server-internal and not in nextcloud/ocp stubs
+        - '#unknown class OCA\\DAV\\#'
+        - '#Class OCA\\DAV\\#'
         # OCA classes from other apps (OpenRegister) not available during static analysis
-        - '#OCA\\OpenRegister\\#'
+        - '#unknown class OCA\\OpenRegister\\#'
+        - '#OCA\\OpenRegister\\[a-zA-Z\\]+.*not found#'
+        - '#on an unknown class OCA\\OpenRegister\\#'
+        - '#has invalid return type OCA\\OpenRegister\\#'
+        - '#has invalid type OCA\\OpenRegister\\#'
+        - '#implements unknown interface OCA\\OpenRegister\\#'
         # GuzzleHttp is available at runtime via Nextcloud but not in composer require
         - '#unknown class GuzzleHttp\\#'
         - '#GuzzleHttp\\[a-zA-Z\\]+.*not found#'
         - '#on an unknown class GuzzleHttp\\#'
         - '#invalid type GuzzleHttp\\#'
         - '#Caught class GuzzleHttp\\#'
-        # Doctrine DBAL classes used in migrations
-        - '#Doctrine\\DBAL\\#'
+        # Doctrine\DBAL is shipped by Nextcloud server but not stubbed in nextcloud/ocp
+        - '#unknown class Doctrine\\DBAL\\#'
+        - '#Doctrine\\DBAL\\[a-zA-Z\\]+.*not found#'
+        - '#on an unknown class Doctrine\\DBAL\\#'
         # Dynamic HTTP status codes from business rule validation results
-        - '#Parameter \$statusCode of class OCP\\AppFramework\\Http\\JSONResponse constructor expects#'
+        # (matches both `Parameter $statusCode` and `Parameter #N $statusCode` forms emitted by phpstan)
+        - '#Parameter (\#\d+ )?\$statusCode of class OCP\\AppFramework\\Http\\JSONResponse constructor expects#'
+        # registerRepairStep exists on server; not yet in nextcloud/ocp stub used for analysis
+        - '#Call to an undefined method OCP\\AppFramework\\Bootstrap\\IRegistrationContext::registerRepairStep#'
+        # OCP stub gaps for methods that exist at runtime
+        - '#Call to an undefined method OCP\\IRequest::getContent\(\)#'
+        - '#Call to an undefined method OCP\\IRequest::setParameter\(\)#'
+        - '#Call to an undefined method OCP\\Mail\\IMessage::attachFile\(\)#'
+        - '#Call to an undefined method OCP\\AppFramework\\Db\\Entity::jsonSerialize#'

--- a/psalm.xml
+++ b/psalm.xml
@@ -7,7 +7,6 @@
     findUnusedBaselineEntry="true"
     findUnusedCode="true"
     findUnusedVariablesAndParams="true"
-
 >
     <projectFiles>
         <directory name="lib" />
@@ -19,39 +18,9 @@
         <file name="vendor/nextcloud/ocp/OCP/Capabilities/ICapability.php" preloadClasses="true" />
     </stubs>
     <issueHandlers>
-        <UndefinedDocblockClass>
-            <errorLevel type="suppress">
-                <referencedClass name="Doctrine\DBAL\Schema\Table"/>
-                <referencedClass name="Doctrine\DBAL\Schema\Schema"/>
-                <referencedClass name="Doctrine\DBAL\Types\Types"/>
-                <referencedClass name="Doctrine\DBAL\Connection"/>
-                <referencedClass name="Doctrine\DBAL\Platforms\AbstractPlatform"/>
-                <referencedClass name="OCP\IMemcache"/>
-                <referencedClass name="OCP\IDBConnection"/>
-                <referencedClass name="OCP\AppFramework\IAppContainer"/>
-                <referencedClass name="OCP\AppFramework\Db\DoesNotExistException"/>
-                <referencedClass name="OCP\AppFramework\Db\Entity"/>
-                <referencedClass name="OCP\DB\Exception"/>
-                <!-- OpenRegister classes (external app dependency) -->
-                <referencedClass name="OCA\OpenRegister\Service\ObjectService"/>
-                <referencedClass name="OCA\OpenRegister\Db\ObjectEntity"/>
-                <referencedClass name="OCA\OpenRegister\Db\RegisterMapper"/>
-                <referencedClass name="OCA\OpenRegister\Db\Schema"/>
-                <referencedClass name="OCA\OpenRegister\Db\SchemaMapper"/>
-            </errorLevel>
-        </UndefinedDocblockClass>
+        <UndefinedDocblockClass errorLevel="suppress"/>
         <UndefinedClass>
             <errorLevel type="suppress">
-                <referencedClass name="OC"/>
-                <referencedClass name="Doctrine\DBAL\Types\Types"/>
-                <referencedClass name="Doctrine\DBAL\Types\Type"/>
-                <referencedClass name="Doctrine\DBAL\Connection"/>
-                <referencedClass name="Doctrine\DBAL\Schema\Schema"/>
-                <referencedClass name="Symfony\Component\HttpFoundation\Response"/>
-                <referencedClass name="Doctrine\DBAL\Platforms\AbstractPlatform"/>
-                <referencedClass name="Doctrine\DBAL\Platforms\MySQLPlatform"/>
-                <referencedClass name="Doctrine\DBAL\ParameterType"/>
-                <referencedClass name="Ramsey\Uuid\Uuid"/>
                 <!-- Nextcloud OCP Classes -->
                 <referencedClass name="OCP\AppFramework\App"/>
                 <referencedClass name="OCP\AppFramework\Bootstrap\IBootstrap"/>
@@ -70,7 +39,6 @@
                 <referencedClass name="OCP\IGroupManager"/>
                 <referencedClass name="OCP\IUserManager"/>
                 <referencedClass name="OCP\IUserSession"/>
-                <referencedClass name="OCP\Search\IFilteringProvider"/>
                 <referencedClass name="OCP\IMemcache"/>
                 <referencedClass name="OCP\IRequest"/>
                 <referencedClass name="OCP\EventDispatcher\IEventDispatcher"/>
@@ -91,34 +59,42 @@
                 <referencedClass name="OCP\Http\Client\IClientService"/>
                 <referencedClass name="OCP\Notification\IManager"/>
                 <referencedClass name="OCP\Share\IManager"/>
-                <!-- OpenRegister classes (external app dependency) -->
-                <referencedClass name="OCA\OpenRegister\Event\ObjectCreatedEvent"/>
-                <referencedClass name="OCA\OpenRegister\Event\ObjectCreatingEvent"/>
-                <referencedClass name="OCA\OpenRegister\Event\ObjectUpdatedEvent"/>
-                <referencedClass name="OCA\OpenRegister\Event\ObjectUpdatingEvent"/>
-                <referencedClass name="OCA\OpenRegister\Event\ObjectDeletedEvent"/>
-                <referencedClass name="OCA\OpenRegister\Event\ObjectDeletingEvent"/>
-                <referencedClass name="OCA\OpenRegister\Event\ObjectLockedEvent"/>
-                <referencedClass name="OCA\OpenRegister\Event\ObjectUnlockedEvent"/>
-                <referencedClass name="OCA\OpenRegister\Event\ObjectRevertedEvent"/>
-                <referencedClass name="OCA\OpenRegister\Service\ObjectService"/>
+                <!-- OpenRegister cross-app classes (loaded dynamically) -->
                 <referencedClass name="OCA\OpenRegister\Db\ObjectEntity"/>
                 <referencedClass name="OCA\OpenRegister\Db\RegisterMapper"/>
-                <referencedClass name="OCA\OpenRegister\Db\Schema"/>
                 <referencedClass name="OCA\OpenRegister\Db\SchemaMapper"/>
-                <referencedClass name="OCA\OpenRegister\Exception\CustomValidationException"/>
+                <referencedClass name="OCA\OpenRegister\Event\DeepLinkRegistrationEvent"/>
+                <referencedClass name="OCA\OpenRegister\Event\ObjectCreatingEvent"/>
+                <referencedClass name="OCA\OpenRegister\Event\ObjectCreatedEvent"/>
+                <referencedClass name="OCA\OpenRegister\Event\ObjectUpdatingEvent"/>
+                <referencedClass name="OCA\OpenRegister\Event\ObjectUpdatedEvent"/>
+                <referencedClass name="OCA\OpenRegister\Event\ObjectDeletedEvent"/>
+                <referencedClass name="OCA\OpenRegister\Service\ObjectService"/>
+                <referencedClass name="OCA\OpenRegister\Service\ConfigurationService"/>
+                <referencedClass name="OCA\OpenRegister\Service\RegisterService"/>
+                <referencedClass name="OCA\OpenRegister\Service\FileService"/>
+                <referencedClass name="OCA\OpenRegister\Service\CalendarEventService"/>
+                <referencedClass name="OCA\OpenRegister\Mcp\IMcpToolProvider"/>
+                <!-- Additional OCP infrastructure types used across the fleet -->
+                <referencedClass name="OCP\AppFramework\Bootstrap\IBootContext"/>
+                <referencedClass name="OCP\AppFramework\Bootstrap\IRegistrationContext"/>
+                <referencedClass name="OCP\AppFramework\Db\DoesNotExistException"/>
+                <referencedClass name="OCP\DB\Exception"/>
+                <referencedClass name="OCP\IGroup"/>
+                <referencedClass name="OCP\IUser"/>
+                <referencedClass name="OCP\Migration\IRepairStep"/>
+                <!-- Nextcloud server internals -->
+                <referencedClass name="OC"/>
+                <!-- GuzzleHttp (loaded via composer at runtime) -->
+                <referencedClass name="GuzzleHttp\Client"/>
+                <referencedClass name="GuzzleHttp\Exception\GuzzleException"/>
             </errorLevel>
         </UndefinedClass>
-        <InvalidThrow errorLevel="suppress"/>
-        <InvalidTemplateParam errorLevel="suppress"/>
-        <MissingTemplateParam errorLevel="suppress"/>
-        <NoInterfaceProperties errorLevel="suppress"/>
         <UndefinedMagicMethod errorLevel="suppress"/>
         <UnusedClass errorLevel="suppress"/>
         <PossiblyUnusedMethod errorLevel="suppress"/>
         <UnusedMethod errorLevel="suppress"/>
         <UnusedProperty errorLevel="suppress"/>
-        <UnusedParam errorLevel="suppress"/>
         <PossiblyUnusedParam errorLevel="suppress"/>
         <UnusedDocblockParam errorLevel="suppress"/>
         <UnusedVariable errorLevel="suppress"/>
@@ -126,8 +102,6 @@
         <RedundantCondition errorLevel="suppress"/>
         <RedundantFunctionCall errorLevel="suppress"/>
         <RedundantCast errorLevel="suppress"/>
-        <RedundantPropertyInitializationCheck errorLevel="suppress"/>
-        <StringIncrement errorLevel="suppress"/>
         <InvalidDocblock errorLevel="suppress"/>
         <MoreSpecificImplementedParamType errorLevel="suppress"/>
         <MissingDependency errorLevel="suppress"/>
@@ -144,6 +118,8 @@
         <EmptyArrayAccess errorLevel="suppress"/>
         <ImplementedReturnTypeMismatch errorLevel="suppress"/>
         <InvalidMethodCall errorLevel="suppress"/>
+        <UndefinedInterfaceMethod errorLevel="suppress"/>
+        <MissingTemplateParam errorLevel="suppress"/>
     </issueHandlers>
     <extraFiles>
         <directory name="vendor/nextcloud/ocp" />


### PR DESCRIPTION
## Summary

Phase 2 fleet rollout of the root-config consolidation. Replaces per-app `phpcs.xml` / `phpmd.xml` / `psalm.xml` / `phpstan.neon` / `phpstan-bootstrap.php` with the canonical from `nextcloud-app-template`.

Pattern proven on shillinq#300 (merged) and decidesk#243 (merged).

Lint-debt tracking: #239 (sync debt) + #201 (umbrella legacy debt).

## Preserved per-app overrides (tracked in #201)

This is the canonical exception for **tracked debt with a ticket**: the #201 demotions stay, the canonical sync wraps around them.

**PHPCS `<type>warning</type>` demotions:**
- `PEAR.Commenting.FunctionComment`, `PEAR.Commenting.FileComment`, `Generic.Commenting.DocComment`
- `Squiz.Commenting.VariableComment`, `Squiz.Commenting.FunctionComment`, `Squiz.Commenting.InlineComment`
- `Generic.Files.LineLength`
- `Squiz.PHP.DisallowInlineIf`, `Squiz.Operators.ComparisonOperatorUsage`
- Custom `NamedParametersSniff` (was `<type>error</type>` in canonical, demoted to `<type>warning</type>`)

**PHPMD threshold relaxations:**
- `CyclomaticComplexity` reportLevel=15 (canonical default 10)
- `NPathComplexity` minimum=5000 (canonical default 200)
- `ExcessiveMethodLength` minimum=200 (canonical default 100)
- `ExcessiveClassLength` minimum=1500 (canonical default 1000)

## Quality gates

| Gate | Status |
|---|---|
| phpcs | 0 errors, 1524 warnings (all #201) |
| phpstan | 0 unmatched (26 baselined under #239) |
| psalm | 15 pre-existing errors (tracked #239) |
| phpmd | 90 architectural violations (tracked #239 + #201 threshold relaxations) |

phpmd has no native baseline support so CI stays red until #239 closes. Agreed-upon tracked-debt pattern.

## Source changes

- Removed 12 dead `$query = $this->request->getParams();` (with `// Latere zorg` comment) from 6 ZGW controllers (BesluitenController, ResultatenController, StatusenController, ZaakEigenschappenController, ZaakInformatieObjectenController, ZaakObjectenController).

## Test plan

- [x] phpcs: 0 errors (warnings preserved under #201)
- [x] phpstan: 0 unmatched with baseline
- [x] psalm: count stable, all 15 are cross-app `OCA\OpenRegister\…` undefined-class references (pre-existing, baselined for #239)
- [ ] phpmd CI red, tracked #239 + #201