### PR TITLE
feat(nav): add Features & roadmap item + page, bump nc-vue beta.101

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -24,7 +24,7 @@ Create a [bug report](https://github.com/OpenCatalogi/.github/issues/new/choose)
 
 Create a [feature request](https://github.com/OpenCatalogi/.github/issues/new/choose)
     ]]></description>
-	<version>0.2.1</version>
+	<version>0.2.2</version>
 	<licence>agpl</licence>
 	<author mail="info@conduction.nl" homepage="https://www.conduction.nl/">Conduction</author>
 	<namespace>ZaakAfhandelApp</namespace>

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
             "license": "EUPL-1.2",
             "dependencies": {
                 "@babel/core": "^7.29.0",
-                "@conduction/nextcloud-vue": "^1.0.0-beta.97",
+                "@conduction/nextcloud-vue": "^1.0.0-beta.101",
                 "@fortawesome/fontawesome-svg-core": "^6.5.2",
                 "@fortawesome/free-solid-svg-icons": "^6.5.2",
                 "@nextcloud/axios": "~2.5.2",
@@ -2087,9 +2087,9 @@
             }
         },
         "node_modules/@conduction/nextcloud-vue": {
-            "version": "1.0.0-beta.97",
-            "resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-1.0.0-beta.97.tgz",
-            "integrity": "sha512-jlRpA1tjIX3ysP8a42S6lrbrcZfN63yHDzgWMBNaf9Ofs0jvVqqkYawLuEj8vGMU1H4hwvyb0lEOHIsNRmHP6g==",
+            "version": "1.0.0-beta.101",
+            "resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-1.0.0-beta.101.tgz",
+            "integrity": "sha512-UVxKWUU7pf6oHr7Oly5HWPC1e8OK3z2lmdS5xgs28+sYZPNj53co9+xs3tb0mqCGXZ8Oqit9NMapI8ir0fy2iA==",
             "license": "EUPL-1.2",
             "dependencies": {
                 "@codemirror/autocomplete": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     ],
     "dependencies": {
         "@babel/core": "^7.29.0",
-        "@conduction/nextcloud-vue": "^1.0.0-beta.97",
+        "@conduction/nextcloud-vue": "^1.0.0-beta.101",
         "@fortawesome/fontawesome-svg-core": "^6.5.2",
         "@fortawesome/free-solid-svg-icons": "^6.5.2",
         "@nextcloud/axios": "~2.5.2",

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -93,6 +93,14 @@
 			"order": 90
 		},
 		{
+			"id": "FeaturesRoadmapMenu",
+			"label": "Features & roadmap",
+			"icon": "icon-toggle",
+			"route": "FeaturesRoadmap",
+			"section": "footer",
+			"order": 91
+		},
+		{
 			"id": "SettingsMenu",
 			"label": "Settings",
 			"icon": "icon-settings",
@@ -102,6 +110,15 @@
 		}
 	],
 	"pages": [
+		{
+			"id": "FeaturesRoadmap",
+			"route": "/features-roadmap",
+			"type": "roadmap",
+			"title": "Features & roadmap",
+			"config": {
+				"documentationUrl": "https://zaakafhandelapp.conduction.nl"
+			}
+		},
 		{
 			"id": "Dashboard",
 			"route": "/",


### PR DESCRIPTION
## Summary
- Add "Features & roadmap" footer menu item (`FeaturesRoadmapMenu`, route `FeaturesRoadmap`, order 91 just after Documentation)
- Add `roadmap` page `FeaturesRoadmap` at `/features-roadmap` with `documentationUrl: https://zaakafhandelapp.conduction.nl`
- Bump `@conduction/nextcloud-vue` to `^1.0.0-beta.101` (lockfile resolves `1.0.0-beta.101`)
- Bump app version 0.2.1 -> 0.2.2

## Test plan
- [ ] Footer shows "Features & roadmap" entry, routes to the roadmap page