### PR TITLE
chore(deps): bump PHP requirement to ^8.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,7 @@
 		"openapi": "generate-spec"
 	},
 	"require": {
-		"php": "^8.1",
+		"php": "^8.3",
 		"adbario/php-dot-notation": "^3.3.0",
 		"bamarni/composer-bin-plugin": "^1.8",
 		"elasticsearch/elasticsearch": "^v8.14.0",


### PR DESCRIPTION
Brings composer `require.php` from `^8.1` (or `^8.2`) to `^8.3`. Container + CI already use PHP 8.3; this just tightens the formal constraint. Part of the fleet-wide PHP 8.3 sweep.