### PR TITLE
retrofit: spec-coverage to zero (13 capabilities / 625 methods)

### DIFF
--- a/lib/Controller/BerichtenController.php
+++ b/lib/Controller/BerichtenController.php
@@ -26,6 +26,8 @@ class BerichtenController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse
+      *
+      * @spec openspec/specs/zgw-client-interaction/spec.md#REQ-001
      */
     public function index(): JSONResponse
     {
@@ -47,6 +49,8 @@ class BerichtenController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+      *
+      * @spec openspec/specs/zgw-client-interaction/spec.md#REQ-004
      */
     public function page(?string $getParameter): TemplateResponse
     {
@@ -82,6 +86,8 @@ class BerichtenController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse
+      *
+      * @spec openspec/specs/zgw-client-interaction/spec.md#REQ-001
      */
     public function show(string $id): JSONResponse
     {
@@ -99,6 +105,8 @@ class BerichtenController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse
+      *
+      * @spec openspec/specs/zgw-client-interaction/spec.md#REQ-002
      */
     public function create(): JSONResponse
     {
@@ -122,6 +130,8 @@ class BerichtenController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse
+      *
+      * @spec openspec/specs/zgw-client-interaction/spec.md#REQ-002
      */
     public function update(string $id): JSONResponse
     {
@@ -142,6 +152,8 @@ class BerichtenController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse
+      *
+      * @spec openspec/specs/zgw-client-interaction/spec.md#REQ-002
      */
     public function destroy(string $id): JSONResponse
     {
@@ -159,6 +171,8 @@ class BerichtenController extends Controller
          * @NoCSRFRequired
          *
          * @return JSONResponse
+          *
+          * @spec openspec/specs/zgw-client-interaction/spec.md#REQ-004
          */
     public function getAuditTrail(string $id): JSONResponse
     {

--- a/lib/Controller/BesluitenController.php
+++ b/lib/Controller/BesluitenController.php
@@ -55,6 +55,8 @@ class BesluitenController extends Controller
      * @NoCSRFRequired
      *
      * @return TemplateResponse
+      *
+      * @spec openspec/specs/zgw-related-resources/spec.md#REQ-003
      */
     public function page(): TemplateResponse
     {
@@ -73,6 +75,8 @@ class BesluitenController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse
+      *
+      * @spec openspec/specs/zgw-related-resources/spec.md#REQ-001
      */
     public function index(CallService $callService): JSONResponse
     {
@@ -87,6 +91,8 @@ class BesluitenController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse
+      *
+      * @spec openspec/specs/zgw-related-resources/spec.md#REQ-001
      */
     public function show(string $id, CallService $callService): JSONResponse
     {
@@ -101,6 +107,8 @@ class BesluitenController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse
+      *
+      * @spec openspec/specs/zgw-related-resources/spec.md#REQ-002
      */
     public function create(CallService $callService): JSONResponse
     {
@@ -117,6 +125,8 @@ class BesluitenController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse
+      *
+      * @spec openspec/specs/zgw-related-resources/spec.md#REQ-002
      */
     public function update(string $id, CallService $callService): JSONResponse
     {
@@ -132,6 +142,8 @@ class BesluitenController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse
+      *
+      * @spec openspec/specs/zgw-related-resources/spec.md#REQ-002
      */
     public function destroy(string $id, CallService $callService): JSONResponse
     {

--- a/lib/Controller/ConfigurationController.php
+++ b/lib/Controller/ConfigurationController.php
@@ -21,6 +21,8 @@ class ConfigurationController extends Controller
     /**
      * @NoAdminRequired
      * @NoCSRFRequired
+      *
+      * @spec openspec/specs/app-configuration/spec.md#REQ-001
      */
     public function index(): JSONResponse
     {
@@ -71,6 +73,8 @@ class ConfigurationController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+      *
+      * @spec openspec/specs/app-configuration/spec.md#REQ-001
      */
     public function create(): JSONResponse
     {

--- a/lib/Controller/ContactMomentenController.php
+++ b/lib/Controller/ContactMomentenController.php
@@ -29,6 +29,8 @@ class ContactMomentenController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse
+      *
+      * @spec openspec/specs/zgw-client-interaction/spec.md#REQ-001
      */
     public function index(): JSONResponse
     {
@@ -50,6 +52,8 @@ class ContactMomentenController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+      *
+      * @spec openspec/specs/zgw-client-interaction/spec.md#REQ-004
      */
     public function page(?string $getParameter): TemplateResponse
     {
@@ -85,6 +89,8 @@ class ContactMomentenController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse
+      *
+      * @spec openspec/specs/zgw-client-interaction/spec.md#REQ-001
      */
     public function show(string $id): JSONResponse
     {
@@ -102,6 +108,8 @@ class ContactMomentenController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse
+      *
+      * @spec openspec/specs/zgw-client-interaction/spec.md#REQ-002
      */
     public function create(): JSONResponse
     {
@@ -125,6 +133,8 @@ class ContactMomentenController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse
+      *
+      * @spec openspec/specs/zgw-client-interaction/spec.md#REQ-002
      */
     public function update(string $id): JSONResponse
     {
@@ -145,6 +155,8 @@ class ContactMomentenController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse
+      *
+      * @spec openspec/specs/zgw-client-interaction/spec.md#REQ-002
      */
     public function destroy(string $id): JSONResponse
     {
@@ -162,6 +174,8 @@ class ContactMomentenController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse
+      *
+      * @spec openspec/specs/zgw-client-interaction/spec.md#REQ-004
      */
     public function getAuditTrail(string $id): JSONResponse
     {

--- a/lib/Controller/DashboardController.php
+++ b/lib/Controller/DashboardController.php
@@ -50,6 +50,8 @@ class DashboardController extends Controller
      * @NoCSRFRequired
      *
      * @return TemplateResponse
+      *
+      * @spec openspec/specs/app-configuration/spec.md#REQ-003
      */
     public function page(): TemplateResponse
     {
@@ -68,6 +70,8 @@ class DashboardController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse
+      *
+      * @spec openspec/specs/app-configuration/spec.md#REQ-003
      */
     public function index(): JSONResponse
     {
@@ -82,6 +86,8 @@ class DashboardController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse
+      *
+      * @spec openspec/specs/app-configuration/spec.md#REQ-003
      */
     public function show(string $id): JSONResponse
     {
@@ -96,6 +102,8 @@ class DashboardController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse
+      *
+      * @spec openspec/specs/app-configuration/spec.md#REQ-003
      */
     public function create(): JSONResponse
     {
@@ -110,6 +118,8 @@ class DashboardController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse
+      *
+      * @spec openspec/specs/app-configuration/spec.md#REQ-003
      */
     public function update(string $id): JSONResponse
     {
@@ -124,6 +134,8 @@ class DashboardController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse
+      *
+      * @spec openspec/specs/app-configuration/spec.md#REQ-003
      */
     public function destroy(string $id): JSONResponse
     {

--- a/lib/Controller/DocumentenController.php
+++ b/lib/Controller/DocumentenController.php
@@ -32,6 +32,8 @@ class DocumentenController extends Controller
      * @NoCSRFRequired
      *
      * @return TemplateResponse
+      *
+      * @spec openspec/specs/zgw-related-resources/spec.md#REQ-003
      */
     public function page(): TemplateResponse
     {
@@ -50,6 +52,8 @@ class DocumentenController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse
+      *
+      * @spec openspec/specs/zgw-related-resources/spec.md#REQ-001
      */
     public function index(): JSONResponse
     {
@@ -64,6 +68,8 @@ class DocumentenController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse
+      *
+      * @spec openspec/specs/zgw-related-resources/spec.md#REQ-001
      */
     public function show(string $id): JSONResponse
     {
@@ -78,6 +84,8 @@ class DocumentenController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse
+      *
+      * @spec openspec/specs/zgw-related-resources/spec.md#REQ-002
      */
     public function create(): JSONResponse
     {
@@ -92,6 +100,8 @@ class DocumentenController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse
+      *
+      * @spec openspec/specs/zgw-related-resources/spec.md#REQ-002
      */
     public function update(string $id): JSONResponse
     {
@@ -106,6 +116,8 @@ class DocumentenController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse
+      *
+      * @spec openspec/specs/zgw-related-resources/spec.md#REQ-002
      */
     public function destroy(string $id): JSONResponse
     {

--- a/lib/Controller/KlantenController.php
+++ b/lib/Controller/KlantenController.php
@@ -26,6 +26,8 @@ class KlantenController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse
+      *
+      * @spec openspec/specs/zgw-client-interaction/spec.md#REQ-001
      */
     public function index(): JSONResponse
     {
@@ -47,6 +49,8 @@ class KlantenController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+      *
+      * @spec openspec/specs/zgw-client-interaction/spec.md#REQ-004
      */
     public function page(?string $getParameter): TemplateResponse
     {
@@ -82,6 +86,8 @@ class KlantenController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse
+      *
+      * @spec openspec/specs/zgw-client-interaction/spec.md#REQ-001
      */
     public function show(string $id): JSONResponse
     {
@@ -99,6 +105,8 @@ class KlantenController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse
+      *
+      * @spec openspec/specs/zgw-client-interaction/spec.md#REQ-002
      */
     public function create(): JSONResponse
     {
@@ -122,6 +130,8 @@ class KlantenController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse
+      *
+      * @spec openspec/specs/zgw-client-interaction/spec.md#REQ-002
      */
     public function update(string $id): JSONResponse
     {
@@ -142,6 +152,8 @@ class KlantenController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse
+      *
+      * @spec openspec/specs/zgw-client-interaction/spec.md#REQ-002
      */
     public function destroy(string $id): JSONResponse
     {
@@ -159,6 +171,8 @@ class KlantenController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse
+      *
+      * @spec openspec/specs/zgw-client-interaction/spec.md#REQ-003
      */
     public function getZaken(string $id): JSONResponse
     {
@@ -174,6 +188,8 @@ class KlantenController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse
+      *
+      * @spec openspec/specs/zgw-client-interaction/spec.md#REQ-003
      */
     public function getTaken(string $id): JSONResponse
     {
@@ -189,6 +205,8 @@ class KlantenController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse
+      *
+      * @spec openspec/specs/zgw-client-interaction/spec.md#REQ-003
      */
     public function getBerichten(string $id): JSONResponse
     {
@@ -204,6 +222,8 @@ class KlantenController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse
+      *
+      * @spec openspec/specs/zgw-client-interaction/spec.md#REQ-003
      */
     public function getContactmomenten(string $id): JSONResponse
     {
@@ -219,6 +239,8 @@ class KlantenController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse
+      *
+      * @spec openspec/specs/zgw-client-interaction/spec.md#REQ-004
      */
     public function getAuditTrail(string $id): JSONResponse
     {

--- a/lib/Controller/MedewerkersController.php
+++ b/lib/Controller/MedewerkersController.php
@@ -29,6 +29,8 @@ class MedewerkersController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse
+      *
+      * @spec openspec/specs/zgw-client-interaction/spec.md#REQ-001
      */
     public function index(): JSONResponse
     {
@@ -50,6 +52,8 @@ class MedewerkersController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+      *
+      * @spec openspec/specs/zgw-client-interaction/spec.md#REQ-004
      */
     public function page(?string $getParameter): TemplateResponse
     {
@@ -85,6 +89,8 @@ class MedewerkersController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse
+      *
+      * @spec openspec/specs/zgw-client-interaction/spec.md#REQ-001
      */
     public function show(string $id): JSONResponse
     {
@@ -102,6 +108,8 @@ class MedewerkersController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse
+      *
+      * @spec openspec/specs/zgw-client-interaction/spec.md#REQ-002
      */
     public function create(): JSONResponse
     {
@@ -125,6 +133,8 @@ class MedewerkersController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse
+      *
+      * @spec openspec/specs/zgw-client-interaction/spec.md#REQ-002
      */
     public function update(string $id): JSONResponse
     {
@@ -145,6 +155,8 @@ class MedewerkersController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse
+      *
+      * @spec openspec/specs/zgw-client-interaction/spec.md#REQ-002
      */
     public function destroy(string $id): JSONResponse
     {
@@ -162,6 +174,8 @@ class MedewerkersController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse
+      *
+      * @spec openspec/specs/zgw-client-interaction/spec.md#REQ-004
      */
     public function getAuditTrail(string $id): JSONResponse
     {

--- a/lib/Controller/ObjectsController.php
+++ b/lib/Controller/ObjectsController.php
@@ -30,6 +30,8 @@ class ObjectsController extends Controller
      * @param string $objectType The type of object to return
      *
      * @return JSONResponse
+      *
+      * @spec openspec/specs/zgw-object-data-access/spec.md#REQ-002
      */
     public function index(string $objectType): JSONResponse
     {
@@ -53,6 +55,8 @@ class ObjectsController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse
+      *
+      * @spec openspec/specs/zgw-object-data-access/spec.md#REQ-002
      */
     public function show(string $objectType, string $id): JSONResponse
     {
@@ -86,6 +90,8 @@ class ObjectsController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse
+      *
+      * @spec openspec/specs/zgw-object-data-access/spec.md#REQ-003
      */
     public function create(string $objectType): JSONResponse
     {
@@ -116,6 +122,8 @@ class ObjectsController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse
+      *
+      * @spec openspec/specs/zgw-object-data-access/spec.md#REQ-003
      */
     public function update(string $objectType, string $id): JSONResponse
     {
@@ -146,6 +154,8 @@ class ObjectsController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse
+      *
+      * @spec openspec/specs/zgw-object-data-access/spec.md#REQ-003
      */
     public function destroy(string $objectType, string $id): JSONResponse
     {
@@ -170,6 +180,8 @@ class ObjectsController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse
+      *
+      * @spec openspec/specs/zgw-object-data-access/spec.md#REQ-002
      */
     public function getAuditTrail(string $objectType, string $id): JSONResponse
     {
@@ -191,6 +203,8 @@ class ObjectsController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse
+      *
+      * @spec openspec/specs/zgw-object-data-access/spec.md#REQ-002
      */
     public function getRelations(string $objectType, string $id): JSONResponse
     {
@@ -215,6 +229,8 @@ class ObjectsController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse
+      *
+      * @spec openspec/specs/zgw-object-data-access/spec.md#REQ-002
      */
     public function getUses(string $objectType, string $id): JSONResponse
     {

--- a/lib/Controller/ResultatenController.php
+++ b/lib/Controller/ResultatenController.php
@@ -54,6 +54,8 @@ class ResultatenController extends Controller
      * @NoCSRFRequired
      *
      * @return TemplateResponse
+      *
+      * @spec openspec/specs/zgw-related-resources/spec.md#REQ-003
      */
     public function pages(): TemplateResponse
     {
@@ -72,6 +74,8 @@ class ResultatenController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse
+      *
+      * @spec openspec/specs/zgw-related-resources/spec.md#REQ-001
      */
     public function index(CallService $callService): JSONResponse
     {
@@ -86,6 +90,8 @@ class ResultatenController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse
+      *
+      * @spec openspec/specs/zgw-related-resources/spec.md#REQ-001
      */
     public function show(string $id, CallService $callService): JSONResponse
     {
@@ -100,6 +106,8 @@ class ResultatenController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse
+      *
+      * @spec openspec/specs/zgw-related-resources/spec.md#REQ-002
      */
     public function create(CallService $callService): JSONResponse
     {
@@ -116,6 +124,8 @@ class ResultatenController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse
+      *
+      * @spec openspec/specs/zgw-related-resources/spec.md#REQ-002
      */
     public function update(string $id, CallService $callService): JSONResponse
     {
@@ -131,6 +141,8 @@ class ResultatenController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse
+      *
+      * @spec openspec/specs/zgw-related-resources/spec.md#REQ-002
      */
     public function destroy(string $id, CallService $callService): JSONResponse
     {

--- a/lib/Controller/RollenController.php
+++ b/lib/Controller/RollenController.php
@@ -38,6 +38,8 @@ class RollenController extends Controller
      * @NoCSRFRequired
      *
      * @return TemplateResponse
+      *
+      * @spec openspec/specs/zgw-related-resources/spec.md#REQ-003
      */
     public function page(): TemplateResponse
     {
@@ -53,6 +55,8 @@ class RollenController extends Controller
      * @param CallService $callService The call service
      *
      * @return JSONResponse
+      *
+      * @spec openspec/specs/zgw-related-resources/spec.md#REQ-001
      */
     public function index(CallService $callService): JSONResponse
     {
@@ -70,6 +74,8 @@ class RollenController extends Controller
      * @param CallService $callService The call service
      *
      * @return JSONResponse
+      *
+      * @spec openspec/specs/zgw-related-resources/spec.md#REQ-001
      */
     public function show(string $id, CallService $callService): JSONResponse
     {
@@ -86,6 +92,8 @@ class RollenController extends Controller
      * @param CallService $callService The call service
      *
      * @return JSONResponse
+      *
+      * @spec openspec/specs/zgw-related-resources/spec.md#REQ-002
      */
     public function create(CallService $callService): JSONResponse
     {
@@ -104,6 +112,8 @@ class RollenController extends Controller
      * @param CallService $callService The call service
      *
      * @return JSONResponse
+      *
+      * @spec openspec/specs/zgw-related-resources/spec.md#REQ-002
      */
     public function update(string $id, CallService $callService): JSONResponse
     {
@@ -122,6 +132,8 @@ class RollenController extends Controller
      * @param CallService $callService The call service
      *
      * @return JSONResponse
+      *
+      * @spec openspec/specs/zgw-related-resources/spec.md#REQ-002
      */
     public function destroy(string $id, CallService $callService): JSONResponse
     {

--- a/lib/Controller/SettingsController.php
+++ b/lib/Controller/SettingsController.php
@@ -62,6 +62,8 @@ class SettingsController extends Controller
      * @return JSONResponse JSON response containing the current settings
      *
      * @NoCSRFRequired
+      *
+      * @spec openspec/specs/app-configuration/spec.md#REQ-002
      */
     public function index(): JSONResponse
     {
@@ -96,6 +98,8 @@ class SettingsController extends Controller
      * @return JSONResponse JSON response containing the updated settings
      *
      * @NoCSRFRequired
+      *
+      * @spec openspec/specs/app-configuration/spec.md#REQ-002
      */
     public function create(): JSONResponse
     {

--- a/lib/Controller/StatusenController.php
+++ b/lib/Controller/StatusenController.php
@@ -54,6 +54,8 @@ class StatusenController extends Controller
      * @NoCSRFRequired
      *
      * @return TemplateResponse
+      *
+      * @spec openspec/specs/zgw-related-resources/spec.md#REQ-003
      */
     public function page(): TemplateResponse
     {
@@ -72,6 +74,8 @@ class StatusenController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse
+      *
+      * @spec openspec/specs/zgw-related-resources/spec.md#REQ-001
      */
     public function index(CallService $callService): JSONResponse
     {
@@ -86,6 +90,8 @@ class StatusenController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse
+      *
+      * @spec openspec/specs/zgw-related-resources/spec.md#REQ-001
      */
     public function show(string $id, CallService $callService): JSONResponse
     {
@@ -100,6 +106,8 @@ class StatusenController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse
+      *
+      * @spec openspec/specs/zgw-related-resources/spec.md#REQ-002
      */
     public function create(CallService $callService): JSONResponse
     {
@@ -116,6 +124,8 @@ class StatusenController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse
+      *
+      * @spec openspec/specs/zgw-related-resources/spec.md#REQ-002
      */
     public function update(string $id, CallService $callService): JSONResponse
     {
@@ -131,6 +141,8 @@ class StatusenController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse
+      *
+      * @spec openspec/specs/zgw-related-resources/spec.md#REQ-002
      */
     public function destroy(string $id, CallService $callService): JSONResponse
     {

--- a/lib/Controller/TakenController.php
+++ b/lib/Controller/TakenController.php
@@ -28,6 +28,8 @@ class TakenController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse
+      *
+      * @spec openspec/specs/zgw-client-interaction/spec.md#REQ-001
      */
     public function index(): JSONResponse
     {
@@ -50,6 +52,8 @@ class TakenController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+      *
+      * @spec openspec/specs/zgw-client-interaction/spec.md#REQ-004
      */
     public function page(?string $getParameter): TemplateResponse
     {
@@ -87,6 +91,8 @@ class TakenController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse
+      *
+      * @spec openspec/specs/zgw-client-interaction/spec.md#REQ-001
      */
     public function show(string $id): JSONResponse
     {
@@ -104,6 +110,8 @@ class TakenController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse
+      *
+      * @spec openspec/specs/zgw-client-interaction/spec.md#REQ-002
      */
     public function create(): JSONResponse
     {
@@ -131,6 +139,8 @@ class TakenController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse
+      *
+      * @spec openspec/specs/zgw-client-interaction/spec.md#REQ-002
      */
     public function update(string $id): JSONResponse
     {
@@ -162,6 +172,8 @@ class TakenController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse
+      *
+      * @spec openspec/specs/zgw-client-interaction/spec.md#REQ-002
      */
     public function destroy(string $id): JSONResponse
     {
@@ -181,6 +193,8 @@ class TakenController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse
+      *
+      * @spec openspec/specs/zgw-client-interaction/spec.md#REQ-004
      */
     public function getAuditTrail(string $id): JSONResponse
     {

--- a/lib/Controller/UsersController.php
+++ b/lib/Controller/UsersController.php
@@ -39,6 +39,8 @@ class UsersController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse Info about the current user.
+      *
+      * @spec openspec/specs/app-configuration/spec.md#REQ-004
      */
     public function me(): JSONResponse
     {

--- a/lib/Controller/ZaakAuditTrailController.php
+++ b/lib/Controller/ZaakAuditTrailController.php
@@ -50,6 +50,8 @@ class ZaakAuditTrailController extends Controller
      * @NoCSRFRequired
      *
      * @return TemplateResponse
+      *
+      * @spec openspec/specs/zgw-zaak-management/spec.md#REQ-005
      */
     public function page(): TemplateResponse
     {
@@ -68,6 +70,8 @@ class ZaakAuditTrailController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse
+      *
+      * @spec openspec/specs/zgw-zaak-management/spec.md#REQ-005
      */
     public function index(): JSONResponse
     {
@@ -82,6 +86,8 @@ class ZaakAuditTrailController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse
+      *
+      * @spec openspec/specs/zgw-zaak-management/spec.md#REQ-005
      */
     public function show(string $id): JSONResponse
     {
@@ -96,6 +102,8 @@ class ZaakAuditTrailController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse
+      *
+      * @spec openspec/specs/zgw-zaak-management/spec.md#REQ-005
      */
     public function create(): JSONResponse
     {
@@ -110,6 +118,8 @@ class ZaakAuditTrailController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse
+      *
+      * @spec openspec/specs/zgw-zaak-management/spec.md#REQ-005
      */
     public function update(string $id): JSONResponse
     {
@@ -124,6 +134,8 @@ class ZaakAuditTrailController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse
+      *
+      * @spec openspec/specs/zgw-zaak-management/spec.md#REQ-005
      */
     public function destroy(string $id): JSONResponse
     {

--- a/lib/Controller/ZaakBesluitenController.php
+++ b/lib/Controller/ZaakBesluitenController.php
@@ -50,6 +50,8 @@ class ZaakBesluitenController extends Controller
      * @NoCSRFRequired
      *
      * @return TemplateResponse
+      *
+      * @spec openspec/specs/zgw-zaak-management/spec.md#REQ-005
      */
     public function page(): TemplateResponse
     {
@@ -68,6 +70,8 @@ class ZaakBesluitenController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse
+      *
+      * @spec openspec/specs/zgw-zaak-management/spec.md#REQ-005
      */
     public function index(): JSONResponse
     {
@@ -82,6 +86,8 @@ class ZaakBesluitenController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse
+      *
+      * @spec openspec/specs/zgw-zaak-management/spec.md#REQ-005
      */
     public function show(string $id): JSONResponse
     {
@@ -96,6 +102,8 @@ class ZaakBesluitenController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse
+      *
+      * @spec openspec/specs/zgw-zaak-management/spec.md#REQ-005
      */
     public function create(): JSONResponse
     {
@@ -110,6 +118,8 @@ class ZaakBesluitenController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse
+      *
+      * @spec openspec/specs/zgw-zaak-management/spec.md#REQ-005
      */
     public function update(string $id): JSONResponse
     {
@@ -124,6 +134,8 @@ class ZaakBesluitenController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse
+      *
+      * @spec openspec/specs/zgw-zaak-management/spec.md#REQ-005
      */
     public function destroy(string $id): JSONResponse
     {

--- a/lib/Controller/ZaakEigenschappenController.php
+++ b/lib/Controller/ZaakEigenschappenController.php
@@ -51,6 +51,8 @@ class ZaakEigenschappenController extends Controller
      * @NoCSRFRequired
      *
      * @return TemplateResponse
+      *
+      * @spec openspec/specs/zgw-zaak-management/spec.md#REQ-005
      */
     public function page(): TemplateResponse
     {
@@ -69,6 +71,8 @@ class ZaakEigenschappenController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse
+      *
+      * @spec openspec/specs/zgw-zaak-management/spec.md#REQ-005
      */
     public function index(CallService $callService, string $zaakId): JSONResponse
     {
@@ -83,6 +87,8 @@ class ZaakEigenschappenController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse
+      *
+      * @spec openspec/specs/zgw-zaak-management/spec.md#REQ-005
      */
     public function show(string $id, CallService $callService, string $zaakId): JSONResponse
     {
@@ -97,6 +103,8 @@ class ZaakEigenschappenController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse
+      *
+      * @spec openspec/specs/zgw-zaak-management/spec.md#REQ-005
      */
     public function create(CallService $callService, string $zaakId): JSONResponse
     {
@@ -113,6 +121,8 @@ class ZaakEigenschappenController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse
+      *
+      * @spec openspec/specs/zgw-zaak-management/spec.md#REQ-005
      */
     public function update(string $id, CallService $callService, string $zaakId): JSONResponse
     {
@@ -128,6 +138,8 @@ class ZaakEigenschappenController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse
+      *
+      * @spec openspec/specs/zgw-zaak-management/spec.md#REQ-005
      */
     public function destroy(string $id, CallService $callService, string $zaakId): JSONResponse
     {

--- a/lib/Controller/ZaakInformatieObjectenController.php
+++ b/lib/Controller/ZaakInformatieObjectenController.php
@@ -51,6 +51,8 @@ class ZaakInformatieObjectenController extends Controller
      * @NoCSRFRequired
      *
      * @return TemplateResponse
+      *
+      * @spec openspec/specs/zgw-zaak-management/spec.md#REQ-005
      */
     public function page(): TemplateResponse
     {
@@ -69,6 +71,8 @@ class ZaakInformatieObjectenController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse
+      *
+      * @spec openspec/specs/zgw-zaak-management/spec.md#REQ-005
      */
     public function index(CallService $callService): JSONResponse
     {
@@ -83,6 +87,8 @@ class ZaakInformatieObjectenController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse
+      *
+      * @spec openspec/specs/zgw-zaak-management/spec.md#REQ-005
      */
     public function show(string $id, CallService $callService): JSONResponse
     {
@@ -97,6 +103,8 @@ class ZaakInformatieObjectenController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse
+      *
+      * @spec openspec/specs/zgw-zaak-management/spec.md#REQ-005
      */
     public function create(CallService $callService): JSONResponse
     {
@@ -113,6 +121,8 @@ class ZaakInformatieObjectenController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse
+      *
+      * @spec openspec/specs/zgw-zaak-management/spec.md#REQ-005
      */
     public function update(string $id, CallService $callService): JSONResponse
     {
@@ -128,6 +138,8 @@ class ZaakInformatieObjectenController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse
+      *
+      * @spec openspec/specs/zgw-zaak-management/spec.md#REQ-005
      */
     public function destroy(string $id, CallService $callService): JSONResponse
     {

--- a/lib/Controller/ZaakObjectenController.php
+++ b/lib/Controller/ZaakObjectenController.php
@@ -51,6 +51,8 @@ class ZaakObjectenController extends Controller
      * @NoCSRFRequired
      *
      * @return TemplateResponse
+      *
+      * @spec openspec/specs/zgw-zaak-management/spec.md#REQ-005
      */
     public function page(): TemplateResponse
     {
@@ -69,6 +71,8 @@ class ZaakObjectenController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse
+      *
+      * @spec openspec/specs/zgw-zaak-management/spec.md#REQ-005
      */
     public function index(CallService $callService): JSONResponse
     {
@@ -83,6 +87,8 @@ class ZaakObjectenController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse
+      *
+      * @spec openspec/specs/zgw-zaak-management/spec.md#REQ-005
      */
     public function show(string $id, CallService $callService): JSONResponse
     {
@@ -97,6 +103,8 @@ class ZaakObjectenController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse
+      *
+      * @spec openspec/specs/zgw-zaak-management/spec.md#REQ-005
      */
     public function create(CallService $callService): JSONResponse
     {
@@ -113,6 +121,8 @@ class ZaakObjectenController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse
+      *
+      * @spec openspec/specs/zgw-zaak-management/spec.md#REQ-005
      */
     public function update(string $id, CallService $callService): JSONResponse
     {
@@ -128,6 +138,8 @@ class ZaakObjectenController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse
+      *
+      * @spec openspec/specs/zgw-zaak-management/spec.md#REQ-005
      */
     public function destroy(string $id, CallService $callService): JSONResponse
     {

--- a/lib/Controller/ZaakTypenController.php
+++ b/lib/Controller/ZaakTypenController.php
@@ -26,6 +26,8 @@ class ZaakTypenController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse
+      *
+      * @spec openspec/specs/zgw-related-resources/spec.md#REQ-001
      */
     public function index(): JSONResponse
     {
@@ -47,6 +49,8 @@ class ZaakTypenController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+      *
+      * @spec openspec/specs/zgw-related-resources/spec.md#REQ-003
      */
     public function page(?string $getParameter): TemplateResponse
     {
@@ -82,6 +86,8 @@ class ZaakTypenController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse
+      *
+      * @spec openspec/specs/zgw-related-resources/spec.md#REQ-001
      */
     public function show(string $id): JSONResponse
     {
@@ -99,6 +105,8 @@ class ZaakTypenController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse
+      *
+      * @spec openspec/specs/zgw-related-resources/spec.md#REQ-002
      */
     public function create(): JSONResponse
     {
@@ -122,6 +130,8 @@ class ZaakTypenController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse
+      *
+      * @spec openspec/specs/zgw-related-resources/spec.md#REQ-002
      */
     public function update(string $id): JSONResponse
     {
@@ -147,6 +157,8 @@ class ZaakTypenController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse
+      *
+      * @spec openspec/specs/zgw-related-resources/spec.md#REQ-002
      */
     public function destroy(string $id): JSONResponse
     {

--- a/lib/Controller/ZakenController.php
+++ b/lib/Controller/ZakenController.php
@@ -25,6 +25,8 @@ class ZakenController extends Controller
     /**
      * Return (and serach) all objects
      *
+     * @spec openspec/specs/zgw-zaak-management/spec.md#REQ-001
+     *
      * @NoAdminRequired
      * @NoCSRFRequired
      *
@@ -50,6 +52,8 @@ class ZakenController extends Controller
      *
      * @NoAdminRequired
      * @NoCSRFRequired
+      *
+      * @spec openspec/specs/zgw-zaak-management/spec.md#REQ-005
      */
     public function page(?string $getParameter): TemplateResponse
     {
@@ -85,6 +89,8 @@ class ZakenController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse
+      *
+      * @spec openspec/specs/zgw-zaak-management/spec.md#REQ-002
      */
     public function show(string $id): JSONResponse
     {
@@ -102,6 +108,8 @@ class ZakenController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse
+      *
+      * @spec openspec/specs/zgw-zaak-management/spec.md#REQ-003
      */
     public function create(): JSONResponse
     {
@@ -125,6 +133,8 @@ class ZakenController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse
+      *
+      * @spec openspec/specs/zgw-zaak-management/spec.md#REQ-003
      */
     public function update(string $id): JSONResponse
     {
@@ -145,6 +155,8 @@ class ZakenController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse
+      *
+      * @spec openspec/specs/zgw-zaak-management/spec.md#REQ-003
      */
     public function destroy(string $id): JSONResponse
     {
@@ -162,6 +174,8 @@ class ZakenController extends Controller
          * @NoCSRFRequired
          *
          * @return JSONResponse
+          *
+          * @spec openspec/specs/zgw-zaak-management/spec.md#REQ-004
          */
     public function getAuditTrail(string $id): JSONResponse
     {

--- a/lib/Service/CallService.php
+++ b/lib/Service/CallService.php
@@ -37,6 +37,8 @@ class CallService
      * Gets the guzzle config as an array
      *
      * @return array
+      *
+      * @spec openspec/specs/zgw-object-data-access/spec.md#REQ-005
      */
     public function getConfig(?string $source=null, array $query=[]): array
     {
@@ -73,6 +75,8 @@ class CallService
      * @return array The objects found for given filters.
      *
      * @throws \GuzzleHttp\Exception\GuzzleException
+      *
+      * @spec openspec/specs/zgw-object-data-access/spec.md#REQ-005
      */
     public function index(string $source, string $endpoint, array $query=[]): array | null
     {
@@ -99,6 +103,8 @@ class CallService
      * @return array The objects found for given filters.
      *
      * @throws \GuzzleHttp\Exception\GuzzleException
+      *
+      * @spec openspec/specs/zgw-object-data-access/spec.md#REQ-005
      */
     public function show(string $source, string $endpoint, string $id, array $query=[]): array | null
     {
@@ -125,6 +131,8 @@ class CallService
      * @return array The objects found for given filters.
      *
      * @throws \GuzzleHttp\Exception\GuzzleException
+      *
+      * @spec openspec/specs/zgw-object-data-access/spec.md#REQ-005
      */
     public function create(string $source, string $endpoint, array $data): array | null
     {
@@ -147,6 +155,8 @@ class CallService
      * @return array The objects found for given filters.
      *
      * @throws \GuzzleHttp\Exception\GuzzleException
+      *
+      * @spec openspec/specs/zgw-object-data-access/spec.md#REQ-005
      */
     public function update(string $source, string $endpoint, array $data, string $id): array | null
     {
@@ -168,6 +178,8 @@ class CallService
      * @return array The objects found for given filters.
      *
      * @throws \GuzzleHttp\Exception\GuzzleException
+      *
+      * @spec openspec/specs/zgw-object-data-access/spec.md#REQ-005
      */
     public function destroy(string $source, string $endpoint, string $id): array | null
     {

--- a/lib/Service/IObjectService.php
+++ b/lib/Service/IObjectService.php
@@ -60,6 +60,8 @@ interface IObjectService
      * @param boolean $updateVersion Whether to bump version
      *
      * @return mixed The saved object
+      *
+      * @spec openspec/specs/zgw-object-data-access/spec.md#REQ-003
      */
     public function saveObject(string $objectType, array $object, bool $updateVersion=true): mixed;
 
@@ -70,6 +72,8 @@ interface IObjectService
      * @param string|integer $id         The id
      *
      * @return boolean Success
+      *
+      * @spec openspec/specs/zgw-object-data-access/spec.md#REQ-003
      */
     public function deleteObject(string $objectType, string|int $id): bool;
 }//end interface

--- a/lib/Service/MailService.php
+++ b/lib/Service/MailService.php
@@ -29,6 +29,8 @@ class MailService
      *
      * @return array The current version of the object.
      * @throws \Exception
+      *
+      * @spec openspec/specs/zgw-object-data-access/spec.md#REQ-005
      */
     public function sendMail(array $oldObject, array $newObject): array
     {

--- a/lib/Service/ObjectMapperService.php
+++ b/lib/Service/ObjectMapperService.php
@@ -44,6 +44,8 @@ class ObjectMapperService
      *
      * @return mixed The appropriate mapper
      * @throws InvalidArgumentException|Exception
+      *
+      * @spec openspec/specs/zgw-object-data-access/spec.md#REQ-001
      */
     public function getMapper(string $objectType): mixed
     {
@@ -91,6 +93,8 @@ class ObjectMapperService
      * Attempts to retrieve the OpenRegister service.
      *
      * @return \OCA\OpenRegister\Service\ObjectService|null The service or null
+      *
+      * @spec openspec/specs/zgw-object-data-access/spec.md#REQ-001
      */
     public function getOpenRegisters(): ?\OCA\OpenRegister\Service\ObjectService
     {

--- a/lib/Service/ObjectQueryService.php
+++ b/lib/Service/ObjectQueryService.php
@@ -25,6 +25,8 @@ class ObjectQueryService
 
     /**
      * Gets an object by type and id.
+      *
+      * @spec openspec/specs/zgw-object-data-access/spec.md#REQ-002
      */
     public function getObject(string $objectType, string $id, array $extend=[]): mixed
     {
@@ -37,6 +39,8 @@ class ObjectQueryService
 
     /**
      * Gets objects with filters, sorting, and extensions.
+      *
+      * @spec openspec/specs/zgw-object-data-access/spec.md#REQ-002
      */
     public function getObjects(
         string $objectType,
@@ -58,6 +62,8 @@ class ObjectQueryService
 
     /**
      * Gets facets for a specific object type.
+      *
+      * @spec openspec/specs/zgw-object-data-access/spec.md#REQ-002
      */
     public function getFacets(string $objectType, array $filters=[]): array
     {
@@ -75,6 +81,8 @@ class ObjectQueryService
 
     /**
      * Creates or updates an object.
+      *
+      * @spec openspec/specs/zgw-object-data-access/spec.md#REQ-003
      */
     public function saveObject(string $objectType, array $object, bool $updateVersion=true): mixed
     {
@@ -84,6 +92,8 @@ class ObjectQueryService
 
     /**
      * Deletes an object.
+      *
+      * @spec openspec/specs/zgw-object-data-access/spec.md#REQ-003
      */
     public function deleteObject(string $objectType, string|int $id): bool
     {
@@ -98,6 +108,8 @@ class ObjectQueryService
 
     /**
      * Get count of objects.
+      *
+      * @spec openspec/specs/zgw-object-data-access/spec.md#REQ-002
      */
     public function getCount(string $objectType, array $filters=[]): int
     {
@@ -107,6 +119,8 @@ class ObjectQueryService
 
     /**
      * Get a result array for a request.
+      *
+      * @spec openspec/specs/zgw-object-data-access/spec.md#REQ-004
      */
     public function getResultArrayForRequest(string $objectType, array $requestParams): array
     {
@@ -121,6 +135,8 @@ class ObjectQueryService
 
     /**
      * Gets multiple objects by ids.
+      *
+      * @spec openspec/specs/zgw-object-data-access/spec.md#REQ-002
      */
     public function getMultipleObjects(string $objectType, array $ids): array
     {
@@ -139,6 +155,8 @@ class ObjectQueryService
 
     /**
      * Call a mapper method by name for an object type and id.
+      *
+      * @spec openspec/specs/zgw-object-data-access/spec.md#REQ-002
      */
     public function callMapperMethod(string $objectType, string $method, string $id): array
     {

--- a/lib/Service/ObjectService.php
+++ b/lib/Service/ObjectService.php
@@ -73,6 +73,8 @@ class ObjectService implements IObjectService
      * @param array|null   $extend     Extensions
      *
      * @return array The retrieved objects as arrays
+      *
+      * @spec openspec/specs/zgw-object-data-access/spec.md#REQ-002
      */
     public function getObjects(
         string $objectType,
@@ -104,6 +106,8 @@ class ObjectService implements IObjectService
 
     /**
      * Creates or updates an object.
+      *
+      * @spec openspec/specs/zgw-object-data-access/spec.md#REQ-003
      */
     public function saveObject(string $objectType, array $object, bool $updateVersion=true): mixed
     {
@@ -112,6 +116,8 @@ class ObjectService implements IObjectService
 
     /**
      * Deletes an object.
+      *
+      * @spec openspec/specs/zgw-object-data-access/spec.md#REQ-003
      */
     public function deleteObject(string $objectType, string|int $id): bool
     {

--- a/lib/Service/RequestParamsParser.php
+++ b/lib/Service/RequestParamsParser.php
@@ -35,6 +35,8 @@ class RequestParamsParser
      * @param array $requestParams The raw request parameters
      *
      * @return array Parsed parameters with keys: limit, offset, order, extend, search, filters
+      *
+      * @spec openspec/specs/zgw-object-data-access/spec.md#REQ-004
      */
     public function parse(array $requestParams): array
     {

--- a/lib/Service/ZGWArchiveDateService.php
+++ b/lib/Service/ZGWArchiveDateService.php
@@ -40,6 +40,8 @@ class ZGWArchiveDateService
      * @param string      $besluitSchema      The besluit schema slug
      *
      * @return string|null The calculated archive action date, or null
+      *
+      * @spec openspec/specs/zgw-case-lifecycle/spec.md#REQ-004
      */
     public function calculateArchiveDate(
         ?string $afleidingswijze,

--- a/lib/Service/ZGWLogicService.php
+++ b/lib/Service/ZGWLogicService.php
@@ -35,6 +35,8 @@ class ZGWLogicService
 
     /**
      * Create an OIO for a zaakinformatieobject. ZRC-005.
+      *
+      * @spec openspec/specs/zgw-case-lifecycle/spec.md#REQ-001
      */
     public function createObjectInformatieObjectZaak(ObjectEntity $zio): void
     {
@@ -44,6 +46,8 @@ class ZGWLogicService
 
     /**
      * Create an OIO for a besluitinformatieobject. BRC-005.
+      *
+      * @spec openspec/specs/zgw-case-lifecycle/spec.md#REQ-001
      */
     public function createObjectInformatieObjectBesluit(ObjectEntity $bio): void
     {
@@ -53,6 +57,8 @@ class ZGWLogicService
 
     /**
      * Delete OIO when a ZIO or BIO is deleted. ZRC-023 / BRC-009.
+      *
+      * @spec openspec/specs/zgw-case-lifecycle/spec.md#REQ-001
      */
     public function deleteObjectInformatieObject(ObjectEntity $object, Schema $schema): void
     {
@@ -69,6 +75,8 @@ class ZGWLogicService
 
     /**
      * Create a zaakbesluit when a besluit is created.
+      *
+      * @spec openspec/specs/zgw-case-lifecycle/spec.md#REQ-001
      */
     public function createZaakBesluit(ObjectEntity $besluit): void
     {
@@ -99,6 +107,8 @@ class ZGWLogicService
 
     /**
      * Cascade delete BesluitInformatieObjecten when a besluit is deleted.
+      *
+      * @spec openspec/specs/zgw-case-lifecycle/spec.md#REQ-001
      */
     public function deleteBesluit(ObjectEntity $besluit): void
     {
@@ -144,6 +154,9 @@ class ZGWLogicService
     {
         return $this->getObjectByEndpointUrl($internalReference);
     }//end rewriteInternalReference()
+    /**
+     * @spec openspec/specs/zgw-case-lifecycle/spec.md#REQ-001
+     */
 
     public function createZaakTypeInformatieObjecttype(ObjectEntity $ztIot):  void
     {
@@ -186,6 +199,9 @@ class ZGWLogicService
         $this->objectService->clearCurrents();
 
     }//end createZaakTypeInformatieObjecttype()
+    /**
+     * @spec openspec/specs/zgw-case-lifecycle/spec.md#REQ-001
+     */
 
     public function deleteZaakTypeInformatieObjecttype(ObjectEntity $ztIot):  void
     {

--- a/lib/Service/ZGWRegistryService.php
+++ b/lib/Service/ZGWRegistryService.php
@@ -119,6 +119,8 @@ class ZGWRegistryService
      * @param string $url The endpoint URL
      *
      * @return string The extracted object ID
+      *
+      * @spec openspec/specs/zgw-case-lifecycle/spec.md#REQ-001
      */
     public function getObjectIdByEndpointUrl(string $url): string
     {

--- a/lib/Service/ZGWValidationService.php
+++ b/lib/Service/ZGWValidationService.php
@@ -27,6 +27,8 @@ class ZGWValidationService
 
     /**
      * ZRC-010: Validate relevanteAndereZaken references.
+      *
+      * @spec openspec/specs/zgw-case-lifecycle/spec.md#REQ-005
      */
     public function checkRelevanteAndereZaken(ObjectEntity $zaak): void
     {
@@ -62,6 +64,8 @@ class ZGWValidationService
 
     /**
      * Validate a BesluitInformatieObject's type against besluittype.
+      *
+      * @spec openspec/specs/zgw-case-lifecycle/spec.md#REQ-005
      */
     public function validateBesluitInformatieObject(ObjectEntity $bio): void
     {

--- a/lib/Service/ZGWZaakCloseService.php
+++ b/lib/Service/ZGWZaakCloseService.php
@@ -24,6 +24,8 @@ class ZGWZaakCloseService
 
     /**
      * Close a zaak when eindstatus is set.
+      *
+      * @spec openspec/specs/zgw-case-lifecycle/spec.md#REQ-002
      */
     public function closeZaak(ObjectEntity $status): void
     {
@@ -55,6 +57,8 @@ class ZGWZaakCloseService
 
     /**
      * Check if status is eindstatus for its zaaktype.
+      *
+      * @spec openspec/specs/zgw-case-lifecycle/spec.md#REQ-002
      */
     public function isEindStatus(array $sa): bool
     {

--- a/lib/Service/ZGWZaakLifecycleService.php
+++ b/lib/Service/ZGWZaakLifecycleService.php
@@ -23,6 +23,8 @@ class ZGWZaakLifecycleService
 
     /**
      * Close a zaak. Delegates to ZGWZaakCloseService.
+      *
+      * @spec openspec/specs/zgw-case-lifecycle/spec.md#REQ-002
      */
     public function closeZaak(ObjectEntity $status): void
     {
@@ -31,6 +33,8 @@ class ZGWZaakLifecycleService
 
     /**
      * Reopen a zaak when non-eindstatus is set. ZRC-008.
+      *
+      * @spec openspec/specs/zgw-case-lifecycle/spec.md#REQ-002
      */
     public function reopenZaak(ObjectEntity $status): void
     {
@@ -48,6 +52,8 @@ class ZGWZaakLifecycleService
 
     /**
      * Delete dependent objects. ZRC-023.
+      *
+      * @spec openspec/specs/zgw-case-lifecycle/spec.md#REQ-003
      */
     public function deleteZaak(ObjectEntity $zaak): void
     {
@@ -64,6 +70,8 @@ class ZGWZaakLifecycleService
 
     /**
      * ZRC-009: Set derived vertrouwelijkheidaanduiding.
+      *
+      * @spec openspec/specs/zgw-case-lifecycle/spec.md#REQ-003
      */
     public function setVertrouwelijkheidaanduiding(ObjectEntity $zaak): void
     {

--- a/lib/Service/ZGWZaakValidationService.php
+++ b/lib/Service/ZGWZaakValidationService.php
@@ -20,6 +20,8 @@ class ZGWZaakValidationService
 
     /**
      * ZRC-015: Check productenOfDiensten against zaaktype.
+      *
+      * @spec openspec/specs/zgw-case-lifecycle/spec.md#REQ-005
      */
     public function checkProductenOfDiensten(ObjectEntity $zaak): void
     {
@@ -45,6 +47,8 @@ class ZGWZaakValidationService
 
     /**
      * ZRC-022: Check archive prerequisites.
+      *
+      * @spec openspec/specs/zgw-case-lifecycle/spec.md#REQ-005
      */
     public function checkArchivePrerequisites(ObjectEntity $zaak): void
     {
@@ -67,6 +71,8 @@ class ZGWZaakValidationService
 
     /**
      * ZRC-012: Check verlenging and opschorting parameters.
+      *
+      * @spec openspec/specs/zgw-case-lifecycle/spec.md#REQ-005
      */
     public function checkGegevensgroepen(ObjectEntity $zaak): void
     {

--- a/openspec/specs/app-configuration/spec.md
+++ b/openspec/specs/app-configuration/spec.md
@@ -1,0 +1,63 @@
+---
+retrofit: true
+---
+
+# App Configuration
+
+Administrative configuration, settings, dashboard and current-user surfaces of the
+case-handling app. Covers reading and persisting the ZGW source connection config
+(DRC/ORC/ZRC/ZTC/BRC + klanten/elastic/mongodb + organisation identifiers),
+per-object-type register/schema/source settings, the dashboard KPI endpoints, and
+the current-user profile lookup. Reverse-specified from observed controller
+behavior.
+
+## Requirements
+
+### REQ-001: Read and persist ZGW connection configuration
+
+The system SHALL return the stored configuration values for every known
+configuration key (filling defaults for unset keys) and SHALL persist posted
+configuration values back to app config, echoing the stored result.
+
+#### Scenario: Reading configuration
+
+- **WHEN** an admin reads the configuration
+- **THEN** the system returns each known key with its stored or default value
+
+#### Scenario: Saving configuration
+
+- **WHEN** an admin posts configuration values
+- **THEN** the system stores each value and returns the persisted set
+
+### REQ-002: Read and persist object-type settings and available registers
+
+The system SHALL return the available object types, whether OpenRegister is
+present, the available registers, and the per-object-type source/schema/register
+settings (with defaults), and SHALL persist posted settings — returning an error
+response with HTTP 500 on failure.
+
+#### Scenario: Reading settings with OpenRegister present
+
+- **WHEN** an admin reads settings and OpenRegister is installed
+- **THEN** the system returns the available registers and object-type settings
+
+### REQ-003: Serve dashboard data
+
+The system SHALL provide the dashboard endpoints (page render plus list/read/
+create/update/delete of dashboard objects) returning JSON.
+
+#### Scenario: Loading the dashboard
+
+- **WHEN** a client requests the dashboard index
+- **THEN** the system returns the dashboard result set as JSON
+
+### REQ-004: Return the current user profile
+
+The system SHALL return the authenticated user's profile (identity, email,
+quota, capabilities and related medewerker reference), returning an error
+response with HTTP 500 on failure.
+
+#### Scenario: Fetching the current user
+
+- **WHEN** an authenticated client requests its own profile
+- **THEN** the system returns the user details as JSON

--- a/openspec/specs/domain-entities/spec.md
+++ b/openspec/specs/domain-entities/spec.md
@@ -1,0 +1,24 @@
+---
+retrofit: true
+---
+
+# Domain Entities
+
+The TypeScript entity classes that model each ZGW resource on the client (bericht,
+besluit, contactmoment, document, klanten, medewerkers, resultaat, rol, taak,
+zaak, zaakTypen). Each entity normalises a raw API record into a typed object on
+construction. Reverse-specified from observed entity behavior.
+
+## Requirements
+
+### REQ-001: Construct a typed entity from a raw record
+
+The system SHALL, on construction, map a raw API record onto the entity's typed
+fields, applying defaults for missing fields so downstream code can rely on a
+consistent shape.
+
+#### Scenario: Wrapping a raw zaak
+
+- **WHEN** a raw zaak record is passed to the Zaak entity constructor
+- **THEN** the entity exposes the record's fields as typed properties with
+  defaults applied

--- a/openspec/specs/state-stores/spec.md
+++ b/openspec/specs/state-stores/spec.md
@@ -1,0 +1,66 @@
+---
+retrofit: true
+---
+
+# State — Pinia Stores
+
+The Pinia stores that own the client-side state for every ZGW resource (zaken,
+besluiten, contactmoment, documenten, resultaten, rol, zaakTypen, berichten,
+klanten, medewerkers, taak) plus navigation and search state. Each store holds the
+active item and list, exposes setters, and performs the fetch/save/delete API
+calls against the app's REST endpoints. Reverse-specified from observed store
+behavior.
+
+## Requirements
+
+### REQ-001: Hold and set the active item and list
+
+The system SHALL hold the active resource item, the collection list and any
+auxiliary state (e.g. audit trail), and expose setters that wrap raw data into
+the resource entity.
+
+#### Scenario: Setting the active item
+
+- **WHEN** a setter is called with raw resource data
+- **THEN** the store wraps it in the entity and stores it as the active item
+
+### REQ-002: Refresh a resource collection
+
+The system SHALL fetch a resource collection from its REST endpoint (optionally
+with a search query), wrap each record in its entity, and update the list state.
+
+#### Scenario: Refreshing a list
+
+- **WHEN** the refresh action runs
+- **THEN** the store fetches the collection and updates the list
+
+### REQ-003: Fetch a single resource and its related data
+
+The system SHALL fetch a single resource by id (and, where applicable, its related
+records such as audit trail or linked resources) and update the active item state.
+
+#### Scenario: Fetching one resource
+
+- **WHEN** the get action runs with an id
+- **THEN** the store fetches and sets the active item
+
+### REQ-004: Create, update and delete a resource
+
+The system SHALL create, update and delete a resource through its REST endpoint
+and refresh the relevant state afterward, returning the response/entities to the
+caller.
+
+#### Scenario: Saving a resource
+
+- **WHEN** the save action runs
+- **THEN** the store posts/puts the resource and refreshes the list
+
+### REQ-005: Initialise the store registry and navigation/search state
+
+The system SHALL initialise the application's store registry, and manage
+navigation (active view/modal/dialog) and search state through dedicated stores.
+
+#### Scenario: Initialising stores
+
+- **WHEN** the app boots
+- **THEN** the store registry is initialised and made available

--- a/openspec/specs/ui-case-views/spec.md
+++ b/openspec/specs/ui-case-views/spec.md
@@ -1,0 +1,64 @@
+---
+retrofit: true
+---
+
+# UI — Case Views
+
+The list and detail views for the case-side ZGW resources: zaken, zaaktypen,
+zaakeigenschappen, statussen, besluiten, resultaten and documenten. These views
+fetch their data from the corresponding stores, present master/detail layouts,
+react to selection, and trigger the create/edit/delete modals. Reverse-specified
+from observed component behavior.
+
+## Requirements
+
+### REQ-001: Fetch and present a resource collection
+
+The system SHALL fetch the resource collection on mount/refresh and present it as
+a selectable list, exposing the current loading/empty state.
+
+#### Scenario: Loading the zaken list
+
+- **WHEN** the zaken view is opened
+- **THEN** it fetches the zaken collection and renders the list
+
+### REQ-002: Select and expand a resource for detail
+
+The system SHALL set the active resource item when the user selects a row and
+expose its detail, including expanding/collapsing nested rows where the view
+supports it.
+
+#### Scenario: Selecting a zaak
+
+- **WHEN** the user clicks a zaak in the list
+- **THEN** the view sets it as the active item and shows its detail
+
+### REQ-003: Filter and clear the resource list
+
+The system SHALL filter the presented collection by the user's search text and
+clear the filter on request.
+
+#### Scenario: Searching the list
+
+- **WHEN** the user types search text
+- **THEN** the view filters the collection accordingly
+
+### REQ-004: Trigger create, edit and delete from a view
+
+The system SHALL open the appropriate modal (create/edit/delete/view) for the
+selected resource in response to the user's action.
+
+#### Scenario: Editing a resource
+
+- **WHEN** the user chooses edit on a row
+- **THEN** the view sets the active item and opens the edit modal
+
+### REQ-005: Derive presentational helpers
+
+The system SHALL compute presentational values used by the view — icons, status
+labels, formatted identifiers and derived ids — from the resource data.
+
+#### Scenario: Rendering a resource icon
+
+- **WHEN** the view renders a resource row
+- **THEN** it derives the icon/label from the resource's type or status

--- a/openspec/specs/ui-client-views/spec.md
+++ b/openspec/specs/ui-client-views/spec.md
@@ -1,0 +1,65 @@
+---
+retrofit: true
+---
+
+# UI — Client Interaction Views
+
+The list and detail views for the people-and-communication ZGW resources:
+klanten, contactmomenten, berichten, medewerkers, rollen and taken. These views
+fetch their data from the corresponding stores, present master/detail layouts,
+show related records (e.g. a klant's zaken/taken/berichten), and trigger
+create/edit/delete modals. Reverse-specified from observed component behavior.
+
+## Requirements
+
+### REQ-001: Fetch and present a client-interaction collection
+
+The system SHALL fetch the resource collection on mount/refresh and present it as
+a selectable list with its loading/empty state.
+
+#### Scenario: Loading the klanten list
+
+- **WHEN** the klanten view is opened
+- **THEN** it fetches the klanten collection and renders the list
+
+### REQ-002: Select a resource and show related records
+
+The system SHALL set the active item on selection and load/present its related
+records (such as a klant's zaken, taken, berichten and contactmomenten, or a
+taak's linked zaak).
+
+#### Scenario: Selecting a klant
+
+- **WHEN** the user selects a klant
+- **THEN** the view sets it active and loads its related records
+
+### REQ-003: Filter and clear the list
+
+The system SHALL filter the presented collection by search text and clear the
+filter on request.
+
+#### Scenario: Searching contactmomenten
+
+- **WHEN** the user types search text
+- **THEN** the view filters the contactmomenten list
+
+### REQ-004: Trigger create, edit and delete
+
+The system SHALL open the appropriate modal for the selected resource in response
+to the user's action, and react to status changes (e.g. closing or handling a
+taak).
+
+#### Scenario: Closing a taak
+
+- **WHEN** the user marks a taak closed
+- **THEN** the view updates the taak status and refreshes
+
+### REQ-005: Derive presentational helpers
+
+The system SHALL compute icons, status labels, role labels and formatted values
+for display from the resource data.
+
+#### Scenario: Rendering a contact icon
+
+- **WHEN** the view renders a contactmoment
+- **THEN** it derives the channel icon (phone/email/agent/mailbox) from the data

--- a/openspec/specs/ui-dashboard-widgets/spec.md
+++ b/openspec/specs/ui-dashboard-widgets/spec.md
@@ -1,0 +1,66 @@
+---
+retrofit: true
+---
+
+# UI — Dashboard Widgets
+
+The Nextcloud dashboard widgets that surface case-handling data on the home
+dashboard: open zaken, taken, contactmomenten, personen, organisaties and a
+general zaken widget. Each widget fetches a scoped set of items, presents them
+compactly, derives per-item icons and menus, and links into the full views.
+Reverse-specified from observed component behavior.
+
+## Requirements
+
+### REQ-001: Fetch the widget's items
+
+The system SHALL fetch the scoped item set for the widget (e.g. open zaken, the
+current user's taken, recent contactmomenten, personen, organisaties) and expose
+them as the widget's items, optionally resolving the current user first.
+
+#### Scenario: Loading the open-zaken widget
+
+- **WHEN** the open zaken widget mounts
+- **THEN** it fetches the open zaken and presents them as items
+
+### REQ-002: Search and filter widget items
+
+The system SHALL filter the widget's items by the user's search input.
+
+#### Scenario: Searching within a widget
+
+- **WHEN** the user types in the widget search
+- **THEN** the widget filters its items
+
+### REQ-003: Derive per-item presentation
+
+The system SHALL derive each item's icon, label and context menu from the item
+data, including channel-specific icons for contactmomenten (phone/email/agent/
+mailbox).
+
+#### Scenario: Rendering a contactmoment item
+
+- **WHEN** the contactmomenten widget renders an item
+- **THEN** it derives the channel icon from the contactmoment
+
+### REQ-004: Open and act on a widget item
+
+The system SHALL open a modal or navigate to the resource when the user activates
+an item, and support per-item actions (edit, show, close, mark handled), opening
+and closing the relevant modal.
+
+#### Scenario: Showing a widget item
+
+- **WHEN** the user activates a widget item
+- **THEN** the widget opens the item detail or navigates to it
+
+### REQ-005: Manage widget modals and related lookups
+
+The system SHALL open/close the widget's own modals and fetch related lookups
+(e.g. a person's zaken/taken/contactmomenten, or klant search results) when
+required.
+
+#### Scenario: Opening klant search from the personen widget
+
+- **WHEN** the user opens klant search in the personen widget
+- **THEN** the widget shows the klant search modal and fetches results

--- a/openspec/specs/ui-modals/spec.md
+++ b/openspec/specs/ui-modals/spec.md
@@ -1,0 +1,70 @@
+---
+retrofit: true
+---
+
+# UI — Modals & Dialogs
+
+The create/edit/view/delete modals for every ZGW resource (zaken, klanten,
+contactmomenten, berichten, medewerkers, taken, besluiten, documenten, rollen,
+resultaten, zaaktypen). Each modal collects or displays a resource's data,
+validates and submits it through the store, surfaces success/error state, and
+closes itself. Reverse-specified from observed component behavior.
+
+## Requirements
+
+### REQ-001: Open and close a resource modal
+
+The system SHALL open a modal seeded with the relevant resource (empty for create,
+populated for edit/view) and close it on cancel or after a successful action,
+resetting transient state.
+
+#### Scenario: Opening an edit modal
+
+- **WHEN** the user triggers edit
+- **THEN** the modal opens populated with the selected resource
+
+### REQ-002: Capture and bind form input
+
+The system SHALL bind the resource's fields to form inputs, including nested and
+list fields, and keep the working copy in sync with user edits.
+
+#### Scenario: Editing a field
+
+- **WHEN** the user changes a field in the modal
+- **THEN** the working copy reflects the change
+
+### REQ-003: Submit create / update / delete through the store
+
+The system SHALL submit the resource via the corresponding store action,
+present the in-flight loading state, and on success update the list and close.
+
+#### Scenario: Saving a resource
+
+- **WHEN** the user confirms a create/edit modal
+- **THEN** the modal calls the store save action and closes on success
+
+#### Scenario: Deleting a resource
+
+- **WHEN** the user confirms a delete modal
+- **THEN** the modal calls the store delete action and closes on success
+
+### REQ-004: Surface success and error feedback
+
+The system SHALL show success or error feedback from the store action and keep the
+modal open with an error state on failure.
+
+#### Scenario: A failed save
+
+- **WHEN** the store save action fails
+- **THEN** the modal shows the error and stays open
+
+### REQ-005: Support resource-specific lookups and helpers
+
+The system SHALL support resource-specific behaviors within modals — looking up
+related entities, fetching option lists, deriving labels/icons, and formatting
+values for display or submission.
+
+#### Scenario: Loading options in a modal
+
+- **WHEN** a modal needs a related option list
+- **THEN** it fetches and presents the options

--- a/openspec/specs/ui-search-navigation/spec.md
+++ b/openspec/specs/ui-search-navigation/spec.md
@@ -1,0 +1,66 @@
+---
+retrofit: true
+---
+
+# UI — Search, Navigation & Utilities
+
+Cross-cutting frontend surfaces: the search sidebar (searching klanten,
+personen and organisaties with debounced input), the configuration navigation
+panel, the app permissions surface, and shared presentational utilities (theme
+resolution, ISO date normalisation, and the MDI icon path providers used across
+the app). Reverse-specified from observed component behavior.
+
+## Requirements
+
+### REQ-001: Search across klanten, personen and organisaties
+
+The system SHALL search klanten, personen and organisaties from the sidebar,
+debouncing user input, exposing the active result tab, and deriving display
+name/subname for each result.
+
+#### Scenario: Searching from the sidebar
+
+- **WHEN** the user types a query in the search sidebar
+- **THEN** the system debounces the input, runs the searches, and presents the
+  results under the active tab
+
+### REQ-002: Load and save app configuration from the nav panel
+
+The system SHALL fetch the current configuration into the navigation panel and
+persist edited configuration back through the configuration endpoint.
+
+#### Scenario: Saving configuration from the nav panel
+
+- **WHEN** the user saves configuration in the nav panel
+- **THEN** the system posts the configuration and reflects the result
+
+### REQ-003: Expose the app permission surface
+
+The system SHALL compute the permission flags the app uses to gate UI actions.
+
+#### Scenario: Resolving permissions
+
+- **WHEN** the app initialises
+- **THEN** it exposes the current permission flags to its child views
+
+### REQ-004: Resolve theme and normalise dates
+
+The system SHALL resolve the active Nextcloud theme for presentational use, and
+normalise arbitrary date input into a valid ISO string (returning a safe value
+for invalid input).
+
+#### Scenario: Normalising a date
+
+- **WHEN** a component needs an ISO date from raw input
+- **THEN** the utility returns a valid ISO string or a safe fallback
+
+### REQ-005: Provide MDI icon path data
+
+The system SHALL expose the SVG path data for the app's MDI glyphs
+(briefcase-account, calendar-check, calendar-month, card-account-phone, pencil,
+progress-close) for use by icon components.
+
+#### Scenario: Rendering an icon
+
+- **WHEN** a component renders an MDI icon
+- **THEN** the icon provider returns the glyph's SVG path data

--- a/openspec/specs/zgw-case-lifecycle/spec.md
+++ b/openspec/specs/zgw-case-lifecycle/spec.md
@@ -1,0 +1,82 @@
+---
+retrofit: true
+---
+
+# ZGW Case Lifecycle
+
+Business logic that enforces the ZGW lifecycle and integrity rules as objects are
+created, related, transitioned and archived. Covers the cascade relations between
+zaken, besluiten and informatieobjecten; status-driven case open/close/reopen
+transitions; archive-date calculation; and the validation rules that gate
+archiving and decision linking. Reverse-specified from observed service behavior.
+
+## Requirements
+
+### REQ-001: Maintain ZGW cascade relations between objects
+
+The system SHALL, when ZGW objects are created or deleted, maintain the derived
+relations the standard requires: linking objectinformatieobjecten to their zaak or
+besluit, creating and deleting zaakbesluiten for a besluit, and creating/deleting
+zaaktype-informatieobjecttype links — including cleaning up the related objects
+when a parent is deleted.
+
+#### Scenario: Creating a besluit links it to its zaak
+
+- **WHEN** a besluit object is created
+- **THEN** the system creates the corresponding zaakbesluit relation
+
+#### Scenario: Deleting a besluit cleans up relations
+
+- **WHEN** a besluit is deleted
+- **THEN** the system removes the dependent objectinformatieobject / zaakbesluit
+  relations
+
+### REQ-002: Transition a case open, closed or reopened on status change
+
+The system SHALL, when a zaak status changes, close the zaak when the status is an
+eind-status (setting the close-relevant fields), reopen it when moving away from an
+eind-status, and recognise whether a given status array represents an end status.
+
+#### Scenario: Closing a case on end status
+
+- **WHEN** a status that is an eind-status is set on a zaak
+- **THEN** the system marks the zaak closed and records the closing data
+
+#### Scenario: Reopening a case
+
+- **WHEN** a zaak that was closed receives a non-eind status
+- **THEN** the system reopens the zaak
+
+### REQ-003: Apply confidentiality and deletion lifecycle actions
+
+The system SHALL apply a zaak's vertrouwelijkheidaanduiding (confidentiality
+level) across its related objects, and delete a zaak together with its dependent
+records.
+
+#### Scenario: Cascading confidentiality
+
+- **WHEN** a zaak's confidentiality level is set
+- **THEN** the system propagates it to the related objects
+
+### REQ-004: Calculate the archive date
+
+The system SHALL calculate the archiefactiedatum for a zaak from its
+resultaat/archiefnominatie and the configured retention term.
+
+#### Scenario: Computing the archive date
+
+- **WHEN** archive parameters are provided for a zaak
+- **THEN** the system returns the calculated archive date
+
+### REQ-005: Validate archiving and decision-linking prerequisites
+
+The system SHALL enforce ZGW validation rules: that a zaak has the required
+producten-of-diensten, gegevensgroepen and archive prerequisites before archiving,
+that relevante-andere-zaken references are consistent, and that a
+besluitinformatieobject is valid before it is linked. Failed checks raise an
+error rather than persisting an invalid state.
+
+#### Scenario: Blocking an archive when prerequisites are missing
+
+- **WHEN** a zaak is checked for archiving without the required gegevensgroepen
+- **THEN** the system raises a validation error

--- a/openspec/specs/zgw-client-interaction/spec.md
+++ b/openspec/specs/zgw-client-interaction/spec.md
@@ -1,0 +1,57 @@
+---
+retrofit: true
+---
+
+# ZGW Client Interaction
+
+Management of the people-and-communication resources around case handling:
+klanten (customers/citizens), medewerkers (employees), contactmomenten (contact
+moments), berichten (messages) and taken (tasks). Each is a uniform REST
+collection; klanten additionally exposes its related zaken, taken, berichten and
+contactmomenten. Reverse-specified from observed controller behavior.
+
+## Requirements
+
+### REQ-001: List and read client-interaction resources
+
+The system SHALL list and read by id the klanten, medewerkers, contactmomenten,
+berichten and taken collections, returning JSON, with list results filtered and
+ordered by request parameters.
+
+#### Scenario: Listing contactmomenten
+
+- **WHEN** a client lists contactmomenten with filters
+- **THEN** the system returns the matching contactmomenten as JSON
+
+### REQ-002: Create, update and delete client-interaction resources
+
+The system SHALL create, update and delete klanten, medewerkers, contactmomenten,
+berichten and taken, returning the resulting object or delete result as JSON.
+Creation strips any client-supplied `id`; a delete returns HTTP 404 when the
+object did not exist.
+
+#### Scenario: Creating a taak
+
+- **WHEN** a client posts taak data
+- **THEN** the system persists it and returns the created taak
+
+### REQ-003: Read related resources of a klant
+
+The system SHALL return, for a given klant, the zaken, taken, berichten and
+contactmomenten related to that klant.
+
+#### Scenario: Fetching a klant's zaken
+
+- **WHEN** a client requests the zaken of a klant id
+- **THEN** the system returns the related zaken as JSON
+
+### REQ-004: Read audit trails and render pages
+
+The system SHALL return the audit trail of a client-interaction resource by id,
+and render the app template for the resource page route (or an error template on
+failure).
+
+#### Scenario: Requesting a bericht audit trail
+
+- **WHEN** a client requests the audit trail for a bericht id
+- **THEN** the system returns the audit trail entries as JSON

--- a/openspec/specs/zgw-object-data-access/spec.md
+++ b/openspec/specs/zgw-object-data-access/spec.md
@@ -1,0 +1,82 @@
+---
+retrofit: true
+---
+
+# ZGW Object Data Access
+
+The data-access layer that controllers use to read and persist ZGW objects. It
+resolves the right mapper per object type (OpenRegister-backed or local),
+translates request parameters into filters/order/pagination, and provides
+CRUD + facet + count operations. Also covers the HTTP CallService used to
+proxy upstream ZGW sources and the mail notification side effect.
+Reverse-specified from observed service behavior.
+
+## Requirements
+
+### REQ-001: Resolve the object mapper and register for an object type
+
+The system SHALL resolve the appropriate mapper for a given object type, and
+expose the OpenRegister object service when available (returning null when
+OpenRegister is not installed/available).
+
+#### Scenario: Resolving a mapper
+
+- **WHEN** a caller requests the mapper for an object type
+- **THEN** the system returns the matching mapper (OpenRegister-backed when present)
+
+### REQ-002: Read objects with filtering, pagination, faceting and counting
+
+The system SHALL read a single object by id (optionally extended), read
+collections with filters/sort/search/pagination, read all objects, read multiple
+objects by id list, compute facets, and count objects for a given filter set.
+
+#### Scenario: Reading a filtered collection
+
+- **WHEN** a caller queries objects with filters and pagination
+- **THEN** the system delegates to the resolved mapper and returns the matching
+  objects
+
+#### Scenario: Reading multiple objects by id
+
+- **WHEN** a caller passes a list of ids
+- **THEN** the system returns the objects for those ids
+
+### REQ-003: Persist and delete objects
+
+The system SHALL save (create or update, with optional version bump) and delete
+objects by id, delegating to the resolved mapper.
+
+#### Scenario: Saving an object
+
+- **WHEN** a caller saves object data for a type
+- **THEN** the system persists it via the mapper and returns the stored object
+
+### REQ-004: Build paginated result arrays from request parameters
+
+The system SHALL parse raw request parameters into filters, ordering and
+pagination (page/limit/offset, with offset derived from page and limit) and return
+a result array suitable for a JSON list response.
+
+#### Scenario: Building a result array
+
+- **WHEN** a controller passes raw request params
+- **THEN** the system parses them and returns the matching objects plus pagination
+  metadata
+
+### REQ-005: Proxy upstream ZGW sources and send notifications
+
+The system SHALL perform authenticated index/show/create/update/destroy calls
+against a configured upstream ZGW source and expose its resolved config, and SHALL
+send a mail notification describing the change between an old and new object
+version.
+
+#### Scenario: Proxying an upstream index call
+
+- **WHEN** a controller calls the upstream source for a collection
+- **THEN** the system issues the authenticated HTTP request and returns the decoded
+  response (or null)
+
+#### Scenario: Sending a change notification
+
+- **WHEN** an object transitions from an old to a new state
+- **THEN** the system composes and sends a mail describing the change

--- a/openspec/specs/zgw-related-resources/spec.md
+++ b/openspec/specs/zgw-related-resources/spec.md
@@ -1,0 +1,56 @@
+---
+retrofit: true
+---
+
+# ZGW Related Resources
+
+REST management of the ZGW catalogue and decision resources that exist alongside
+zaken: besluiten (decisions), documenten/informatieobjecten, resultaten,
+rollen, statussen, and zaaktypen. Each is exposed as a uniform REST collection
+backed by either the local OpenRegister object store or an upstream ZGW source via
+the CallService. Reverse-specified from observed controller behavior.
+
+## Requirements
+
+### REQ-001: List and read ZGW resources
+
+The system SHALL list a ZGW resource collection (besluiten, documenten,
+resultaten, rollen, statussen, zaaktypen) and read a single resource by id,
+returning JSON. Where a controller is backed by an upstream source it delegates
+the read through the CallService; otherwise it reads from the object service.
+
+#### Scenario: Listing besluiten
+
+- **WHEN** a client lists besluiten
+- **THEN** the system returns the besluiten collection as JSON
+
+#### Scenario: Reading a single resultaat
+
+- **WHEN** a client requests a resultaat by id
+- **THEN** the system returns that resultaat as JSON
+
+### REQ-002: Create, update and delete ZGW resources
+
+The system SHALL create, update and delete besluiten, documenten, resultaten,
+rollen, statussen and zaaktypen, returning the resulting object (or delete result)
+as JSON. Creation strips any client-supplied `id`.
+
+#### Scenario: Creating a rol
+
+- **WHEN** a client posts rol data
+- **THEN** the system persists it and returns the created rol
+
+#### Scenario: Deleting a status
+
+- **WHEN** a client deletes a status by id
+- **THEN** the system removes it and returns the delete result
+
+### REQ-003: Render resource pages
+
+The system SHALL render the app template for a ZGW resource page route, returning
+an error template if rendering fails.
+
+#### Scenario: Requesting a zaaktypen page
+
+- **WHEN** a client requests the zaaktypen page route
+- **THEN** the system returns the rendered app template

--- a/openspec/specs/zgw-zaak-management/spec.md
+++ b/openspec/specs/zgw-zaak-management/spec.md
@@ -1,0 +1,78 @@
+---
+retrofit: true
+---
+
+# ZGW Zaak Management
+
+Case (zaak) management surface implementing the VNG GEMMA Zaken standard
+(https://vng-realisatie.github.io/gemma-zaken/standaard/zaken/). Exposes a REST
+collection over the `zaken` register, plus the case-bound sub-resources that the
+ZGW standard attaches to a zaak (audit trail, besluiten, eigenschappen,
+informatieobjecten, objecten). Reverse-specified from observed controller
+behavior.
+
+## Requirements
+
+### REQ-001: List and search zaken
+
+The system SHALL return the full collection of zaken, filtered and ordered by the
+request parameters, as a JSON response.
+
+#### Scenario: Listing zaken with filters
+
+- **WHEN** a client issues `GET` against the zaken collection with query parameters
+- **THEN** the system resolves the parameters into filters/order and returns the
+  matching zaken as a JSON result array
+
+### REQ-002: Read a single zaak
+
+The system SHALL return a single zaak identified by its id as a JSON response.
+
+#### Scenario: Fetching one zaak
+
+- **WHEN** a client requests a zaak by id
+- **THEN** the system returns that zaak object as JSON
+
+### REQ-003: Create, update and delete a zaak
+
+The system SHALL create a new zaak from the posted parameters (ignoring any
+supplied `id`), update an existing zaak by id, and delete a zaak by id, each
+returning a JSON response. A delete returns `success` true with HTTP 200 when the
+object existed, otherwise HTTP 404.
+
+#### Scenario: Creating a zaak
+
+- **WHEN** a client posts zaak data
+- **THEN** the system strips any `id`, persists the object, and returns the created
+  zaak
+
+#### Scenario: Deleting a missing zaak
+
+- **WHEN** a client deletes a zaak id that does not exist
+- **THEN** the system returns `{success:false}` with HTTP 404
+
+### REQ-004: Read the audit trail of a zaak
+
+The system SHALL return the audit trail entries for a zaak identified by its id.
+
+#### Scenario: Requesting a zaak audit trail
+
+- **WHEN** a client requests the audit trail for a zaak id
+- **THEN** the system returns the audit trail entries as JSON
+
+### REQ-005: Manage case-bound sub-resources
+
+The system SHALL expose REST CRUD collections for the sub-resources that the ZGW
+standard binds to a zaak — audit trail records, zaakbesluiten, zaakeigenschappen,
+zaakinformatieobjecten, and zaakobjecten — each scoped to the relevant zaak where
+the route provides a `zaakId`.
+
+#### Scenario: Listing zaakeigenschappen for a zaak
+
+- **WHEN** a client lists eigenschappen for a given `zaakId`
+- **THEN** the system returns the eigenschappen bound to that zaak as JSON
+
+#### Scenario: Reading the rendered case page
+
+- **WHEN** a client requests a sub-resource page route
+- **THEN** the system renders the app template (or an error template on failure)

--- a/src/App.vue
+++ b/src/App.vue
@@ -61,6 +61,9 @@ export default {
 		Modals,
 		Dialogs,
 	},
+	/**
+	 * @spec exclude framework DI plumbing — provides app-level injections
+	 */
 
 	provide() {
 		return {
@@ -138,6 +141,9 @@ export default {
 	},
 
 	computed: {
+		/**
+		 * @spec openspec/specs/ui-search-navigation/spec.md#REQ-003
+		 */
 		permissions() {
 			return window.OC?.currentUser?.permissions ?? []
 		},
@@ -151,6 +157,8 @@ export default {
 		 *
 		 * @param {string} key Translation key.
 		 * @return {string} Translated string (or the key on miss).
+		  *
+		  * @spec exclude i18n wrapper around Nextcloud t()
 		 */
 		translateForApp(key) {
 			return ncT('zaakafhandelapp', key)

--- a/src/entities/bericht/bericht.ts
+++ b/src/entities/bericht/bericht.ts
@@ -20,6 +20,9 @@ export class Bericht implements TBericht {
 	public bijlageType: string
 	public omschrijving: string
 	public volgorde: string
+	/**
+	 * @spec openspec/specs/domain-entities/spec.md#REQ-001
+	 */
 
 	constructor(source: TBericht) {
 		this.id = source.id || ''

--- a/src/entities/besluit/besluit.ts
+++ b/src/entities/besluit/besluit.ts
@@ -7,6 +7,9 @@ export class Besluit implements TBesluit {
 	public url: string
 	public besluit: string
 	public zaak: string
+	/**
+	 * @spec openspec/specs/domain-entities/spec.md#REQ-001
+	 */
 
 	constructor(source: TBesluit) {
 		this.id = source.id || ''

--- a/src/entities/contactmoment/contactmoment.ts
+++ b/src/entities/contactmoment/contactmoment.ts
@@ -15,6 +15,9 @@ export class ContactMoment implements TContactMoment {
 	public contactmoment: string
 	public medewerker: string
 	public kanaal: string
+	/**
+	 * @spec openspec/specs/domain-entities/spec.md#REQ-001
+	 */
 
 	constructor(source: TContactMoment) {
 		this.id = source.id || ''

--- a/src/entities/document/document.ts
+++ b/src/entities/document/document.ts
@@ -73,6 +73,9 @@ export class Document implements TDocument {
 			}
 		}
 	}
+	/**
+	 * @spec openspec/specs/domain-entities/spec.md#REQ-001
+	 */
 
 	constructor(source: TDocument) {
 		this.id = source.id || ''

--- a/src/entities/klanten/klanten.ts
+++ b/src/entities/klanten/klanten.ts
@@ -34,6 +34,9 @@ export class Klant implements TKlant {
 	public subject: string
 	public subjectIdentificatie: string
 	public subjectType: string
+	/**
+	 * @spec openspec/specs/domain-entities/spec.md#REQ-001
+	 */
 
 	constructor(source: TKlant) {
 		this.id = source.id || ''

--- a/src/entities/medewerkers/medewerkers.ts
+++ b/src/entities/medewerkers/medewerkers.ts
@@ -9,6 +9,9 @@ export class Medewerker implements TMedewerker {
 	public achternaam: string
 	public email: string
 	public telefoonnummer: string
+	/**
+	 * @spec openspec/specs/domain-entities/spec.md#REQ-001
+	 */
 
 	constructor(source: TMedewerker) {
 		this.id = source.id || ''

--- a/src/entities/resultaat/resultaat.ts
+++ b/src/entities/resultaat/resultaat.ts
@@ -8,6 +8,9 @@ export class Resultaat implements TResultaat {
 	public zaak: string
 	public resultaattype: string
 	public toelichting: string
+	/**
+	 * @spec openspec/specs/domain-entities/spec.md#REQ-001
+	 */
 
 	constructor(source: TResultaat) {
 		this.id = source.id || ''

--- a/src/entities/rol/rol.ts
+++ b/src/entities/rol/rol.ts
@@ -36,6 +36,9 @@ export class Rol implements TRol {
         voorletters?: string
         voorvoegselAchternaam?: string
     }
+	/**
+	 * @spec openspec/specs/domain-entities/spec.md#REQ-001
+	 */
 
 	constructor(source: TRol) {
 		this.id = source.id || null

--- a/src/entities/taak/taak.ts
+++ b/src/entities/taak/taak.ts
@@ -16,6 +16,9 @@ export class Taak implements TTaak {
 	public klant: string
 	public contactmoment: string
 	public medewerker: string
+	/**
+	 * @spec openspec/specs/domain-entities/spec.md#REQ-001
+	 */
 	constructor(source: TTaak) {
 		this.id = source.id || ''
 		this.title = source.title || ''

--- a/src/entities/zaak/zaak.ts
+++ b/src/entities/zaak/zaak.ts
@@ -27,6 +27,9 @@ export class Zaak implements TZaak {
 	public hoofdzaak: string
 	public klant: string
 	public berichten: string[]
+	/**
+	 * @spec openspec/specs/domain-entities/spec.md#REQ-001
+	 */
 
 	constructor(source: TZaak) {
 		this.id = source.id || ''

--- a/src/entities/zaakTypen/zaakTypen.ts
+++ b/src/entities/zaakTypen/zaakTypen.ts
@@ -31,6 +31,9 @@ export class ZaakType implements TZaakType {
 	public beginObject: string
 	public eindeObject: string
 	public versiedatum: string
+	/**
+	 * @spec openspec/specs/domain-entities/spec.md#REQ-001
+	 */
 
 	constructor(source: TZaakType) {
 		this.id = source.id || ''

--- a/src/modals/berichten/EditBericht.vue
+++ b/src/modals/berichten/EditBericht.vue
@@ -167,6 +167,9 @@ export default {
 			},
 		}
 	},
+	/**
+	 * @spec openspec/specs/ui-modals/spec.md#REQ-003
+	 */
 	updated() {
 		if (navigationStore.modal === 'editBericht' && !this.hasUpdated) {
 			if (berichtStore.berichtItem?.id) {
@@ -194,11 +197,17 @@ export default {
 		}
 	},
 	methods: {
+		/**
+		 * @spec openspec/specs/ui-modals/spec.md#REQ-001
+		 */
 		closeModalFromButton() {
 			setTimeout(() => {
 				this.closeModal()
 			}, 300)
 		},
+		/**
+		 * @spec openspec/specs/ui-modals/spec.md#REQ-001
+		 */
 		closeModal() {
 			navigationStore.setModal(false)
 			this.success = false
@@ -224,6 +233,9 @@ export default {
 			this.$emit('close-modal')
 
 		},
+		/**
+		 * @spec openspec/specs/ui-modals/spec.md#REQ-003
+		 */
 		async editBericht() {
 			this.loading = true
 			try {
@@ -244,6 +256,9 @@ export default {
 				this.error = error.message || 'An error occurred while saving the bericht'
 			}
 		},
+		/**
+		 * @spec openspec/specs/ui-modals/spec.md#REQ-004
+		 */
 		openLink(url, target) {
 			window.open(url, target)
 		},

--- a/src/modals/berichten/ViewBerichtAuditTrail.vue
+++ b/src/modals/berichten/ViewBerichtAuditTrail.vue
@@ -58,11 +58,17 @@ export default {
 			auditTrail: {}, // Initialize with an empty object
 		}
 	},
+	/**
+	 * @spec openspec/specs/ui-modals/spec.md#REQ-004
+	 */
 	mounted() {
 		// Assuming berichtStore.auditTrailItem is a single audit trail object
 		this.auditTrail = berichtStore.auditTrailItem || {}
 	},
 	methods: {
+		/**
+		 * @spec openspec/specs/ui-modals/spec.md#REQ-004
+		 */
 		closeDialog() {
 			navigationStore.setModal(null)
 			berichtStore.setAuditTrailItem(null)

--- a/src/modals/besluiten/BesluitForm.vue
+++ b/src/modals/besluiten/BesluitForm.vue
@@ -104,6 +104,9 @@ export default {
 			},
 		}
 	},
+	/**
+	 * @spec openspec/specs/ui-modals/spec.md#REQ-004
+	 */
 	mounted() {
 		// If zaakItem in the store is set. apply it to zaak in this modal.
 		if (besluitStore.besluitItem?.id) {
@@ -117,11 +120,17 @@ export default {
 		this.fetchZaak()
 	},
 	methods: {
+		/**
+		 * @spec openspec/specs/ui-modals/spec.md#REQ-001
+		 */
 		closeModal() {
 			navigationStore.setModal(null)
 			besluitStore.zaakId = null
 			this.dashboardWidget && this.$emit('close-modal')
 		},
+		/**
+		 * @spec openspec/specs/ui-modals/spec.md#REQ-005
+		 */
 		fetchZaak() {
 			this.zaakLoading = true
 
@@ -147,6 +156,9 @@ export default {
 					this.zaakLoading = false
 				})
 		},
+		/**
+		 * @spec openspec/specs/ui-modals/spec.md#REQ-003
+		 */
 		saveBesluit() {
 			this.loading = true
 

--- a/src/modals/besluiten/DeleteBesluit.vue
+++ b/src/modals/besluiten/DeleteBesluit.vue
@@ -75,11 +75,17 @@ export default {
 		}
 	},
 	methods: {
+		/**
+		 * @spec openspec/specs/ui-modals/spec.md#REQ-004
+		 */
 		closeDialog() {
 			navigationStore.setModal(null)
 			besluitStore.zaakId = null
 			clearTimeout(this.closeModalTimeout)
 		},
+		/**
+		 * @spec openspec/specs/ui-modals/spec.md#REQ-003
+		 */
 		async deleteBesluit() {
 			this.loading = true
 

--- a/src/modals/contactMomenten/ContactMomentenForm.vue
+++ b/src/modals/contactMomenten/ContactMomentenForm.vue
@@ -770,6 +770,9 @@ export default {
 			},
 		}
 	},
+	/**
+	 * @spec openspec/specs/ui-modals/spec.md#REQ-004
+	 */
 	mounted() {
 		const contactMomentId = this.contactMomentId ?? contactMomentStore.contactMomentItem?.id ?? null
 		this.isEdit = !!contactMomentId
@@ -784,6 +787,9 @@ export default {
 		}
 	},
 	methods: {
+		/**
+		 * @spec openspec/specs/ui-modals/spec.md#REQ-004
+		 */
 
 		closeTab(x) {
 			for (let i = 0; i < this.tabs.length; i++) {
@@ -796,6 +802,8 @@ export default {
 		/**
 		 * Creates a new tab with the given tabData. If no tabData is provided, it creates a new tab with default data.
 		 * @param {object} tabData - The data for the new tab.
+		  *
+		  * @spec openspec/specs/ui-modals/spec.md#REQ-004
 		 */
 		newTab(tabData = null) {
 			const index = this.tabCounter + 1
@@ -825,6 +833,9 @@ export default {
 				this.fetchData(tabData.id, index)
 			}
 		},
+		/**
+		 * @spec openspec/specs/ui-modals/spec.md#REQ-005
+		 */
 
 		async fetchData(id, index) {
 			this.fetchLoading = true
@@ -862,6 +873,9 @@ export default {
 
 			this.fetchLoading = false
 		},
+		/**
+		 * @spec openspec/specs/ui-modals/spec.md#REQ-005
+		 */
 
 		async fetchMedewerkers(medewerkerId = null, index) {
 			return Promise.all([
@@ -917,17 +931,26 @@ export default {
 		},
 
 		// Modal functions
+		/**
+		 * @spec openspec/specs/ui-modals/spec.md#REQ-001
+		 */
 		closeModalFromButton() {
 			setTimeout(() => {
 				this.closeModal()
 			}, 300)
 		},
+		/**
+		 * @spec openspec/specs/ui-modals/spec.md#REQ-001
+		 */
 		closeModal() {
 			navigationStore.setModal(false)
 
 			this.$emit('close-modal')
 		},
 		// Contactmoment functions
+		/**
+		 * @spec openspec/specs/ui-modals/spec.md#REQ-004
+		 */
 		addContactMoment(i) {
 
 			this.selectedContactMoment = i
@@ -995,21 +1018,33 @@ export default {
 		},
 
 		// Search functions
+		/**
+		 * @spec openspec/specs/ui-modals/spec.md#REQ-004
+		 */
 		openSearchKlantModal(type) {
 			this.searchKlantModalOpen = true
 			this.startingType = type
 		},
 
 		// Klant functions
+		/**
+		 * @spec openspec/specs/ui-modals/spec.md#REQ-004
+		 */
 		closeSearchKlantModal() {
 			this.searchKlantModalOpen = false
 		},
+		/**
+		 * @spec openspec/specs/ui-modals/spec.md#REQ-004
+		 */
 
 		openTaakForm(clientType = 'both') {
 			this.taakFormOpen = true
 			this.taakClientType = clientType
 			taakStore.setTaakItem(null)
 		},
+		/**
+		 * @spec openspec/specs/ui-modals/spec.md#REQ-004
+		 */
 
 		closeTaakForm(e) {
 			if (e) {
@@ -1019,10 +1054,16 @@ export default {
 			}
 			this.taakFormOpen = false
 		},
+		/**
+		 * @spec openspec/specs/ui-modals/spec.md#REQ-004
+		 */
 
 		viewContactMoment(contactMoment) {
 			this.newTab(contactMoment)
 		},
+		/**
+		 * @spec openspec/specs/ui-modals/spec.md#REQ-004
+		 */
 
 		viewZaak(id) {
 			if (this.dashboardWidget) {
@@ -1032,6 +1073,9 @@ export default {
 				navigationStore.setModal(false)
 			}
 		},
+		/**
+		 * @spec openspec/specs/ui-modals/spec.md#REQ-004
+		 */
 
 		viewTaak(id) {
 			if (this.dashboardWidget) {
@@ -1041,11 +1085,17 @@ export default {
 				navigationStore.setModal(false)
 			}
 		},
+		/**
+		 * @spec openspec/specs/ui-modals/spec.md#REQ-004
+		 */
 
 		closeViewContactMomentModal() {
 			this.isContactMomentFormOpen = false
 			navigationStore.setViewModal(false)
 		},
+		/**
+		 * @spec openspec/specs/ui-modals/spec.md#REQ-004
+		 */
 
 		removeKlant(i) {
 			this.contactMomenten[i].klant = null
@@ -1057,15 +1107,24 @@ export default {
 		},
 
 		// zaak functions
+		/**
+		 * @spec openspec/specs/ui-modals/spec.md#REQ-004
+		 */
 		openZaakForm() {
 			zaakStore.setZaakItem(null)
 			this.zaakFormOpen = true
 		},
+		/**
+		 * @spec openspec/specs/ui-modals/spec.md#REQ-004
+		 */
 
 		zaakFormSaveSuccess() {
 			this.zaakFormOpen = false
 			this.fetchKlantData(this.contactMomenten[this.selectedContactMoment].klant.id)
 		},
+		/**
+		 * @spec openspec/specs/ui-modals/spec.md#REQ-004
+		 */
 
 		async closeContactMoment(id) {
 			let data
@@ -1098,6 +1157,9 @@ export default {
 				})
 
 		},
+		/**
+		 * @spec openspec/specs/ui-modals/spec.md#REQ-005
+		 */
 
 		async fetchKlantData(klant) {
 			const klantId = klant.id ?? klant
@@ -1209,6 +1271,9 @@ export default {
 				// even if some data failed to load
 			}
 		},
+		/**
+		 * @spec openspec/specs/ui-modals/spec.md#REQ-005
+		 */
 
 		getInitials(klant) {
 			if (!klant) return
@@ -1222,6 +1287,9 @@ export default {
 			return 'onbekend'
 
 		},
+		/**
+		 * @spec openspec/specs/ui-modals/spec.md#REQ-005
+		 */
 
 		getName(klant) {
 			if (!klant) return
@@ -1234,6 +1302,9 @@ export default {
 			}
 			return 'onbekend'
 		},
+		/**
+		 * @spec openspec/specs/ui-modals/spec.md#REQ-005
+		 */
 		getSex(klant) {
 			if (klant.type === 'persoon') {
 				return `(${klant?.geslacht})`
@@ -1242,22 +1313,34 @@ export default {
 		},
 
 		// Tabs
+		/**
+		 * @spec openspec/specs/ui-modals/spec.md#REQ-002
+		 */
 		setSelectedContactMoment(id, contactMoment) {
 			if (this.contactMomenten[id].selectedKlantContactMoment === contactMoment) {
 				this.contactMomenten[id].selectedKlantContactMoment = null
 			} else { this.contactMomenten[id].selectedKlantContactMoment = contactMoment }
 		},
+		/**
+		 * @spec openspec/specs/ui-modals/spec.md#REQ-002
+		 */
 		setSelectedZaak(id, zaak) {
 			if (this.contactMomenten[id].selectedZaak === zaak) {
 				this.contactMomenten[id].selectedZaak = null
 			} else { this.contactMomenten[id].selectedZaak = zaak }
 		},
+		/**
+		 * @spec openspec/specs/ui-modals/spec.md#REQ-002
+		 */
 
 		setSelectedTaak(id, taak) {
 			if (this.contactMomenten[id].selectedTaak === taak) {
 				this.contactMomenten[id].selectedTaak = null
 			} else { this.contactMomenten[id].selectedTaak = taak }
 		},
+		/**
+		 * @spec openspec/specs/ui-modals/spec.md#REQ-002
+		 */
 
 		setSelectedProduct(id, product) {
 			if (this.contactMomenten[id].selectedProduct === product) {

--- a/src/modals/contactMomenten/DeleteContactMoment.vue
+++ b/src/modals/contactMomenten/DeleteContactMoment.vue
@@ -73,11 +73,17 @@ export default {
 		}
 	},
 	methods: {
+		/**
+		 * @spec openspec/specs/ui-modals/spec.md#REQ-001
+		 */
 		closeModal() {
 			navigationStore.setModal(false)
 			clearTimeout(this.closeTimeoutFunc)
 			this.success = null
 		},
+		/**
+		 * @spec openspec/specs/ui-modals/spec.md#REQ-003
+		 */
 		async deleteContactMoment() {
 			this.loading = true
 			try {

--- a/src/modals/contactMomenten/ViewContactMoment.vue
+++ b/src/modals/contactMomenten/ViewContactMoment.vue
@@ -394,6 +394,9 @@ export default {
 			tabCounter: 1,
 		}
 	},
+	/**
+	 * @spec openspec/specs/ui-modals/spec.md#REQ-004
+	 */
 	mounted() {
 		const contactMomentId = this.contactMomentId ?? contactMomentStore.contactMomentItem?.id ?? null
 		this.isEdit = !!contactMomentId
@@ -406,6 +409,9 @@ export default {
 		}
 	},
 	methods: {
+		/**
+		 * @spec openspec/specs/ui-modals/spec.md#REQ-004
+		 */
 
 		closeTab(x) {
 			for (let i = 0; i < this.tabs.length; i++) {
@@ -414,6 +420,9 @@ export default {
 				}
 			}
 		},
+		/**
+		 * @spec openspec/specs/ui-modals/spec.md#REQ-004
+		 */
 		newTab() {
 			const index = this.tabCounter + 1
 			this.contactMomenten = {
@@ -432,6 +441,9 @@ export default {
 			this.tabs.push(index)
 			this.tabCounter = this.tabCounter + 1
 		},
+		/**
+		 * @spec openspec/specs/ui-modals/spec.md#REQ-005
+		 */
 
 		async fetchData(id) {
 			this.fetchLoading = true
@@ -457,11 +469,17 @@ export default {
 		},
 
 		// Modal functions
+		/**
+		 * @spec openspec/specs/ui-modals/spec.md#REQ-001
+		 */
 		closeModalFromButton() {
 			setTimeout(() => {
 				this.closeModal()
 			}, 300)
 		},
+		/**
+		 * @spec openspec/specs/ui-modals/spec.md#REQ-001
+		 */
 		closeModal() {
 			navigationStore.setModal(false)
 
@@ -469,6 +487,9 @@ export default {
 		},
 
 		// Contactmoment functions
+		/**
+		 * @spec openspec/specs/ui-modals/spec.md#REQ-004
+		 */
 		addContactMoment(i) {
 
 			this.selectedContactMoment = i
@@ -552,26 +573,41 @@ export default {
 		},
 
 		// Search functions
+		/**
+		 * @spec openspec/specs/ui-modals/spec.md#REQ-004
+		 */
 		openSearchKlantModal(type) {
 			this.searchKlantModalOpen = true
 			this.startingType = type
 		},
 
 		// Klant functions
+		/**
+		 * @spec openspec/specs/ui-modals/spec.md#REQ-004
+		 */
 		closeSearchKlantModal() {
 			this.searchKlantModalOpen = false
 		},
+		/**
+		 * @spec openspec/specs/ui-modals/spec.md#REQ-004
+		 */
 
 		openTaakForm(clientType = 'both') {
 			this.taakFormOpen = true
 			this.taakClientType = clientType
 			taakStore.setTaakItem(null)
 		},
+		/**
+		 * @spec openspec/specs/ui-modals/spec.md#REQ-004
+		 */
 
 		closeTaakForm() {
 			this.taakFormOpen = false
 			this.fetchKlantData(this.contactMomenten[this.selectedContactMoment].klant.id)
 		},
+		/**
+		 * @spec openspec/specs/ui-modals/spec.md#REQ-004
+		 */
 
 		removeKlant(i) {
 			this.contactMomenten[i].klant = null
@@ -583,15 +619,24 @@ export default {
 		},
 
 		// zaak functions
+		/**
+		 * @spec openspec/specs/ui-modals/spec.md#REQ-004
+		 */
 		openZaakForm() {
 			zaakStore.setZaakItem(null)
 			this.zaakFormOpen = true
 		},
+		/**
+		 * @spec openspec/specs/ui-modals/spec.md#REQ-004
+		 */
 
 		zaakFormSaveSuccess() {
 			this.zaakFormOpen = false
 			this.fetchKlantData(this.contactMomenten[this.selectedContactMoment].klant.id)
 		},
+		/**
+		 * @spec openspec/specs/ui-modals/spec.md#REQ-004
+		 */
 
 		async closeContactMoment(id) {
 			const { data } = await contactMomentStore.getContactMoment(id)
@@ -613,6 +658,9 @@ export default {
 					}
 				})
 		},
+		/**
+		 * @spec openspec/specs/ui-modals/spec.md#REQ-005
+		 */
 
 		async fetchKlantData(klant) {
 			const klantId = klant.id ?? klant
@@ -724,6 +772,9 @@ export default {
 				// even if some data failed to load
 			}
 		},
+		/**
+		 * @spec openspec/specs/ui-modals/spec.md#REQ-005
+		 */
 
 		getName(klant) {
 			if (!klant) return
@@ -736,6 +787,9 @@ export default {
 			}
 			return 'onbekend'
 		},
+		/**
+		 * @spec openspec/specs/ui-modals/spec.md#REQ-005
+		 */
 		getSex(klant) {
 			if (klant.type === 'persoon') {
 				return `(${klant?.geslacht})`
@@ -744,17 +798,26 @@ export default {
 		},
 
 		// Tabs
+		/**
+		 * @spec openspec/specs/ui-modals/spec.md#REQ-002
+		 */
 		setSelectedZaak(id, zaak) {
 			if (this.contactMomenten[id].selectedZaak === zaak) {
 				this.contactMomenten[id].selectedZaak = null
 			} else { this.contactMomenten[id].selectedZaak = zaak }
 		},
+		/**
+		 * @spec openspec/specs/ui-modals/spec.md#REQ-002
+		 */
 
 		setSelectedTaak(id, taak) {
 			if (this.contactMomenten[id].selectedTaak === taak) {
 				this.contactMomenten[id].selectedTaak = null
 			} else { this.contactMomenten[id].selectedTaak = taak }
 		},
+		/**
+		 * @spec openspec/specs/ui-modals/spec.md#REQ-002
+		 */
 
 		setSelectedProduct(id, product) {
 			if (this.contactMomenten[id].selectedProduct === product) {

--- a/src/modals/documenten/DeleteDocument.vue
+++ b/src/modals/documenten/DeleteDocument.vue
@@ -75,11 +75,17 @@ export default {
 		}
 	},
 	methods: {
+		/**
+		 * @spec openspec/specs/ui-modals/spec.md#REQ-004
+		 */
 		closeDialog() {
 			navigationStore.setModal(null)
 			documentStore.zaakId = null
 			clearTimeout(this.closeModalTimeout)
 		},
+		/**
+		 * @spec openspec/specs/ui-modals/spec.md#REQ-003
+		 */
 		async deleteDocument() {
 			this.loading = true
 

--- a/src/modals/documenten/DocumentForm.vue
+++ b/src/modals/documenten/DocumentForm.vue
@@ -255,6 +255,9 @@ export default {
 			},
 		}
 	},
+	/**
+	 * @spec openspec/specs/ui-modals/spec.md#REQ-004
+	 */
 	mounted() {
 		if (documentStore.documentItem?.id) {
 			this.IS_EDIT = true
@@ -273,11 +276,17 @@ export default {
 		this.fetchZaak()
 	},
 	methods: {
+		/**
+		 * @spec openspec/specs/ui-modals/spec.md#REQ-001
+		 */
 		closeModal() {
 			navigationStore.setModal(null)
 			documentStore.zaakId = null
 			this.dashboardWidget && this.$emit('close-modal')
 		},
+		/**
+		 * @spec openspec/specs/ui-modals/spec.md#REQ-005
+		 */
 		fetchZaak() {
 			this.zaakLoading = true
 
@@ -303,6 +312,9 @@ export default {
 					this.zaakLoading = false
 				})
 		},
+		/**
+		 * @spec openspec/specs/ui-modals/spec.md#REQ-004
+		 */
 		isValid() {
 			return this.document.bronorganisatie
 				&& this.document.creatiedatum
@@ -311,6 +323,9 @@ export default {
 				&& this.document.taal
 				&& this.document.informatieobjecttype
 		},
+		/**
+		 * @spec openspec/specs/ui-modals/spec.md#REQ-003
+		 */
 		saveDocument() {
 			this.loading = true
 

--- a/src/modals/klanten/DeleteKlant.vue
+++ b/src/modals/klanten/DeleteKlant.vue
@@ -73,11 +73,17 @@ export default {
 		}
 	},
 	methods: {
+		/**
+		 * @spec openspec/specs/ui-modals/spec.md#REQ-001
+		 */
 		closeModal() {
 			navigationStore.setModal(false)
 			clearTimeout(this.closeTimeoutFunc)
 			this.success = null
 		},
+		/**
+		 * @spec openspec/specs/ui-modals/spec.md#REQ-003
+		 */
 		async deleteKlant() {
 			this.loading = true
 			try {

--- a/src/modals/klanten/EditKlant.vue
+++ b/src/modals/klanten/EditKlant.vue
@@ -272,10 +272,16 @@ export default {
 		}
 	},
 	computed: {
+		/**
+		 * @spec openspec/specs/ui-modals/spec.md#REQ-004
+		 */
 		items() {
 			return this.contactMomentItems
 		},
 	},
+	/**
+	 * @spec openspec/specs/ui-modals/spec.md#REQ-003
+	 */
 	updated() {
 		if (navigationStore.modal === 'editKlant' && !this.hasUpdated) {
 			const klantType = this.typeOptions.options.find((option) => option.value === klantStore.klantItem?.type)
@@ -319,6 +325,9 @@ export default {
 		}
 	},
 	methods: {
+		/**
+		 * @spec openspec/specs/ui-modals/spec.md#REQ-001
+		 */
 		closeModal() {
 			navigationStore.setModal(false)
 			this.success = false
@@ -354,6 +363,9 @@ export default {
 				subjectType: '',
 			}
 		},
+		/**
+		 * @spec openspec/specs/ui-modals/spec.md#REQ-003
+		 */
 		async editKlant() {
 			this.loading = true
 
@@ -374,6 +386,9 @@ export default {
 				this.error = error.message || 'An error occurred while saving the klant'
 			}
 		},
+		/**
+		 * @spec openspec/specs/ui-modals/spec.md#REQ-004
+		 */
 		openLink(url, target) {
 			window.open(url, target)
 		},

--- a/src/modals/klanten/SearchKlantModal.vue
+++ b/src/modals/klanten/SearchKlantModal.vue
@@ -205,6 +205,9 @@ export default {
 		startingType: {
 			type: String,
 			required: true, // required is set to true as I want developers to be aware of the functionality they're adding / using
+			/**
+			 * @spec openspec/specs/ui-modals/spec.md#REQ-004
+			 */
 			validator(value) {
 				return ['persoon', 'organisatie', 'all'].includes(value)
 			},
@@ -241,6 +244,9 @@ export default {
 		}
 	},
 	computed: {
+		/**
+		 * @spec openspec/specs/ui-modals/spec.md#REQ-004
+		 */
 		searchLabel() {
 			const typeLabels = {
 				persoon: {
@@ -275,6 +281,9 @@ export default {
 		},
 	},
 	watch: {
+		/**
+		 * @spec openspec/specs/ui-modals/spec.md#REQ-004
+		 */
 		klantenSearchType(newVal) {
 			if (newVal === 'geboortedatum_achternaam') {
 				this.searchQuery = [new Date(), '']
@@ -284,20 +293,32 @@ export default {
 		},
 	},
 	methods: {
+		/**
+		 * @spec openspec/specs/ui-modals/spec.md#REQ-001
+		 */
 		closeModalFromButton() {
 			setTimeout(() => {
 				this.closeModal()
 			}, 300)
 		},
+		/**
+		 * @spec openspec/specs/ui-modals/spec.md#REQ-001
+		 */
 		closeModal() {
 			this.$emit('close-modal')
 
 		},
+		/**
+		 * @spec openspec/specs/ui-modals/spec.md#REQ-004
+		 */
 		selectKlant() {
 			console.info('klant selected', this.selectedKlant?.id)
 			this.$emit('selected-klant', this.selectedKlant)
 			this.closeModalFromButton()
 		},
+		/**
+		 * @spec openspec/specs/ui-modals/spec.md#REQ-004
+		 */
 
 		search() {
 			this.loading = true
@@ -332,6 +353,9 @@ export default {
 					this.loading = false
 				})
 		},
+		/**
+		 * @spec openspec/specs/ui-modals/spec.md#REQ-005
+		 */
 		getItemIcon() {
 			const theme = getTheme()
 
@@ -343,6 +367,9 @@ export default {
 
 			return theme === 'light' ? `${appLocation}/zaakafhandelapp/img/office-building-outline-dark.svg` : `${appLocation}/zaakafhandelapp/img/office-building-outline.svg`
 		},
+		/**
+		 * @spec openspec/specs/ui-modals/spec.md#REQ-005
+		 */
 
 		getName(klant) {
 			if (klant.type === 'persoon') {
@@ -353,6 +380,9 @@ export default {
 			}
 			return 'onbekend'
 		},
+		/**
+		 * @spec openspec/specs/ui-modals/spec.md#REQ-005
+		 */
 		getSubname(klant) {
 			if (klant.type === 'persoon') {
 				return klant?.tussenvoegsel ? `${klant.tussenvoegsel} ${klant.achternaam}` : klant?.achternaam ? `${klant.achternaam}` : 'onbekend'
@@ -362,6 +392,9 @@ export default {
 			}
 			return 'onbekend'
 		},
+		/**
+		 * @spec openspec/specs/ui-modals/spec.md#REQ-005
+		 */
 		getSummary(klant) {
 			if (klant.type === 'persoon') {
 				const geboortedatum = getValidISOstring(klant.geboortedatum) ? new Date(klant.geboortedatum).toLocaleDateString() : 'onbekend'
@@ -373,12 +406,18 @@ export default {
 			}
 			return 'onbekend'
 		},
+		/**
+		 * @spec openspec/specs/ui-modals/spec.md#REQ-005
+		 */
 		getSex(klant) {
 			if (klant.type === 'persoon') {
 				return `(${klant?.geslacht})`
 			}
 			return ''
 		},
+		/**
+		 * @spec openspec/specs/ui-modals/spec.md#REQ-002
+		 */
 		setActive(klant) {
 			if (this.selectedKlant?.id === (klant?.id || Symbol('default id'))) {
 				this.selectedKlant = null

--- a/src/modals/klanten/ViewKlant.vue
+++ b/src/modals/klanten/ViewKlant.vue
@@ -272,10 +272,16 @@ export default {
 		}
 	},
 	computed: {
+		/**
+		 * @spec openspec/specs/ui-modals/spec.md#REQ-004
+		 */
 		filteredContactMomenten() {
 			return contactMomentStore.contactMomentenList.filter(contactMoment => contactMoment.klant === this.klant?.id)
 		},
 	},
+	/**
+	 * @spec openspec/specs/ui-modals/spec.md#REQ-004
+	 */
 	mounted() {
 		contactMomentStore.refreshContactMomentenList()
 
@@ -284,6 +290,9 @@ export default {
 			this.fetchKlantData(klantStore.widgetKlantId)
 		}
 	},
+	/**
+	 * @spec openspec/specs/ui-modals/spec.md#REQ-003
+	 */
 	updated() {
 		if (klantStore.widgetKlantId && this.currentActiveKlant !== klantStore.widgetKlantId) {
 			this.currentActiveKlant = klantStore.widgetKlantId
@@ -291,6 +300,9 @@ export default {
 		}
 	},
 	methods: {
+		/**
+		 * @spec openspec/specs/ui-modals/spec.md#REQ-005
+		 */
 
 		fetchKlantData(id) {
 			fetch(`/index.php/apps/zaakafhandelapp/api/klanten/${id}`)
@@ -332,6 +344,9 @@ export default {
 					console.error('Error fetching berichten:', error)
 				})
 		},
+		/**
+		 * @spec openspec/specs/ui-modals/spec.md#REQ-005
+		 */
 
 		fetchTaakItems() {
 			this.taakModalOpen = false
@@ -342,6 +357,9 @@ export default {
 					this.taken = data.results
 				})
 		},
+		/**
+		 * @spec openspec/specs/ui-modals/spec.md#REQ-005
+		 */
 		fetchZaakItems() {
 			this.zaakModalOpen = false
 			this.loading = true
@@ -351,6 +369,9 @@ export default {
 					this.zaken = data.results
 				})
 		},
+		/**
+		 * @spec openspec/specs/ui-modals/spec.md#REQ-005
+		 */
 
 		getName(klant) {
 			if (klant.type === 'persoon') {
@@ -361,16 +382,25 @@ export default {
 			}
 			return 'onbekend'
 		},
+		/**
+		 * @spec openspec/specs/ui-modals/spec.md#REQ-001
+		 */
 
 		closeModalFromButton() {
 			setTimeout(() => {
 				this.closeModal()
 			}, 300)
 		},
+		/**
+		 * @spec openspec/specs/ui-modals/spec.md#REQ-001
+		 */
 		closeModal() {
 			navigationStore.setModal(false)
 			if (this.dashboardWidget) this.$emit('close-modal')
 		},
+		/**
+		 * @spec openspec/specs/ui-modals/spec.md#REQ-004
+		 */
 		openLink(url, target) {
 			window.open(url, target)
 		},

--- a/src/modals/klanten/ViewKlantAuditTrail.vue
+++ b/src/modals/klanten/ViewKlantAuditTrail.vue
@@ -58,11 +58,17 @@ export default {
 			auditTrail: {}, // Initialize with an empty object
 		}
 	},
+	/**
+	 * @spec openspec/specs/ui-modals/spec.md#REQ-004
+	 */
 	mounted() {
 		// Assuming klantStore.auditTrailItem is a single audit trail object
 		this.auditTrail = klantStore.auditTrailItem || {}
 	},
 	methods: {
+		/**
+		 * @spec openspec/specs/ui-modals/spec.md#REQ-004
+		 */
 		closeDialog() {
 			navigationStore.setModal(null)
 			klantStore.setAuditTrailItem(null)

--- a/src/modals/medewerkers/EditMedewerker.vue
+++ b/src/modals/medewerkers/EditMedewerker.vue
@@ -120,6 +120,9 @@ export default {
 			},
 		}
 	},
+	/**
+	 * @spec openspec/specs/ui-modals/spec.md#REQ-004
+	 */
 	mounted() {
 		if (medewerkerStore.medewerkerItem?.id) {
 			this.medewerkerItem = {
@@ -133,9 +136,15 @@ export default {
 		}
 	},
 	methods: {
+		/**
+		 * @spec openspec/specs/ui-modals/spec.md#REQ-001
+		 */
 		closeModal() {
 			navigationStore.setModal(false)
 		},
+		/**
+		 * @spec openspec/specs/ui-modals/spec.md#REQ-003
+		 */
 		async editMedewerker() {
 			this.loading = true
 
@@ -152,6 +161,9 @@ export default {
 				this.error = error.message || 'An error occurred while saving the medewerker'
 			}
 		},
+		/**
+		 * @spec openspec/specs/ui-modals/spec.md#REQ-004
+		 */
 		openLink(url, target) {
 			window.open(url, target)
 		},

--- a/src/modals/medewerkers/SearchKlantModal.vue
+++ b/src/modals/medewerkers/SearchKlantModal.vue
@@ -201,6 +201,9 @@ export default {
 		}
 	},
 	computed: {
+		/**
+		 * @spec openspec/specs/ui-modals/spec.md#REQ-004
+		 */
 		searchLabel() {
 			const typeLabels = {
 				persoon: {
@@ -228,21 +231,33 @@ export default {
 		},
 	},
 	methods: {
+		/**
+		 * @spec openspec/specs/ui-modals/spec.md#REQ-001
+		 */
 		closeModalFromButton() {
 			setTimeout(() => {
 				this.closeModal()
 			}, 300)
 		},
+		/**
+		 * @spec openspec/specs/ui-modals/spec.md#REQ-001
+		 */
 		closeModal() {
 			this.$emit('close-modal')
 
 		},
+		/**
+		 * @spec openspec/specs/ui-modals/spec.md#REQ-004
+		 */
 		addKlant() {
 			// eslint-disable-next-line no-console
 			console.log('added')
 			this.$emit('selected-klant', this.selectedKlant)
 			this.closeModalFromButton()
 		},
+		/**
+		 * @spec openspec/specs/ui-modals/spec.md#REQ-004
+		 */
 
 		search() {
 			this.loading = true
@@ -281,6 +296,9 @@ export default {
 					this.loading = false
 				})
 		},
+		/**
+		 * @spec openspec/specs/ui-modals/spec.md#REQ-005
+		 */
 		getItemIcon() {
 			const theme = getTheme()
 
@@ -292,6 +310,9 @@ export default {
 
 			return theme === 'light' ? `${appLocation}/zaakafhandelapp/img/office-building-outline-dark.svg` : `${appLocation}/zaakafhandelapp/img/office-building-outline.svg`
 		},
+		/**
+		 * @spec openspec/specs/ui-modals/spec.md#REQ-005
+		 */
 
 		getName(klant) {
 			if (klant.type === 'persoon') {
@@ -302,6 +323,9 @@ export default {
 			}
 			return 'onbekend'
 		},
+		/**
+		 * @spec openspec/specs/ui-modals/spec.md#REQ-005
+		 */
 		getSubname(klant) {
 			if (klant.type === 'persoon') {
 				return klant?.tussenvoegsel ? `${klant.tussenvoegsel} ${klant.achternaam}` : klant?.achternaam ? `${klant.achternaam}` : 'onbekend'
@@ -311,6 +335,9 @@ export default {
 			}
 			return 'onbekend'
 		},
+		/**
+		 * @spec openspec/specs/ui-modals/spec.md#REQ-005
+		 */
 		getSummary(klant) {
 			if (klant.type === 'persoon') {
 				const geboortedatum = getValidISOstring(klant.geboortedatum) ? new Date(klant.geboortedatum).toLocaleDateString() : 'onbekend'
@@ -322,12 +349,18 @@ export default {
 			}
 			return 'onbekend'
 		},
+		/**
+		 * @spec openspec/specs/ui-modals/spec.md#REQ-005
+		 */
 		getSex(klant) {
 			if (klant.type === 'persoon') {
 				return `(${klant?.geslacht})`
 			}
 			return ''
 		},
+		/**
+		 * @spec openspec/specs/ui-modals/spec.md#REQ-002
+		 */
 		setActive(klant) {
 			if (this.selectedKlant === klant) {
 				this.selectedKlant = null

--- a/src/modals/medewerkers/ViewKlantAuditTrail.vue
+++ b/src/modals/medewerkers/ViewKlantAuditTrail.vue
@@ -58,11 +58,17 @@ export default {
 			auditTrail: {}, // Initialize with an empty object
 		}
 	},
+	/**
+	 * @spec openspec/specs/ui-modals/spec.md#REQ-004
+	 */
 	mounted() {
 		// Assuming klantStore.auditTrailItem is a single audit trail object
 		this.auditTrail = klantStore.auditTrailItem || {}
 	},
 	methods: {
+		/**
+		 * @spec openspec/specs/ui-modals/spec.md#REQ-004
+		 */
 		closeDialog() {
 			navigationStore.setModal(null)
 			klantStore.setAuditTrailItem(null)

--- a/src/modals/resultaten/DeleteResultaat.vue
+++ b/src/modals/resultaten/DeleteResultaat.vue
@@ -84,10 +84,16 @@ export default {
 		zaakStore.refreshZakenList()
 	},
 	methods: {
+		/**
+		 * @spec openspec/specs/ui-modals/spec.md#REQ-004
+		 */
 		closeDialog() {
 			navigationStore.setModal(null)
 			clearTimeout(this.closeModalTimeout)
 		},
+		/**
+		 * @spec openspec/specs/ui-modals/spec.md#REQ-003
+		 */
 		async deleteResultaat() {
 			this.loading = true
 

--- a/src/modals/resultaten/ResultaatForm.vue
+++ b/src/modals/resultaten/ResultaatForm.vue
@@ -112,6 +112,9 @@ export default {
 			},
 		}
 	},
+	/**
+	 * @spec openspec/specs/ui-modals/spec.md#REQ-004
+	 */
 	mounted() {
 		// If zaakItem in the store is set. apply it to zaak in this modal.
 		if (resultaatStore.resultaatItem?.id) {
@@ -125,11 +128,17 @@ export default {
 		this.fetchZaak()
 	},
 	methods: {
+		/**
+		 * @spec openspec/specs/ui-modals/spec.md#REQ-001
+		 */
 		closeModal() {
 			navigationStore.setModal(null)
 			resultaatStore.zaakId = null
 			this.dashboardWidget && this.$emit('close-modal')
 		},
+		/**
+		 * @spec openspec/specs/ui-modals/spec.md#REQ-005
+		 */
 		fetchZaak() {
 			this.zaakLoading = true
 
@@ -159,6 +168,9 @@ export default {
 					this.zaakLoading = false
 				})
 		},
+		/**
+		 * @spec openspec/specs/ui-modals/spec.md#REQ-003
+		 */
 		saveResultaat() {
 			this.loading = true
 

--- a/src/modals/rollen/DeleteRol.vue
+++ b/src/modals/rollen/DeleteRol.vue
@@ -73,10 +73,16 @@ export default {
 		}
 	},
 	methods: {
+		/**
+		 * @spec openspec/specs/ui-modals/spec.md#REQ-004
+		 */
 		closeDialog() {
 			navigationStore.setModal(null)
 			clearTimeout(this.closeModalTimeout)
 		},
+		/**
+		 * @spec openspec/specs/ui-modals/spec.md#REQ-003
+		 */
 		async deleteRol() {
 			this.loading = true
 

--- a/src/modals/rollen/RolForm.vue
+++ b/src/modals/rollen/RolForm.vue
@@ -164,6 +164,9 @@ export default {
 			IS_EDIT: false,
 		}
 	},
+	/**
+	 * @spec openspec/specs/ui-modals/spec.md#REQ-004
+	 */
 	mounted() {
 		this.IS_EDIT = !!rolStore.rolItem?.id
 
@@ -180,11 +183,17 @@ export default {
 		this.fetchZaak(rolStore.rolItem?.zaak || this.zaakId)
 	},
 	methods: {
+		/**
+		 * @spec openspec/specs/ui-modals/spec.md#REQ-001
+		 */
 		closeModal() {
 			navigationStore.setModal(null)
 			rolStore.setZaakId(null)
 			delete rolStore.extraData?.redirect
 		},
+		/**
+		 * @spec openspec/specs/ui-modals/spec.md#REQ-005
+		 */
 		fetchData(id) {
 			this.rolLoading = true
 
@@ -201,6 +210,9 @@ export default {
 					this.rolLoading = false
 				})
 		},
+		/**
+		 * @spec openspec/specs/ui-modals/spec.md#REQ-005
+		 */
 		fetchZaak(zaakId) {
 			this.zaakOptionsLoading = true
 
@@ -224,6 +236,9 @@ export default {
 					this.zaakOptionsLoading = false
 				})
 		},
+		/**
+		 * @spec openspec/specs/ui-modals/spec.md#REQ-003
+		 */
 		editRol() {
 			this.loading = true
 

--- a/src/modals/taken/EditTaak.vue
+++ b/src/modals/taken/EditTaak.vue
@@ -349,16 +349,25 @@ export default {
 			isContactMomentFormOpen: false,
 		}
 	},
+	/**
+	 * @spec openspec/specs/ui-modals/spec.md#REQ-004
+	 */
 	mounted() {
 		this.fetchData()
 		this.fetchMedewerkers()
 	},
 	methods: {
+		/**
+		 * @spec openspec/specs/ui-modals/spec.md#REQ-001
+		 */
 		closeModalFromButton() {
 			setTimeout(() => {
 				this.closeModal()
 			}, 300)
 		},
+		/**
+		 * @spec openspec/specs/ui-modals/spec.md#REQ-001
+		 */
 		closeModal() {
 			navigationStore.setModal(null)
 
@@ -366,6 +375,9 @@ export default {
 				this.$emit('close-modal')
 			}
 		},
+		/**
+		 * @spec openspec/specs/ui-modals/spec.md#REQ-005
+		 */
 		async fetchData() {
 			let taakEntity
 
@@ -405,6 +417,8 @@ export default {
 		/**
 		 * @param {string} klantId - Optional ID of the klant to select. Will take precedence over the ID present in `taakStore.taakItem`.
 		 *                           If none are provided the default selected klant will be `null`.
+		  *
+		  * @spec openspec/specs/ui-modals/spec.md#REQ-005
 		 */
 		fetchKlanten(klantId = null) {
 			this.klantenLoading = true
@@ -443,6 +457,9 @@ export default {
 					this.klantenLoading = false
 				})
 		},
+		/**
+		 * @spec openspec/specs/ui-modals/spec.md#REQ-005
+		 */
 		fetchContactMomentItems() {
 			this.loading = true
 
@@ -470,6 +487,9 @@ export default {
 					this.loading = false
 				})
 		},
+		/**
+		 * @spec openspec/specs/ui-modals/spec.md#REQ-004
+		 */
 
 		viewContactMoment(id) {
 			this.isContactMomentFormOpen = true
@@ -477,12 +497,18 @@ export default {
 			this.viewContactMomentId = id
 			navigationStore.setViewModal('viewContactMoment')
 		},
+		/**
+		 * @spec openspec/specs/ui-modals/spec.md#REQ-004
+		 */
 
 		closeViewContactMomentModal() {
 			this.isContactMomentFormOpen = false
 			navigationStore.setViewModal(null)
 		},
 		// === ICONS ===
+		/**
+		 * @spec openspec/specs/ui-modals/spec.md#REQ-005
+		 */
 		getItemIcon() {
 			const theme = getTheme()
 
@@ -497,6 +523,8 @@ export default {
 		/**
 		 * @param {string} medewerkerId - Optional ID of the medewerker to select. Will take precedence over the ID present in `taakStore.taakItem`.
 		 *                                If none are provided the default selected medewerker will be `null`.
+		  *
+		  * @spec openspec/specs/ui-modals/spec.md#REQ-005
 		 */
 		fetchMedewerkers(medewerkerId = null) {
 			fetch('/ocs/v1.php/cloud/users/details', {
@@ -536,6 +564,9 @@ export default {
 			})
 
 		},
+		/**
+		 * @spec openspec/specs/ui-modals/spec.md#REQ-003
+		 */
 		async editTaak() {
 			this.loading = true
 
@@ -577,6 +608,9 @@ export default {
 					this.loading = false
 				})
 		},
+		/**
+		 * @spec openspec/specs/ui-modals/spec.md#REQ-004
+		 */
 		openLink(url, target) {
 			window.open(url, target)
 		},

--- a/src/modals/taken/ViewTaakAuditTrail.vue
+++ b/src/modals/taken/ViewTaakAuditTrail.vue
@@ -58,11 +58,17 @@ export default {
 			auditTrail: {}, // Initialize with an empty object
 		}
 	},
+	/**
+	 * @spec openspec/specs/ui-modals/spec.md#REQ-004
+	 */
 	mounted() {
 		// Assuming taakStore.auditTrailItem is a single audit trail object
 		this.auditTrail = taakStore.auditTrailItem || {}
 	},
 	methods: {
+		/**
+		 * @spec openspec/specs/ui-modals/spec.md#REQ-004
+		 */
 		closeDialog() {
 			navigationStore.setModal(null)
 			taakStore.setAuditTrailItem(null)

--- a/src/modals/zaakTypen/DeleteZaaktype.vue
+++ b/src/modals/zaakTypen/DeleteZaaktype.vue
@@ -73,10 +73,16 @@ export default {
 		}
 	},
 	methods: {
+		/**
+		 * @spec openspec/specs/ui-modals/spec.md#REQ-004
+		 */
 		closeDialog() {
 			navigationStore.setModal(null)
 			clearTimeout(this.closeModalTimeout)
 		},
+		/**
+		 * @spec openspec/specs/ui-modals/spec.md#REQ-003
+		 */
 		async deleteZaakType() {
 			this.loading = true
 

--- a/src/modals/zaakTypen/ZaaktypeForm.vue
+++ b/src/modals/zaakTypen/ZaaktypeForm.vue
@@ -191,12 +191,18 @@ export default {
 			closeModalTimeout: null,
 		}
 	},
+	/**
+	 * @spec openspec/specs/ui-modals/spec.md#REQ-004
+	 */
 	mounted() {
 		if (zaakTypeStore.zaakTypeItem?.id) {
 			this.initZaaktype()
 		}
 	},
 	methods: {
+		/**
+		 * @spec openspec/specs/ui-modals/spec.md#REQ-004
+		 */
 		initZaaktype() {
 			this.zaaktype = {
 				...this.zaaktype,
@@ -206,10 +212,16 @@ export default {
 			const selectedArchiefStatus = this.archiefstatus.options.find((options) => options.id === this.zaaktype.archiefstatus)
 			this.archiefstatus.value = selectedArchiefStatus || null
 		},
+		/**
+		 * @spec openspec/specs/ui-modals/spec.md#REQ-001
+		 */
 		closeModal() {
 			navigationStore.setModal(null)
 			clearTimeout(this.closeModalTimeout)
 		},
+		/**
+		 * @spec openspec/specs/ui-modals/spec.md#REQ-003
+		 */
 		saveZaakType() {
 			this.loading = true
 

--- a/src/modals/zaken/AddBerichtToZaak.vue
+++ b/src/modals/zaken/AddBerichtToZaak.vue
@@ -69,14 +69,23 @@ export default {
 			hasUpdated: false,
 		}
 	},
+	/**
+	 * @spec openspec/specs/ui-modals/spec.md#REQ-004
+	 */
 	mounted() {
 		this.zaakItem = zaakStore.zaakItem
 		this.fetchBerichtenData()
 	},
 	methods: {
+		/**
+		 * @spec openspec/specs/ui-modals/spec.md#REQ-001
+		 */
 		closeModal() {
 			navigationStore.setModal(false)
 		},
+		/**
+		 * @spec openspec/specs/ui-modals/spec.md#REQ-005
+		 */
 		fetchBerichtenData() {
 			this.berichtenLoading = true
 
@@ -98,6 +107,9 @@ export default {
 					this.berichtenLoading = false
 				})
 		},
+		/**
+		 * @spec openspec/specs/ui-modals/spec.md#REQ-004
+		 */
 		addBerichtToZaak() {
 			this.loading = true
 			this.error = false
@@ -118,6 +130,9 @@ export default {
 
 					// Wait for the user to read the feedback then close the model
 					const self = this
+					/**
+					 * @spec openspec/specs/ui-modals/spec.md#REQ-002
+					 */
 					setTimeout(function() {
 						self.success = null
 						self.closeModal()

--- a/src/modals/zaken/AddRolToZaak.vue
+++ b/src/modals/zaken/AddRolToZaak.vue
@@ -73,9 +73,15 @@ export default {
 		this.fetchRollenData()
 	},
 	methods: {
+		/**
+		 * @spec openspec/specs/ui-modals/spec.md#REQ-001
+		 */
 		closeModal() {
 			navigationStore.setModal(false)
 		},
+		/**
+		 * @spec openspec/specs/ui-modals/spec.md#REQ-005
+		 */
 		fetchRollenData() {
 			this.rollenLoading = true
 
@@ -98,6 +104,9 @@ export default {
 					this.rollenLoading = false
 				})
 		},
+		/**
+		 * @spec openspec/specs/ui-modals/spec.md#REQ-004
+		 */
 		addRolToZaak() {
 			this.loading = true
 			this.error = false
@@ -121,6 +130,9 @@ export default {
 
 					// Wait for the user to read the feedback then close the model
 					const self = this
+					/**
+					 * @spec openspec/specs/ui-modals/spec.md#REQ-002
+					 */
 					setTimeout(function() {
 						self.success = null
 						self.closeModal()

--- a/src/modals/zaken/AddTaakToZaak.vue
+++ b/src/modals/zaken/AddTaakToZaak.vue
@@ -69,14 +69,23 @@ export default {
 			hasUpdated: false,
 		}
 	},
+	/**
+	 * @spec openspec/specs/ui-modals/spec.md#REQ-004
+	 */
 	mounted() {
 		this.zaakItem = zaakStore.zaakItem
 		this.fetchTakenData()
 	},
 	methods: {
+		/**
+		 * @spec openspec/specs/ui-modals/spec.md#REQ-001
+		 */
 		closeModal() {
 			navigationStore.setModal(false)
 		},
+		/**
+		 * @spec openspec/specs/ui-modals/spec.md#REQ-005
+		 */
 		fetchTakenData() {
 			this.takenLoading = true
 
@@ -99,6 +108,9 @@ export default {
 					this.takenLoading = false
 				})
 		},
+		/**
+		 * @spec openspec/specs/ui-modals/spec.md#REQ-004
+		 */
 		addTaakToZaak() {
 			this.loading = true
 			this.error = false
@@ -122,6 +134,9 @@ export default {
 
 					// Wait for the user to read the feedback then close the model
 					const self = this
+					/**
+					 * @spec openspec/specs/ui-modals/spec.md#REQ-002
+					 */
 					setTimeout(function() {
 						self.success = null
 						self.closeModal()

--- a/src/modals/zaken/ViewZaakAuditTrail.vue
+++ b/src/modals/zaken/ViewZaakAuditTrail.vue
@@ -71,15 +71,24 @@ export default {
 			auditTrail: {}, // Initialize with an empty object
 		}
 	},
+	/**
+	 * @spec openspec/specs/ui-modals/spec.md#REQ-004
+	 */
 	mounted() {
 		// Assuming zaakStore.auditTrailItem is a single audit trail object
 		this.auditTrail = zaakStore.auditTrailItem || {}
 	},
 	methods: {
+		/**
+		 * @spec openspec/specs/ui-modals/spec.md#REQ-004
+		 */
 		closeDialog() {
 			navigationStore.setModal(null)
 			zaakStore.setAuditTrailItem(null)
 		},
+		/**
+		 * @spec openspec/specs/ui-modals/spec.md#REQ-004
+		 */
 		formatValue(value) {
 			if (value === null || value === undefined) {
 				return 'N/A' // Handle null or undefined

--- a/src/modals/zaken/WidgetZaakForm.vue
+++ b/src/modals/zaken/WidgetZaakForm.vue
@@ -171,6 +171,9 @@ export default {
 			},
 		}
 	},
+	/**
+	 * @spec openspec/specs/ui-modals/spec.md#REQ-004
+	 */
 	mounted() {
 		this.setArchiefStatusOptions()
 		// this.fetchZaakType()
@@ -185,6 +188,9 @@ export default {
 		}
 	},
 	methods: {
+		/**
+		 * @spec openspec/specs/ui-modals/spec.md#REQ-001
+		 */
 		closeModal() {
 			this?.dashboardWidget && this.$emit('close')
 			this.success = null
@@ -208,6 +214,9 @@ export default {
 				this.$emit('close-modal')
 			}
 		},
+		/**
+		 * @spec openspec/specs/ui-modals/spec.md#REQ-005
+		 */
 		fetchKlanten() {
 			this.klantenLoading = true
 
@@ -238,6 +247,9 @@ export default {
 					this.klantenLoading = false
 				})
 		},
+		/**
+		 * @spec openspec/specs/ui-modals/spec.md#REQ-005
+		 */
 		fetchZaakType() {
 			this.zaakTypeLoading = true
 
@@ -265,6 +277,9 @@ export default {
 					this.zaakTypeLoading = false
 				})
 		},
+		/**
+		 * @spec openspec/specs/ui-modals/spec.md#REQ-002
+		 */
 		setArchiefStatusOptions() {
 			const selectedArchiefStatusOption = this.archiefstatus.options.find((options) => options.id === this.zaak.archiefstatus)
 
@@ -275,6 +290,9 @@ export default {
 				}
 			}
 		},
+		/**
+		 * @spec openspec/specs/ui-modals/spec.md#REQ-003
+		 */
 		saveZaak() {
 			this.loading = true
 

--- a/src/modals/zaken/ZaakForm.vue
+++ b/src/modals/zaken/ZaakForm.vue
@@ -176,6 +176,9 @@ export default {
 			},
 		}
 	},
+	/**
+	 * @spec openspec/specs/ui-modals/spec.md#REQ-004
+	 */
 	mounted() {
 		this.setArchiefStatusOptions()
 		this.fetchZaakType()
@@ -190,10 +193,16 @@ export default {
 		}
 	},
 	methods: {
+		/**
+		 * @spec openspec/specs/ui-modals/spec.md#REQ-001
+		 */
 		closeModal() {
 			navigationStore.setModal(null)
 			this?.dashboardWidget && this.$emit('close-modal')
 		},
+		/**
+		 * @spec openspec/specs/ui-modals/spec.md#REQ-005
+		 */
 		fetchZaakType() {
 			this.zaakTypeLoading = true
 
@@ -221,6 +230,9 @@ export default {
 					this.zaakTypeLoading = false
 				})
 		},
+		/**
+		 * @spec openspec/specs/ui-modals/spec.md#REQ-002
+		 */
 		setArchiefStatusOptions() {
 			const selectedArchiefStatusOption = this.archiefstatus.options.find((options) => options.id === this.zaak.archiefstatus)
 
@@ -231,6 +243,9 @@ export default {
 				}
 			}
 		},
+		/**
+		 * @spec openspec/specs/ui-modals/spec.md#REQ-003
+		 */
 		saveZaak() {
 			this.loading = true
 

--- a/src/navigation/Configuration.vue
+++ b/src/navigation/Configuration.vue
@@ -444,6 +444,9 @@ export default {
 	},
 	methods: {
 		// We use the catalogi in the menu so lets fetch those
+		/**
+		 * @spec openspec/specs/ui-search-navigation/spec.md#REQ-002
+		 */
 		fetchData(newPage) {
 			this.loading = true
 			fetch(
@@ -463,6 +466,9 @@ export default {
 					this.loading = false
 				})
 		},
+		/**
+		 * @spec openspec/specs/ui-search-navigation/spec.md#REQ-002
+		 */
 		saveConfig() {
 			// Simple POST request with a JSON body using fetch
 			const requestOptions = {

--- a/src/services/getTheme.js
+++ b/src/services/getTheme.js
@@ -8,6 +8,8 @@
  * accordingly. If neither attribute is present, it defaults to 'dark'.
  *
  * @return { 'light' | 'dark' } The current theme, either 'light' or 'dark'.
+  *
+  * @spec openspec/specs/ui-search-navigation/spec.md#REQ-004
  */
 export const getTheme = () => {
 	if (document.body.hasAttribute('data-theme-light')) {

--- a/src/services/getValidISOstring.js
+++ b/src/services/getValidISOstring.js
@@ -8,6 +8,8 @@
  *
  * @param { string | Date } dateString The date string or Date object to be converted.
  * @return { string | null } The ISO string representation of the date or null.
+  *
+  * @spec openspec/specs/ui-search-navigation/spec.md#REQ-004
  */
 export default function getValidISOstring(dateString) {
 	const date = new Date(dateString)

--- a/src/services/icons/icon/icon-briefcase-account-outline.js
+++ b/src/services/icons/icon/icon-briefcase-account-outline.js
@@ -5,6 +5,8 @@ import { getTheme } from '../../getTheme.js'
  *
  * this class name can be put into a component that accepts an 'icon' prop
  * @return {string}
+  *
+  * @spec openspec/specs/ui-search-navigation/spec.md#REQ-005
  */
 export function iconBriefcaseAccountOutline() {
 	const theme = getTheme()

--- a/src/services/icons/icon/icon-calendar-check-outline.js
+++ b/src/services/icons/icon/icon-calendar-check-outline.js
@@ -5,6 +5,8 @@ import { getTheme } from '../../getTheme.js'
  *
  * this class name can be put into a component that accepts an 'icon' prop
  * @return {string}
+  *
+  * @spec openspec/specs/ui-search-navigation/spec.md#REQ-005
  */
 export function iconCalendarCheckOutline() {
 	const theme = getTheme()

--- a/src/services/icons/icon/icon-calendar-month-outline.js
+++ b/src/services/icons/icon/icon-calendar-month-outline.js
@@ -5,6 +5,8 @@ import { getTheme } from '../../getTheme.js'
  *
  * this class name can be put into a component that accepts an 'icon' prop
  * @return {string}
+  *
+  * @spec openspec/specs/ui-search-navigation/spec.md#REQ-005
  */
 export function iconCalendarMonthOutline() {
 	const theme = getTheme()

--- a/src/services/icons/icon/icon-card-account-phone-outline.js
+++ b/src/services/icons/icon/icon-card-account-phone-outline.js
@@ -5,6 +5,8 @@ import { getTheme } from '../../getTheme.js'
  *
  * this class name can be put into a component that accepts an 'icon' prop
  * @return {string}
+  *
+  * @spec openspec/specs/ui-search-navigation/spec.md#REQ-005
  */
 export function iconCardAccountPhoneOutline() {
 	const theme = getTheme()

--- a/src/services/icons/icon/icon-pencil.js
+++ b/src/services/icons/icon/icon-pencil.js
@@ -5,6 +5,8 @@ import { getTheme } from '../../getTheme.js'
  *
  * this class name can be put into a component that accepts an 'icon' prop
  * @return {string}
+  *
+  * @spec openspec/specs/ui-search-navigation/spec.md#REQ-005
  */
 export function iconPencil() {
 	const theme = getTheme()

--- a/src/services/icons/icon/icon-progress-close.js
+++ b/src/services/icons/icon/icon-progress-close.js
@@ -5,6 +5,8 @@ import { getTheme } from '../../getTheme.js'
  *
  * this class name can be put into a component that accepts an 'icon' prop
  * @return {string}
+  *
+  * @spec openspec/specs/ui-search-navigation/spec.md#REQ-005
  */
 export function iconProgressClose() {
 	const theme = getTheme()

--- a/src/sidebars/search/SearchSideBar.vue
+++ b/src/sidebars/search/SearchSideBar.vue
@@ -265,15 +265,27 @@ export default {
 		}
 	},
 	watch: {
+		/**
+		 * @spec openspec/specs/ui-search-navigation/spec.md#REQ-001
+		 */
 		klantenSearch() {
 			this.debouncedFetchKlanten()
 		},
+		/**
+		 * @spec openspec/specs/ui-search-navigation/spec.md#REQ-001
+		 */
 		personenSearch() {
 			this.debouncedFetchKlanten()
 		},
+		/**
+		 * @spec openspec/specs/ui-search-navigation/spec.md#REQ-001
+		 */
 		organisatiesSearch() {
 			this.debouncedFetchKlanten()
 		},
+		/**
+		 * @spec openspec/specs/ui-search-navigation/spec.md#REQ-001
+		 */
 		activeTab() {
 			this.fetchKlanten()
 		},
@@ -281,11 +293,17 @@ export default {
 	mounted() {
 		this.fetchKlanten()
 	},
+	/**
+	 * @spec openspec/specs/ui-search-navigation/spec.md#REQ-001
+	 */
 	created() {
 		// Initialize the debounced function
 		this.debouncedFetchKlanten = this.debounce(() => this.fetchKlanten(), 100)
 	},
 	methods: {
+		/**
+		 * @spec openspec/specs/ui-search-navigation/spec.md#REQ-001
+		 */
 		debounce(func, timeout = 300) {
 			let timer
 			return (...args) => {
@@ -293,6 +311,9 @@ export default {
 				timer = setTimeout(() => { func.apply(this, args) }, timeout)
 			}
 		},
+		/**
+		 * @spec openspec/specs/ui-search-navigation/spec.md#REQ-001
+		 */
 		getName(klant) {
 			if (klant.type === 'persoon') {
 				return klant?.voornaam ?? 'onbekend'
@@ -302,6 +323,9 @@ export default {
 			}
 			return 'onbekend'
 		},
+		/**
+		 * @spec openspec/specs/ui-search-navigation/spec.md#REQ-001
+		 */
 		getSubname(klant) {
 			if (klant.type === 'persoon') {
 				return klant?.tussenvoegsel ? `${klant.tussenvoegsel} ${klant.achternaam}` : klant?.achternaam ? `${klant.achternaam}` : 'onbekend'
@@ -311,6 +335,9 @@ export default {
 			}
 			return 'onbekend'
 		},
+		/**
+		 * @spec openspec/specs/ui-search-navigation/spec.md#REQ-001
+		 */
 		fetchKlanten() {
 			this.loading = true
 			let activeFilter = null

--- a/src/store/modules/berichten.js
+++ b/src/store/modules/berichten.js
@@ -12,10 +12,16 @@ export const useBerichtStore = defineStore('berichten', {
 		auditTrailItem: null,
 	}),
 	actions: {
+		/**
+		 * @spec openspec/specs/state-stores/spec.md#REQ-001
+		 */
 		setBerichtItem(berichtItem) {
 			this.berichtItem = berichtItem && new Bericht(berichtItem)
 			console.log('Active bericht item set to ' + berichtItem)
 		},
+		/**
+		 * @spec openspec/specs/state-stores/spec.md#REQ-001
+		 */
 		setBerichtenList(berichtenList) {
 			this.berichtenList = berichtenList.map(
 			    (berichtItem) => new Bericht(berichtItem),
@@ -26,6 +32,9 @@ export const useBerichtStore = defineStore('berichten', {
 			this.auditTrailItem = auditTrailItem
 		},
 		/* istanbul ignore next */ // ignore this for Jest until moved into a service
+		/**
+		 * @spec openspec/specs/state-stores/spec.md#REQ-002
+		 */
 		async refreshBerichtenList(search = null) {
 			let endpoint = apiEndpoint
 
@@ -50,6 +59,9 @@ export const useBerichtStore = defineStore('berichten', {
 			return { response, data, entities }
 		},
 		// New function to get a single bericht
+		/**
+		 * @spec openspec/specs/state-stores/spec.md#REQ-003
+		 */
 		async getBericht(id) {
 			const endpoint = `${apiEndpoint}/${id}`
 
@@ -70,6 +82,9 @@ export const useBerichtStore = defineStore('berichten', {
 			return { response, data, entity }
 		},
 		// Delete a bericht
+		/**
+		 * @spec openspec/specs/state-stores/spec.md#REQ-004
+		 */
 		async deleteBericht(berichtItem) {
 			if (!berichtItem.id) {
 				throw new Error('No bericht item to delete')
@@ -92,6 +107,9 @@ export const useBerichtStore = defineStore('berichten', {
 			return { response }
 		},
 		// Create or save a bericht from store
+		/**
+		 * @spec openspec/specs/state-stores/spec.md#REQ-004
+		 */
 		async saveBericht(berichtItem) {
 			if (!berichtItem) {
 				throw new Error('No bericht item to save')

--- a/src/store/modules/besluiten.ts
+++ b/src/store/modules/besluiten.ts
@@ -16,6 +16,9 @@ export const useBesluitStore = defineStore('besluiten', {
 		zaakId: null,
 	}),
 	actions: {
+		/**
+		 * @spec openspec/specs/state-stores/spec.md#REQ-001
+		 */
 		setBesluitItem(besluitItem: Besluit | TBesluit) {
 			this.besluitItem = besluitItem && new Besluit(besluitItem)
 			console.info('Active besluit item set to ' + besluitItem)

--- a/src/store/modules/contactmoment.ts
+++ b/src/store/modules/contactmoment.ts
@@ -15,6 +15,8 @@ export const useContactMomentStore = defineStore('contactmomenten', {
 		 * Set the active contact moment item.
 		 *
 		 * @param contactMomentItem - The contact moment item to set.
+		  *
+		  * @spec openspec/specs/state-stores/spec.md#REQ-001
 		 */
 		setContactMomentItem(contactMomentItem: TContactMoment | ContactMoment) {
 			this.contactMomentItem = contactMomentItem && new ContactMoment(contactMomentItem)
@@ -24,6 +26,8 @@ export const useContactMomentStore = defineStore('contactmomenten', {
 		 * Set the list of contact moments.
 		 *
 		 * @param contactMomentenList - The list of contact moments to set.
+		  *
+		  * @spec openspec/specs/state-stores/spec.md#REQ-001
 		 */
 		setContactMomentenList(contactMomentenList: TContactMoment[] | ContactMoment[]) {
 			this.contactMomentenList = contactMomentenList.map(

--- a/src/store/modules/documenten.ts
+++ b/src/store/modules/documenten.ts
@@ -20,10 +20,16 @@ export const useDocumentStore = defineStore('documenten', {
 		zaakId: null,
 	}),
 	actions: {
+		/**
+		 * @spec openspec/specs/state-stores/spec.md#REQ-001
+		 */
 		setDocumentItem(documentItem: Document | TDocument) {
 			this.documentItem = documentItem && new Document(documentItem)
 			console.info('Active document item set to ' + documentItem)
 		},
+		/**
+		 * @spec openspec/specs/state-stores/spec.md#REQ-001
+		 */
 		setDocumentenList(documentenList: Document[] | TDocument[]) {
 			this.documentenList = documentenList.map(
 			    (documentItem) => new Document(documentItem),

--- a/src/store/modules/klanten.js
+++ b/src/store/modules/klanten.js
@@ -13,14 +13,23 @@ export const useKlantStore = defineStore('klanten', {
 		auditTrailItem: null,
 	}),
 	actions: {
+		/**
+		 * @spec openspec/specs/state-stores/spec.md#REQ-001
+		 */
 		setKlantItem(klantItem) {
 			this.klantItem = klantItem && new Klant(klantItem)
 			console.log('Active klant item set to ' + klantItem)
 		},
+		/**
+		 * @spec openspec/specs/state-stores/spec.md#REQ-001
+		 */
 		setWidgetKlantId(widgetKlantId) {
 			this.widgetKlantId = widgetKlantId
 			console.log('Widget klant id set to ' + widgetKlantId)
 		},
+		/**
+		 * @spec openspec/specs/state-stores/spec.md#REQ-001
+		 */
 		setKlantenList(klantenList) {
 			this.klantenList = klantenList.map(
 			    (klantItem) => new Klant(klantItem),
@@ -31,6 +40,9 @@ export const useKlantStore = defineStore('klanten', {
 			this.auditTrailItem = auditTrailItem
 		},
 		/* istanbul ignore next */ // ignore this for Jest until moved into a service
+		/**
+		 * @spec openspec/specs/state-stores/spec.md#REQ-002
+		 */
 		async refreshKlantenList(search = null) {
 			let endpoint = apiEndpoint
 
@@ -54,6 +66,9 @@ export const useKlantStore = defineStore('klanten', {
 
 			return { response, data, entities }
 		},
+		/**
+		 * @spec openspec/specs/state-stores/spec.md#REQ-002
+		 */
 
 		async searchKlanten(queryParams = null) {
 			let endpoint = apiEndpoint
@@ -78,6 +93,9 @@ export const useKlantStore = defineStore('klanten', {
 
 			return { response, data, entities }
 		},
+		/**
+		 * @spec openspec/specs/state-stores/spec.md#REQ-002
+		 */
 
 		async searchPersons(search = null) {
 			let endpoint = apiEndpoint
@@ -104,6 +122,9 @@ export const useKlantStore = defineStore('klanten', {
 
 			return { response, data, entities }
 		},
+		/**
+		 * @spec openspec/specs/state-stores/spec.md#REQ-002
+		 */
 
 		async searchOrganisations(search = null) {
 			let endpoint = apiEndpoint
@@ -132,6 +153,9 @@ export const useKlantStore = defineStore('klanten', {
 		},
 
 		// New function to get a single klant
+		/**
+		 * @spec openspec/specs/state-stores/spec.md#REQ-003
+		 */
 		async getKlant(id) {
 			const endpoint = `${apiEndpoint}/${id}`
 
@@ -152,6 +176,9 @@ export const useKlantStore = defineStore('klanten', {
 			return { response, data, entity }
 		},
 		// Delete a klant
+		/**
+		 * @spec openspec/specs/state-stores/spec.md#REQ-004
+		 */
 		async deleteKlant(klantItem) {
 			if (!klantItem.id) {
 				throw new Error('No klant item to delete')
@@ -174,6 +201,9 @@ export const useKlantStore = defineStore('klanten', {
 			return { response }
 		},
 		// Create or save a klant from store
+		/**
+		 * @spec openspec/specs/state-stores/spec.md#REQ-004
+		 */
 		async saveKlant(klantItem) {
 			if (!klantItem) {
 				throw new Error('No klant item to save')

--- a/src/store/modules/medewerkers.js
+++ b/src/store/modules/medewerkers.js
@@ -13,14 +13,23 @@ export const useMedewerkerStore = defineStore('medewerkers', {
 		auditTrailItem: null,
 	}),
 	actions: {
+		/**
+		 * @spec openspec/specs/state-stores/spec.md#REQ-001
+		 */
 		setMedewerkerItem(medewerkerItem) {
 			this.medewerkerItem = medewerkerItem && new Medewerker(medewerkerItem)
 			console.log('Active medewerker item set to ' + medewerkerItem)
 		},
+		/**
+		 * @spec openspec/specs/state-stores/spec.md#REQ-001
+		 */
 		setWidgetMedewerkerId(widgetMedewerkerId) {
 			this.widgetMedewerkerId = widgetMedewerkerId
 			console.log('Widget medewerker id set to ' + widgetMedewerkerId)
 		},
+		/**
+		 * @spec openspec/specs/state-stores/spec.md#REQ-001
+		 */
 		setMedewerkersList(medewerkersList) {
 			this.medewerkersList = medewerkersList.map(
 			    (medewerkerItem) => new Medewerker(medewerkerItem),
@@ -31,6 +40,9 @@ export const useMedewerkerStore = defineStore('medewerkers', {
 			this.auditTrailItem = auditTrailItem
 		},
 		/* istanbul ignore next */ // ignore this for Jest until moved into a service
+		/**
+		 * @spec openspec/specs/state-stores/spec.md#REQ-002
+		 */
 		async refreshMedewerkersList(search = null) {
 			let endpoint = apiEndpoint
 
@@ -54,6 +66,9 @@ export const useMedewerkerStore = defineStore('medewerkers', {
 
 			return { response, data, entities }
 		},
+		/**
+		 * @spec openspec/specs/state-stores/spec.md#REQ-002
+		 */
 
 		async searchMedewerkers(queryParams = null) {
 			let endpoint = apiEndpoint
@@ -78,6 +93,9 @@ export const useMedewerkerStore = defineStore('medewerkers', {
 
 			return { response, data, entities }
 		},
+		/**
+		 * @spec openspec/specs/state-stores/spec.md#REQ-002
+		 */
 
 		async searchPersons(search = null) {
 			let endpoint = apiEndpoint
@@ -104,6 +122,9 @@ export const useMedewerkerStore = defineStore('medewerkers', {
 
 			return { response, data, entities }
 		},
+		/**
+		 * @spec openspec/specs/state-stores/spec.md#REQ-002
+		 */
 
 		async searchOrganisations(search = null) {
 			let endpoint = apiEndpoint
@@ -132,6 +153,9 @@ export const useMedewerkerStore = defineStore('medewerkers', {
 		},
 
 		// New function to get a single medewerker
+		/**
+		 * @spec openspec/specs/state-stores/spec.md#REQ-003
+		 */
 		async getMedewerker(id) {
 			const endpoint = `${apiEndpoint}/${id}`
 
@@ -152,6 +176,9 @@ export const useMedewerkerStore = defineStore('medewerkers', {
 			return { response, data, entity }
 		},
 		// Delete a medewerker
+		/**
+		 * @spec openspec/specs/state-stores/spec.md#REQ-004
+		 */
 		async deleteMedewerker(medewerkerItem) {
 			if (!medewerkerItem.id) {
 				throw new Error('No medewerker item to delete')
@@ -174,6 +201,9 @@ export const useMedewerkerStore = defineStore('medewerkers', {
 			return { response }
 		},
 		// Create or save a medewerker from store
+		/**
+		 * @spec openspec/specs/state-stores/spec.md#REQ-004
+		 */
 		async saveMedewerker(medewerkerItem) {
 			if (!medewerkerItem) {
 				throw new Error('No medewerker item to save')

--- a/src/store/modules/navigation.ts
+++ b/src/store/modules/navigation.ts
@@ -20,14 +20,23 @@ export const useNavigationStore = defineStore('ui', {
 		transferData: null,
 	} as NavigationStoreState),
 	actions: {
+		/**
+		 * @spec openspec/specs/state-stores/spec.md#REQ-005
+		 */
 		setModal(modal: NavigationStoreState['modal']) {
 			this.modal = modal
 			console.log('Active modal set to ' + modal)
 		},
+		/**
+		 * @spec openspec/specs/state-stores/spec.md#REQ-005
+		 */
 		setViewModal(viewModal: NavigationStoreState['viewModal']) {
 			this.viewModal = viewModal
 			console.log('Active view modal set to ' + viewModal)
 		},
+		/**
+		 * @spec openspec/specs/state-stores/spec.md#REQ-005
+		 */
 		setDialog(dialog: NavigationStoreState['dialog']) {
 			this.dialog = dialog
 			console.log('Active dialog set to ' + dialog)

--- a/src/store/modules/resultaten.ts
+++ b/src/store/modules/resultaten.ts
@@ -20,10 +20,16 @@ export const useResultaatStore = defineStore('resultaten', {
 		zaakId: null,
 	}),
 	actions: {
+		/**
+		 * @spec openspec/specs/state-stores/spec.md#REQ-001
+		 */
 		setResultaatItem(resultaatItem: Resultaat | TResultaat) {
 			this.resultaatItem = resultaatItem && new Resultaat(resultaatItem)
 			console.info('Active resultaat item set to ' + resultaatItem)
 		},
+		/**
+		 * @spec openspec/specs/state-stores/spec.md#REQ-001
+		 */
 		setResultatenList(resultatenList: Resultaat[] | TResultaat[]) {
 			this.resultatenList = resultatenList.map(
 			    (resultaatItem) => new Resultaat(resultaatItem),

--- a/src/store/modules/rol.ts
+++ b/src/store/modules/rol.ts
@@ -36,10 +36,16 @@ export const useRolStore = defineStore('rollen', {
 		extraData: {} as Record<string, any>,
 	}),
 	actions: {
+		/**
+		 * @spec openspec/specs/state-stores/spec.md#REQ-001
+		 */
 		setRolItem(rolItem: Rol | TRol) {
 			this.rolItem = rolItem && new Rol(rolItem)
 			console.info('Active rol item set to ' + rolItem)
 		},
+		/**
+		 * @spec openspec/specs/state-stores/spec.md#REQ-001
+		 */
 		setRollenList(rollenList: Rol[] | TRol[]) {
 			this.rollenList = rollenList.map(
 			    (rolItem) => new Rol(rolItem),

--- a/src/store/modules/search.ts
+++ b/src/store/modules/search.ts
@@ -10,15 +10,24 @@ export const useSearchStore = defineStore('search', {
 		searchError: '',
 	}),
 	actions: {
+		/**
+		 * @spec openspec/specs/state-stores/spec.md#REQ-005
+		 */
 		setSearch(search: string) {
 			this.search = search
 			console.log('Active search set to ' + search)
 		},
+		/**
+		 * @spec openspec/specs/state-stores/spec.md#REQ-005
+		 */
 		setSearchResults(searchResults: string[]) {
 			this.searchResults = searchResults
 			console.log('Active search set to ' + searchResults)
 		},
 		/* istanbul ignore next */ // ignore this for Jest until moved into a service
+		/**
+		 * @spec openspec/specs/state-stores/spec.md#REQ-005
+		 */
 		getSearchResults() {
 			const enabledPublicationTypeIds = Object.entries(this.publicationType)
 				// eslint-disable-next-line @typescript-eslint/no-unused-vars
@@ -61,6 +70,9 @@ export const useSearchStore = defineStore('search', {
 					},
 				)
 		},
+		/**
+		 * @spec openspec/specs/state-stores/spec.md#REQ-005
+		 */
 		clearSearch() {
 			this.search = ''
 			this.searchError = ''

--- a/src/store/modules/taak.js
+++ b/src/store/modules/taak.js
@@ -14,16 +14,25 @@ export const useTaakStore = defineStore('taken', {
 		widgetTaakId: null,
 	}),
 	actions: {
+		/**
+		 * @spec openspec/specs/state-stores/spec.md#REQ-001
+		 */
 		setTaakItem(taakItem) {
 			this.taakItem = taakItem && new Taak(taakItem)
 			console.log('Active taak item set to ' + taakItem)
 		},
+		/**
+		 * @spec openspec/specs/state-stores/spec.md#REQ-001
+		 */
 		setTakenList(takenList) {
 			this.takenList = takenList.map(
 				(taakItem) => new Taak(taakItem),
 			)
 			console.log('Taken list set to ' + takenList.length + ' items')
 		},
+		/**
+		 * @spec openspec/specs/state-stores/spec.md#REQ-001
+		 */
 		setTaakZaakId(taakZaakId) {
 			this.taakZaakId = taakZaakId
 			console.log('Active taak Zaak Id set to ' + taakZaakId)
@@ -31,11 +40,17 @@ export const useTaakStore = defineStore('taken', {
 		setAuditTrailItem(auditTrailItem) {
 			this.auditTrailItem = auditTrailItem
 		},
+		/**
+		 * @spec openspec/specs/state-stores/spec.md#REQ-001
+		 */
 		setWidgetTaakId(widgetTaakId) {
 			this.widgetTaakId = widgetTaakId
 			console.log('Active widget taak Id set to ' + widgetTaakId)
 		},
 		/* istanbul ignore next */ // ignore this for Jest until moved into a service
+		/**
+		 * @spec openspec/specs/state-stores/spec.md#REQ-002
+		 */
 		async refreshTakenList(search = null, notClosed = false, user = null) {
 			let endpoint = apiEndpoint
 
@@ -71,6 +86,9 @@ export const useTaakStore = defineStore('taken', {
 			return { response, data, entities }
 		},
 		// Function to get a single taak
+		/**
+		 * @spec openspec/specs/state-stores/spec.md#REQ-003
+		 */
 		async getTaak(id) {
 			const endpoint = `${apiEndpoint}/${id}`
 
@@ -91,6 +109,9 @@ export const useTaakStore = defineStore('taken', {
 			return { response, data, entity }
 		},
 		// Delete a taak
+		/**
+		 * @spec openspec/specs/state-stores/spec.md#REQ-004
+		 */
 		async deleteTaak(taakItem) {
 			if (!taakItem.id) {
 				throw new Error('No taak item to delete')
@@ -114,6 +135,9 @@ export const useTaakStore = defineStore('taken', {
 			return { response }
 		},
 		// Create or save a taak from store
+		/**
+		 * @spec openspec/specs/state-stores/spec.md#REQ-004
+		 */
 		async saveTaak(taakItem, options = { redirect: true }) {
 			if (!taakItem) {
 				throw new Error('No taak item to save')

--- a/src/store/modules/zaakTypen.ts
+++ b/src/store/modules/zaakTypen.ts
@@ -17,10 +17,16 @@ export const useZaakTypeStore = defineStore('zaakTypen', {
 		zaakTypeList: [],
 	}),
 	actions: {
+		/**
+		 * @spec openspec/specs/state-stores/spec.md#REQ-001
+		 */
 		setZaakTypeItem(zaakTypeItem: ZaakType | TZaakType) {
 			this.zaakTypeItem = zaakTypeItem && new ZaakType(zaakTypeItem)
 			console.info('Active zaaktype item set to ' + zaakTypeItem)
 		},
+		/**
+		 * @spec openspec/specs/state-stores/spec.md#REQ-001
+		 */
 		setZaakTypeList(zaakTypeList: ZaakType[] | TZaakType[]) {
 			this.zaakTypeList = zaakTypeList.map(
 			    (zaakTypeItem) => new ZaakType(zaakTypeItem),

--- a/src/store/modules/zaken.ts
+++ b/src/store/modules/zaken.ts
@@ -18,10 +18,16 @@ export const useZaakStore = defineStore('zaken', {
 		auditTrailItem: null,
 	}),
 	actions: {
+		/**
+		 * @spec openspec/specs/state-stores/spec.md#REQ-001
+		 */
 		setZaakItem(zaakItem: Zaak | TZaak) {
 			this.zaakItem = zaakItem && new Zaak(zaakItem)
 			console.info('Active zaak item set to ' + zaakItem)
 		},
+		/**
+		 * @spec openspec/specs/state-stores/spec.md#REQ-001
+		 */
 		setZakenList(zakenList: Zaak[] | TZaak[]) {
 			this.zakenList = zakenList.map(
 			    (zaakItem) => new Zaak(zaakItem),

--- a/src/store/store.js
+++ b/src/store/store.js
@@ -77,6 +77,8 @@ let initialized = false
  * resolution will live here.
  *
  * @return {Promise<ReturnType<typeof useObjectStore>>} The configured lib store.
+  *
+  * @spec openspec/specs/state-stores/spec.md#REQ-005
  */
 export async function initializeStores() {
 	const objectStore = useObjectStore(pinia)

--- a/src/views/berichten/BerichtDetails.vue
+++ b/src/views/berichten/BerichtDetails.vue
@@ -158,6 +158,9 @@ export default {
 		}
 	},
 	watch: {
+		/**
+		 * @spec openspec/specs/ui-client-views/spec.md#REQ-005
+		 */
 		id(newId) {
 			this.fetchData(newId)
 		},
@@ -166,6 +169,9 @@ export default {
 		this.fetchData(this.id)
 	},
 	methods: {
+		/**
+		 * @spec openspec/specs/ui-client-views/spec.md#REQ-001
+		 */
 		fetchData(id) {
 			this.loading = true
 
@@ -176,6 +182,9 @@ export default {
 
 			this.fetchAuditTrails(id)
 		},
+		/**
+		 * @spec openspec/specs/ui-client-views/spec.md#REQ-001
+		 */
 		fetchAuditTrails(id) {
 			fetch(`/index.php/apps/zaakafhandelapp/api/berichten/${id}/audit_trail`)
 				.then(response => response.json())

--- a/src/views/berichten/BerichtenList.vue
+++ b/src/views/berichten/BerichtenList.vue
@@ -112,23 +112,38 @@ export default {
 			berichtenList: [],
 		}
 	},
+	/**
+	 * @spec openspec/specs/ui-client-views/spec.md#REQ-005
+	 */
 	mounted() {
 		berichtStore.refreshBerichtenList().then(() => {
 			this.loading = false
 		})
 	},
 	methods: {
+		/**
+		 * @spec openspec/specs/ui-client-views/spec.md#REQ-004
+		 */
 		openBericht(bericht) {
 			berichtStore.setBerichtItem(bericht)
 			this.$router.push({ name: 'BerichtDetail', params: { id: bericht.id } })
 		},
+		/**
+		 * @spec openspec/specs/ui-client-views/spec.md#REQ-004
+		 */
 		editBericht(bericht) {
 			berichtStore.setBerichtItem(bericht)
 			navigationStore.setModal('editBericht')
 		},
+		/**
+		 * @spec openspec/specs/ui-client-views/spec.md#REQ-005
+		 */
 		storeBericht(bericht) {
 			berichtStore.setBerichtItem(bericht)
 		},
+		/**
+		 * @spec openspec/specs/ui-client-views/spec.md#REQ-001
+		 */
 		fetchData(newPage) {
 			this.loading = true
 			fetch(
@@ -148,6 +163,9 @@ export default {
 					this.loading = false
 				})
 		},
+		/**
+		 * @spec openspec/specs/ui-client-views/spec.md#REQ-003
+		 */
 		clearText() {
 			this.search = ''
 		},

--- a/src/views/berichten/ZaakBerichten.vue
+++ b/src/views/berichten/ZaakBerichten.vue
@@ -86,11 +86,17 @@ export default {
 		}
 	},
 	computed: {
+		/**
+		 * @spec openspec/specs/ui-client-views/spec.md#REQ-003
+		 */
 		filteredBerichten() {
 			return berichtStore.berichtenList.filter(bericht => zaakStore.zaakItem.berichten.includes(bericht.id))
 		},
 	},
 	watch: {
+		/**
+		 * @spec openspec/specs/ui-client-views/spec.md#REQ-002
+		 */
 		zaakId(newVal) {
 			this.fetchData()
 		},
@@ -99,6 +105,9 @@ export default {
 		this.fetchData()
 	},
 	methods: {
+		/**
+		 * @spec openspec/specs/ui-client-views/spec.md#REQ-001
+		 */
 		fetchData() {
 			this.loading = true
 
@@ -107,6 +116,9 @@ export default {
 					this.loading = false
 				})
 		},
+		/**
+		 * @spec openspec/specs/ui-client-views/spec.md#REQ-002
+		 */
 		toggleBericht(bericht) {
 			if (berichtStore.berichtItem?.id === bericht.id) {
 				berichtStore.setBerichtItem(null)
@@ -114,6 +126,9 @@ export default {
 				berichtStore.setBerichtItem(bericht)
 			}
 		},
+		/**
+		 * @spec openspec/specs/ui-client-views/spec.md#REQ-003
+		 */
 		clearText() {
 			this.search = ''
 		},

--- a/src/views/besluiten/BesluitDetails.vue
+++ b/src/views/besluiten/BesluitDetails.vue
@@ -48,6 +48,9 @@ export default {
 	},
 	watch: {
 		besluitId: {
+			/**
+			 * @spec openspec/specs/ui-case-views/spec.md#REQ-005
+			 */
 			handler(besluitId) {
 				this.fetchData(besluitId)
 			},
@@ -59,6 +62,9 @@ export default {
 		this.fetchData(besluitStore.besluitItem)
 	},
 	methods: {
+		/**
+		 * @spec openspec/specs/ui-case-views/spec.md#REQ-001
+		 */
 		fetchData(besluitId) {
 			this.loading = true
 			fetch(

--- a/src/views/besluiten/BesluitenList.vue
+++ b/src/views/besluiten/BesluitenList.vue
@@ -93,6 +93,9 @@ export default {
 		this.fetchData()
 	},
 	methods: {
+		/**
+		 * @spec openspec/specs/ui-case-views/spec.md#REQ-001
+		 */
 		fetchData(newPage) {
 			this.loading = true
 			fetch(
@@ -112,6 +115,9 @@ export default {
 					this.loading = false
 				})
 		},
+		/**
+		 * @spec openspec/specs/ui-case-views/spec.md#REQ-003
+		 */
 		clearText() {
 			this.search = ''
 		},

--- a/src/views/besluiten/ZaakBesluiten.vue
+++ b/src/views/besluiten/ZaakBesluiten.vue
@@ -80,6 +80,9 @@ export default {
 		}
 	},
 	watch: {
+		/**
+		 * @spec openspec/specs/ui-case-views/spec.md#REQ-002
+		 */
 		zaakId(newVal) {
 			this.fetchData()
 		},
@@ -88,6 +91,9 @@ export default {
 		this.fetchData()
 	},
 	methods: {
+		/**
+		 * @spec openspec/specs/ui-case-views/spec.md#REQ-001
+		 */
 		fetchData() {
 			this.besluiten = {
 				...this.besluiten,
@@ -105,6 +111,9 @@ export default {
 					this.besluiten[this.zaakId].loading = false
 				})
 		},
+		/**
+		 * @spec openspec/specs/ui-case-views/spec.md#REQ-002
+		 */
 		toggleBesluit(besluit) {
 			if (besluitStore.besluitItem?.id === besluit.id) {
 				besluitStore.setBesluitItem(null)
@@ -112,6 +121,9 @@ export default {
 				besluitStore.setBesluitItem(besluit)
 			}
 		},
+		/**
+		 * @spec openspec/specs/ui-case-views/spec.md#REQ-003
+		 */
 		clearText() {
 			this.search = ''
 		},

--- a/src/views/contactMomenten/ContactMomentDetails.vue
+++ b/src/views/contactMomenten/ContactMomentDetails.vue
@@ -152,6 +152,9 @@ export default {
 		}
 	},
 	watch: {
+		/**
+		 * @spec openspec/specs/ui-client-views/spec.md#REQ-005
+		 */
 		id(newId) {
 			this.fetchData(newId)
 		},
@@ -160,6 +163,9 @@ export default {
 		this.fetchData(this.id)
 	},
 	methods: {
+		/**
+		 * @spec openspec/specs/ui-client-views/spec.md#REQ-001
+		 */
 		fetchData(id) {
 			this.loading = true
 
@@ -168,6 +174,9 @@ export default {
 					this.loading = false
 				})
 		},
+		/**
+		 * @spec openspec/specs/ui-client-views/spec.md#REQ-001
+		 */
 		fetchAuditTrails(id) {
 			fetch(`/index.php/apps/zaakafhandelapp/api/contact_momenten/${id}/audit_trail`)
 				.then(response => response.json())
@@ -177,6 +186,9 @@ export default {
 					}
 				})
 		},
+		/**
+		 * @spec openspec/specs/ui-client-views/spec.md#REQ-005
+		 */
 		async closeContactMoment() {
 			if (contactMomentStore.contactMomentItem?.status === 'gesloten') {
 				console.info('Contact moment is already closed')

--- a/src/views/contactMomenten/ContactMomentenList.vue
+++ b/src/views/contactMomenten/ContactMomentenList.vue
@@ -113,6 +113,9 @@ export default {
 			contactMomentenList: [],
 		}
 	},
+	/**
+	 * @spec openspec/specs/ui-client-views/spec.md#REQ-005
+	 */
 	mounted() {
 		Promise.all([
 			contactMomentStore.refreshContactMomentenList(),
@@ -122,17 +125,29 @@ export default {
 		})
 	},
 	methods: {
+		/**
+		 * @spec openspec/specs/ui-client-views/spec.md#REQ-004
+		 */
 		openContactMoment(contactMoment) {
 			contactMomentStore.setContactMomentItem(contactMoment)
 			this.$router.push({ name: 'ContactmomentDetail', params: { id: contactMoment.id } })
 		},
+		/**
+		 * @spec openspec/specs/ui-client-views/spec.md#REQ-004
+		 */
 		editContactMoment(contactMoment) {
 			contactMomentStore.setContactMomentItem(contactMoment)
 			navigationStore.setModal('editContactMoment')
 		},
+		/**
+		 * @spec openspec/specs/ui-client-views/spec.md#REQ-005
+		 */
 		storeContactMoment(contactMoment) {
 			contactMomentStore.setContactMomentItem(contactMoment)
 		},
+		/**
+		 * @spec openspec/specs/ui-client-views/spec.md#REQ-005
+		 */
 		getKlantName(klantId) {
 			const klant = klantStore.klantenList.find(klant => klant.id === klantId)
 			if (!klant) {
@@ -146,6 +161,9 @@ export default {
 			}
 			return 'onbekend'
 		},
+		/**
+		 * @spec openspec/specs/ui-client-views/spec.md#REQ-001
+		 */
 
 		fetchData(newPage) {
 			this.loading = true
@@ -166,6 +184,9 @@ export default {
 					this.loading = false
 				})
 		},
+		/**
+		 * @spec openspec/specs/ui-client-views/spec.md#REQ-003
+		 */
 		clearText() {
 			this.search = ''
 		},

--- a/src/views/documenten/DocumentDetails.vue
+++ b/src/views/documenten/DocumentDetails.vue
@@ -48,6 +48,9 @@ export default {
 	},
 	watch: {
 		documentId: {
+			/**
+			 * @spec openspec/specs/ui-case-views/spec.md#REQ-005
+			 */
 			handler(documentId) {
 				this.fetchData(documentId)
 			},
@@ -59,6 +62,9 @@ export default {
 		this.fetchData(documentStore.documentItem)
 	},
 	methods: {
+		/**
+		 * @spec openspec/specs/ui-case-views/spec.md#REQ-001
+		 */
 		fetchData(documentId) {
 			this.loading = true
 			fetch(

--- a/src/views/documenten/DocumentenList.vue
+++ b/src/views/documenten/DocumentenList.vue
@@ -98,6 +98,9 @@ export default {
 		this.fetchData()
 	},
 	methods: {
+		/**
+		 * @spec openspec/specs/ui-case-views/spec.md#REQ-001
+		 */
 		fetchData(newPage) {
 			this.loading = true
 			fetch(
@@ -117,6 +120,9 @@ export default {
 					this.loading = false
 				})
 		},
+		/**
+		 * @spec openspec/specs/ui-case-views/spec.md#REQ-003
+		 */
 		clearText() {
 			this.search = ''
 		},

--- a/src/views/documenten/ZaakDocumenten.vue
+++ b/src/views/documenten/ZaakDocumenten.vue
@@ -81,6 +81,9 @@ export default {
 		}
 	},
 	watch: {
+		/**
+		 * @spec openspec/specs/ui-case-views/spec.md#REQ-002
+		 */
 		zaakId(newVal) {
 			this.fetchData(newVal)
 		},
@@ -89,6 +92,9 @@ export default {
 		this.fetchData(this.zaakId)
 	},
 	methods: {
+		/**
+		 * @spec openspec/specs/ui-case-views/spec.md#REQ-001
+		 */
 		fetchData() {
 			this.documenten = {
 				...this.documenten,
@@ -106,6 +112,9 @@ export default {
 					this.documenten[this.zaakId].loading = false
 				})
 		},
+		/**
+		 * @spec openspec/specs/ui-case-views/spec.md#REQ-002
+		 */
 		toggleDocument(document) {
 			if (documentStore.documentItem?.id === document.id) {
 				documentStore.setDocumentItem(null)
@@ -113,6 +122,9 @@ export default {
 				documentStore.setDocumentItem(document)
 			}
 		},
+		/**
+		 * @spec openspec/specs/ui-case-views/spec.md#REQ-003
+		 */
 		clearText() {
 			this.search = ''
 		},

--- a/src/views/eigenschappen/ZaakEigenschappen.vue
+++ b/src/views/eigenschappen/ZaakEigenschappen.vue
@@ -73,6 +73,9 @@ export default {
 		}
 	},
 	watch: {
+		/**
+		 * @spec openspec/specs/ui-case-views/spec.md#REQ-002
+		 */
 		zaakId(newVal) {
 			this.fetchData(newVal)
 		},
@@ -81,6 +84,9 @@ export default {
 		this.fetchData(this.zaakId)
 	},
 	methods: {
+		/**
+		 * @spec openspec/specs/ui-case-views/spec.md#REQ-001
+		 */
 		fetchData(zaakId) {
 			this.loading = true
 			fetch(
@@ -100,9 +106,15 @@ export default {
 					this.loading = false
 				})
 		},
+		/**
+		 * @spec openspec/specs/ui-case-views/spec.md#REQ-002
+		 */
 		toggleZaakEigenschap(zaakEigenschap) {
 			// TODO: toggle zaakEigenschap
 		},
+		/**
+		 * @spec openspec/specs/ui-case-views/spec.md#REQ-003
+		 */
 		clearText() {
 			this.search = ''
 		},

--- a/src/views/klanten/KlantDetails.vue
+++ b/src/views/klanten/KlantDetails.vue
@@ -341,11 +341,17 @@ export default {
 		}
 	},
 	computed: {
+		/**
+		 * @spec openspec/specs/ui-client-views/spec.md#REQ-003
+		 */
 		filteredContactMomenten() {
 			return contactMomentStore.contactMomentenList.filter(contactMoment => contactMoment.klant === klantStore.klantItem.id)
 		},
 	},
 	watch: {
+		/**
+		 * @spec openspec/specs/ui-client-views/spec.md#REQ-005
+		 */
 		id(newId) {
 			this.fetchKlantData(newId)
 		},
@@ -354,6 +360,9 @@ export default {
 		this.fetchData(this.id)
 	},
 	methods: {
+		/**
+		 * @spec openspec/specs/ui-client-views/spec.md#REQ-001
+		 */
 		fetchData(id) {
 			this.loading = true
 
@@ -365,6 +374,9 @@ export default {
 			this.fetchContactMomenten()
 			this.fetchKlantData(id)
 		},
+		/**
+		 * @spec openspec/specs/ui-client-views/spec.md#REQ-001
+		 */
 		async fetchKlantData(id) {
 			// when using Promise.allSettled, it will return an array of items.
 			// these items contain a status string, which is either 'fulfilled' or 'rejected'.
@@ -404,9 +416,15 @@ export default {
 				console.error('Error fetching audit trail:', auditTrailResult.reason)
 			}
 		},
+		/**
+		 * @spec openspec/specs/ui-client-views/spec.md#REQ-001
+		 */
 		fetchContactMomenten() {
 			contactMomentStore.refreshContactMomentenList()
 		},
+		/**
+		 * @spec openspec/specs/ui-client-views/spec.md#REQ-005
+		 */
 
 		getName(klant) {
 			if (klant.type === 'persoon') {

--- a/src/views/klanten/KlantenList.vue
+++ b/src/views/klanten/KlantenList.vue
@@ -109,16 +109,25 @@ export default {
 			klantenList: [],
 		}
 	},
+	/**
+	 * @spec openspec/specs/ui-client-views/spec.md#REQ-005
+	 */
 	mounted() {
 		klantStore.refreshKlantenList().then(() => {
 			this.loading = false
 		})
 	},
 	methods: {
+		/**
+		 * @spec openspec/specs/ui-client-views/spec.md#REQ-004
+		 */
 		openKlant(klant) {
 			klantStore.setKlantItem(klant)
 			this.$router.push({ params: { id: klant.id } })
 		},
+		/**
+		 * @spec openspec/specs/ui-client-views/spec.md#REQ-005
+		 */
 		fullName(klant) {
 			let name = klant.achternaam
 			if (klant.tussenvoegsel) {
@@ -129,6 +138,9 @@ export default {
 			}
 			return name
 		},
+		/**
+		 * @spec openspec/specs/ui-client-views/spec.md#REQ-005
+		 */
 		getName(klant) {
 			if (klant.type === 'persoon') {
 				return klant?.voornaam ?? 'onbekend'
@@ -138,6 +150,9 @@ export default {
 			}
 			return 'onbekend'
 		},
+		/**
+		 * @spec openspec/specs/ui-client-views/spec.md#REQ-005
+		 */
 		getSubname(klant) {
 			if (klant.type === 'persoon') {
 				return klant?.tussenvoegsel ? `${klant.tussenvoegsel} ${klant.achternaam}` : klant?.achternaam ? `${klant.achternaam}` : 'onbekend'
@@ -147,6 +162,9 @@ export default {
 			}
 			return 'onbekend'
 		},
+		/**
+		 * @spec openspec/specs/ui-client-views/spec.md#REQ-004
+		 */
 		deleteKlant() {
 			fetch(
 				`/index.php/apps/zaakafhandelapp/api/klanten/${klantStore.klantItem.id}`,
@@ -165,6 +183,9 @@ export default {
 					this.loading = false
 				})
 		},
+		/**
+		 * @spec openspec/specs/ui-client-views/spec.md#REQ-001
+		 */
 		fetchData(newPage) {
 			this.loading = true
 			fetch(
@@ -184,6 +205,9 @@ export default {
 					this.loading = false
 				})
 		},
+		/**
+		 * @spec openspec/specs/ui-client-views/spec.md#REQ-003
+		 */
 		clearText() {
 			this.search = ''
 		},

--- a/src/views/medewerkers/MedewerkerDetails.vue
+++ b/src/views/medewerkers/MedewerkerDetails.vue
@@ -110,6 +110,9 @@ export default {
 		}
 	},
 	watch: {
+		/**
+		 * @spec openspec/specs/ui-client-views/spec.md#REQ-005
+		 */
 		id(newId) {
 			this.fetchData(newId)
 		},
@@ -118,6 +121,9 @@ export default {
 		this.fetchData(this.id)
 	},
 	methods: {
+		/**
+		 * @spec openspec/specs/ui-client-views/spec.md#REQ-001
+		 */
 		fetchData(id) {
 			this.loading = true
 

--- a/src/views/medewerkers/MedewerkerList.vue
+++ b/src/views/medewerkers/MedewerkerList.vue
@@ -102,16 +102,25 @@ export default {
 			medewerkersList: [],
 		}
 	},
+	/**
+	 * @spec openspec/specs/ui-client-views/spec.md#REQ-005
+	 */
 	mounted() {
 		medewerkerStore.refreshMedewerkersList().then(() => {
 			this.loading = false
 		})
 	},
 	methods: {
+		/**
+		 * @spec openspec/specs/ui-client-views/spec.md#REQ-004
+		 */
 		openMedewerker(medewerker) {
 			medewerkerStore.setMedewerkerItem(medewerker)
 			this.$router.push({ name: 'MedewerkerDetail', params: { id: medewerker.id } })
 		},
+		/**
+		 * @spec openspec/specs/ui-client-views/spec.md#REQ-005
+		 */
 		fullName(medewerker) {
 			let name = medewerker.achternaam
 			if (medewerker.tussenvoegsel) {
@@ -125,6 +134,9 @@ export default {
 		getName(medewerker) {
 			return `${medewerker?.voornaam} ${medewerker?.tussenvoegsel} ${medewerker?.achternaam}`
 		},
+		/**
+		 * @spec openspec/specs/ui-client-views/spec.md#REQ-004
+		 */
 		deleteKlant() {
 			fetch(
 				`/index.php/apps/zaakafhandelapp/api/medewerkers/${medewerkerStore.medewerkerItem.id}`,
@@ -143,6 +155,9 @@ export default {
 					this.loading = false
 				})
 		},
+		/**
+		 * @spec openspec/specs/ui-client-views/spec.md#REQ-001
+		 */
 		fetchData(newPage) {
 			this.loading = true
 			fetch(
@@ -162,6 +177,9 @@ export default {
 					this.loading = false
 				})
 		},
+		/**
+		 * @spec openspec/specs/ui-client-views/spec.md#REQ-003
+		 */
 		clearText() {
 			this.search = ''
 		},

--- a/src/views/resultaten/ResultaatDetails.vue
+++ b/src/views/resultaten/ResultaatDetails.vue
@@ -48,6 +48,9 @@ export default {
 	},
 	watch: {
 		resultaatId: {
+			/**
+			 * @spec openspec/specs/ui-case-views/spec.md#REQ-005
+			 */
 			handler(resultaatId) {
 				this.fetchData(resultaatId)
 			},
@@ -58,6 +61,9 @@ export default {
 		this.fetchData(resultaatStore.resultaatItem)
 	},
 	methods: {
+		/**
+		 * @spec openspec/specs/ui-case-views/spec.md#REQ-001
+		 */
 		fetchData(resultaatId) {
 			this.loading = true
 			fetch(

--- a/src/views/resultaten/ResultatenList.vue
+++ b/src/views/resultaten/ResultatenList.vue
@@ -95,6 +95,9 @@ export default {
 		this.fetchData()
 	},
 	methods: {
+		/**
+		 * @spec openspec/specs/ui-case-views/spec.md#REQ-001
+		 */
 		fetchData(newPage) {
 			this.loading = true
 			fetch(
@@ -114,6 +117,9 @@ export default {
 					this.loading = false
 				})
 		},
+		/**
+		 * @spec openspec/specs/ui-case-views/spec.md#REQ-003
+		 */
 		clearText() {
 			this.search = ''
 		},

--- a/src/views/resultaten/ZaakResultaten.vue
+++ b/src/views/resultaten/ZaakResultaten.vue
@@ -77,11 +77,17 @@ export default {
 		}
 	},
 	computed: {
+		/**
+		 * @spec openspec/specs/ui-case-views/spec.md#REQ-003
+		 */
 		filteredResultatenList() {
 			return resultaatStore.resultatenList.filter((resultaat) => resultaat.zaak === this.zaakId)
 		},
 	},
 	watch: {
+		/**
+		 * @spec openspec/specs/ui-case-views/spec.md#REQ-002
+		 */
 		zaakId(newVal) {
 			this.fetchData()
 		},
@@ -90,6 +96,9 @@ export default {
 		this.fetchData()
 	},
 	methods: {
+		/**
+		 * @spec openspec/specs/ui-case-views/spec.md#REQ-001
+		 */
 		fetchData() {
 			this.loading = true
 
@@ -98,6 +107,9 @@ export default {
 					this.loading = false
 				})
 		},
+		/**
+		 * @spec openspec/specs/ui-case-views/spec.md#REQ-002
+		 */
 		toggleResultaat(resultaat) {
 			if (resultaatStore.resultaatItem?.id === resultaat.id) {
 				resultaatStore.setResultaatItem(null)
@@ -105,6 +117,9 @@ export default {
 				resultaatStore.setResultaatItem(resultaat)
 			}
 		},
+		/**
+		 * @spec openspec/specs/ui-case-views/spec.md#REQ-003
+		 */
 		clearText() {
 			this.search = ''
 		},

--- a/src/views/rollen/RolDetails.vue
+++ b/src/views/rollen/RolDetails.vue
@@ -92,6 +92,9 @@ export default {
 		}
 	},
 	watch: {
+		/**
+		 * @spec openspec/specs/ui-client-views/spec.md#REQ-005
+		 */
 		id(newId) {
 			this.fetchData(newId)
 		},
@@ -101,6 +104,9 @@ export default {
 		this.fetchData(this.id)
 	},
 	methods: {
+		/**
+		 * @spec openspec/specs/ui-client-views/spec.md#REQ-001
+		 */
 		fetchData(id) {
 			this.loading = true
 

--- a/src/views/rollen/RollenList.vue
+++ b/src/views/rollen/RollenList.vue
@@ -112,6 +112,9 @@ export default {
 			rollenList: [],
 		}
 	},
+	/**
+	 * @spec openspec/specs/ui-client-views/spec.md#REQ-005
+	 */
 	mounted() {
 		this.loading = true
 
@@ -122,9 +125,15 @@ export default {
 		})
 	},
 	methods: {
+		/**
+		 * @spec openspec/specs/ui-client-views/spec.md#REQ-003
+		 */
 		clearText() {
 			this.search = ''
 		},
+		/**
+		 * @spec openspec/specs/ui-client-views/spec.md#REQ-004
+		 */
 		openRol(rol) {
 			rolStore.setRolItem(rol)
 			this.$router.push({ params: { id: rol.id } })

--- a/src/views/rollen/ZaakRollen.vue
+++ b/src/views/rollen/ZaakRollen.vue
@@ -85,11 +85,17 @@ export default {
 		}
 	},
 	computed: {
+		/**
+		 * @spec openspec/specs/ui-client-views/spec.md#REQ-003
+		 */
 		filteredRollenList() {
 			return rolStore.rollenList.filter((rol) => rol.zaak === this.zaakUrl)
 		},
 	},
 	watch: {
+		/**
+		 * @spec openspec/specs/ui-client-views/spec.md#REQ-005
+		 */
 		zaakUrl(newVal) {
 			this.fetchData()
 		},
@@ -98,10 +104,16 @@ export default {
 		this.fetchData()
 	},
 	methods: {
+		/**
+		 * @spec openspec/specs/ui-client-views/spec.md#REQ-004
+		 */
 		editRol(rol) {
 			rolStore.setRolItem(rol)
 			navigationStore.setModal('editRol')
 		},
+		/**
+		 * @spec openspec/specs/ui-client-views/spec.md#REQ-001
+		 */
 		fetchData() {
 			this.loading = true
 
@@ -110,6 +122,9 @@ export default {
 					this.loading = false
 				})
 		},
+		/**
+		 * @spec openspec/specs/ui-client-views/spec.md#REQ-002
+		 */
 		toggleRol(rol) {
 			if (rolStore.rolItem?.id === rol.id) {
 				rolStore.setRolItem(null)
@@ -117,6 +132,9 @@ export default {
 				rolStore.setRolItem(rol)
 			}
 		},
+		/**
+		 * @spec openspec/specs/ui-client-views/spec.md#REQ-003
+		 */
 		clearText() {
 			this.search = ''
 		},

--- a/src/views/settings/Settings.vue
+++ b/src/views/settings/Settings.vue
@@ -234,6 +234,9 @@ export default {
 	},
 
 	computed: {
+		/**
+		 * @spec openspec/specs/ui-case-views/spec.md#REQ-005
+		 */
 		translatedObjectTypesList() {
 			return [
 				{ id: 'berichten', title: t('zaakafhandelapp', 'Messages'), description: t('zaakafhandelapp', 'Configure storage for messages'), helpLink: 'https://example.com/help/berichten' },
@@ -257,6 +260,9 @@ export default {
 	watch: {
 
 		'berichten.selectedSource': {
+			/**
+			 * @spec openspec/specs/ui-case-views/spec.md#REQ-005
+			 */
 			handler(newValue) {
 				if (newValue?.value === 'internal') {
 
@@ -267,6 +273,9 @@ export default {
 			deep: true,
 		},
 		'berichten.selectedRegister': {
+			/**
+			 * @spec openspec/specs/ui-case-views/spec.md#REQ-005
+			 */
 			handler(newValue, oldValue) {
 
 				if (this.initialization === true && oldValue === '') return
@@ -278,6 +287,9 @@ export default {
 			deep: true,
 		},
 		'besluiten.selectedSource': {
+			/**
+			 * @spec openspec/specs/ui-case-views/spec.md#REQ-005
+			 */
 			handler(newValue) {
 				if (newValue?.value === 'internal') {
 
@@ -288,6 +300,9 @@ export default {
 			deep: true,
 		},
 		'besluiten.selectedRegister': {
+			/**
+			 * @spec openspec/specs/ui-case-views/spec.md#REQ-005
+			 */
 			handler(newValue, oldValue) {
 
 				if (this.initialization === true && oldValue === '') return
@@ -299,6 +314,9 @@ export default {
 			deep: true,
 		},
 		'documenten.selectedSource': {
+			/**
+			 * @spec openspec/specs/ui-case-views/spec.md#REQ-005
+			 */
 			handler(newValue) {
 				if (newValue?.value === 'internal') {
 
@@ -309,6 +327,9 @@ export default {
 			deep: true,
 		},
 		'documenten.selectedRegister': {
+			/**
+			 * @spec openspec/specs/ui-case-views/spec.md#REQ-005
+			 */
 			handler(newValue, oldValue) {
 
 				if (this.initialization === true && oldValue === '') return
@@ -320,6 +341,9 @@ export default {
 			deep: true,
 		},
 		'klanten.selectedSource': {
+			/**
+			 * @spec openspec/specs/ui-case-views/spec.md#REQ-005
+			 */
 			handler(newValue) {
 				if (newValue?.value === 'internal') {
 
@@ -330,6 +354,9 @@ export default {
 			deep: true,
 		},
 		'klanten.selectedRegister': {
+			/**
+			 * @spec openspec/specs/ui-case-views/spec.md#REQ-005
+			 */
 			handler(newValue, oldValue) {
 
 				if (this.initialization === true && oldValue === '') return
@@ -341,6 +368,9 @@ export default {
 			deep: true,
 		},
 		'resultaten.selectedSource': {
+			/**
+			 * @spec openspec/specs/ui-case-views/spec.md#REQ-005
+			 */
 			handler(newValue) {
 				if (newValue?.value === 'internal') {
 
@@ -351,6 +381,9 @@ export default {
 			deep: true,
 		},
 		'resultaten.selectedRegister': {
+			/**
+			 * @spec openspec/specs/ui-case-views/spec.md#REQ-005
+			 */
 			handler(newValue, oldValue) {
 
 				if (this.initialization === true && oldValue === '') return
@@ -362,6 +395,9 @@ export default {
 			deep: true,
 		},
 		'taken.selectedSource': {
+			/**
+			 * @spec openspec/specs/ui-case-views/spec.md#REQ-005
+			 */
 			handler(newValue) {
 				if (newValue?.value === 'internal') {
 
@@ -372,6 +408,9 @@ export default {
 			deep: true,
 		},
 		'taken.selectedRegister': {
+			/**
+			 * @spec openspec/specs/ui-case-views/spec.md#REQ-005
+			 */
 			handler(newValue, oldValue) {
 
 				if (this.initialization === true && oldValue === '') return
@@ -383,6 +422,9 @@ export default {
 			deep: true,
 		},
 		'informatieobjecten.selectedSource': {
+			/**
+			 * @spec openspec/specs/ui-case-views/spec.md#REQ-005
+			 */
 			handler(newValue) {
 				if (newValue?.value === 'internal') {
 
@@ -393,6 +435,9 @@ export default {
 			deep: true,
 		},
 		'informatieobjecten.selectedRegister': {
+			/**
+			 * @spec openspec/specs/ui-case-views/spec.md#REQ-005
+			 */
 			handler(newValue, oldValue) {
 
 				if (this.initialization === true && oldValue === '') return
@@ -404,6 +449,9 @@ export default {
 			deep: true,
 		},
 		'organisaties.selectedSource': {
+			/**
+			 * @spec openspec/specs/ui-case-views/spec.md#REQ-005
+			 */
 			handler(newValue) {
 				if (newValue?.value === 'internal') {
 
@@ -414,6 +462,9 @@ export default {
 			deep: true,
 		},
 		'organisaties.selectedRegister': {
+			/**
+			 * @spec openspec/specs/ui-case-views/spec.md#REQ-005
+			 */
 			handler(newValue, oldValue) {
 
 				if (this.initialization === true && oldValue === '') return
@@ -425,6 +476,9 @@ export default {
 			deep: true,
 		},
 		'personen.selectedSource': {
+			/**
+			 * @spec openspec/specs/ui-case-views/spec.md#REQ-005
+			 */
 			handler(newValue) {
 				if (newValue?.value === 'internal') {
 
@@ -435,6 +489,9 @@ export default {
 			deep: true,
 		},
 		'personen.selectedRegister': {
+			/**
+			 * @spec openspec/specs/ui-case-views/spec.md#REQ-005
+			 */
 			handler(newValue, oldValue) {
 
 				if (this.initialization === true && oldValue === '') return
@@ -446,6 +503,9 @@ export default {
 			deep: true,
 		},
 		'zaken.selectedSource': {
+			/**
+			 * @spec openspec/specs/ui-case-views/spec.md#REQ-005
+			 */
 			handler(newValue) {
 				if (newValue?.value === 'internal') {
 
@@ -456,6 +516,9 @@ export default {
 			deep: true,
 		},
 		'zaken.selectedRegister': {
+			/**
+			 * @spec openspec/specs/ui-case-views/spec.md#REQ-005
+			 */
 			handler(newValue, oldValue) {
 
 				if (this.initialization === true && oldValue === '') return
@@ -467,6 +530,9 @@ export default {
 			deep: true,
 		},
 		'zaaktypen.selectedSource': {
+			/**
+			 * @spec openspec/specs/ui-case-views/spec.md#REQ-005
+			 */
 			handler(newValue) {
 				if (newValue?.value === 'internal') {
 
@@ -477,6 +543,9 @@ export default {
 			deep: true,
 		},
 		'zaaktypen.selectedRegister': {
+			/**
+			 * @spec openspec/specs/ui-case-views/spec.md#REQ-005
+			 */
 			handler(newValue, oldValue) {
 
 				if (this.initialization === true && oldValue === '') return
@@ -488,6 +557,9 @@ export default {
 			deep: true,
 		},
 		'contactmomenten.selectedSource': {
+			/**
+			 * @spec openspec/specs/ui-case-views/spec.md#REQ-005
+			 */
 			handler(newValue) {
 				if (newValue?.value === 'internal') {
 
@@ -498,6 +570,9 @@ export default {
 			deep: true,
 		},
 		'contactmomenten.selectedRegister': {
+			/**
+			 * @spec openspec/specs/ui-case-views/spec.md#REQ-005
+			 */
 			handler(newValue, oldValue) {
 
 				if (this.initialization === true && oldValue === '') return
@@ -509,6 +584,9 @@ export default {
 			deep: true,
 		},
 		'medewerkers.selectedSource': {
+			/**
+			 * @spec openspec/specs/ui-case-views/spec.md#REQ-005
+			 */
 			handler(newValue) {
 				if (newValue?.value === 'internal') {
 
@@ -519,6 +597,9 @@ export default {
 			deep: true,
 		},
 		'medewerkers.selectedRegister': {
+			/**
+			 * @spec openspec/specs/ui-case-views/spec.md#REQ-005
+			 */
 			handler(newValue, oldValue) {
 
 				if (this.initialization === true && oldValue === '') return
@@ -530,6 +611,9 @@ export default {
 			deep: true,
 		},
 		'rollen.selectedSource': {
+			/**
+			 * @spec openspec/specs/ui-case-views/spec.md#REQ-005
+			 */
 			handler(newValue) {
 				if (newValue?.value === 'internal') {
 					this.rollen.selectedRegister = ''
@@ -539,6 +623,9 @@ export default {
 			deep: true,
 		},
 		'rollen.selectedRegister': {
+			/**
+			 * @spec openspec/specs/ui-case-views/spec.md#REQ-005
+			 */
 			handler(newValue, oldValue) {
 				if (this.initialization === true && oldValue === '') return
 				if (newValue) {
@@ -558,6 +645,9 @@ export default {
 			return this[name]
 
 		},
+		/**
+		 * @spec openspec/specs/ui-case-views/spec.md#REQ-005
+		 */
 		setRegisterSchemaOptions(registerId, property) {
 			const selectedRegister = this.availableRegisters.find((register) => register.id.toString() === registerId)
 
@@ -568,6 +658,9 @@ export default {
 				})),
 			}
 		},
+		/**
+		 * @spec openspec/specs/ui-case-views/spec.md#REQ-001
+		 */
 		fetchAll() {
 			this.loading = true
 
@@ -615,6 +708,9 @@ export default {
 					return err
 				})
 		},
+		/**
+		 * @spec openspec/specs/ui-case-views/spec.md#REQ-005
+		 */
 		saveConfig(configId) {
 			this[configId].loading = true
 			this.saving = true
@@ -660,6 +756,9 @@ export default {
 					return err
 				})
 		},
+		/**
+		 * @spec openspec/specs/ui-case-views/spec.md#REQ-005
+		 */
 
 		saveAll() {
 			this.saving = true
@@ -779,6 +878,9 @@ export default {
 					return err
 				})
 		},
+		/**
+		 * @spec openspec/specs/ui-case-views/spec.md#REQ-005
+		 */
 
 		resetConfig() {
 			this.saving = true
@@ -848,6 +950,9 @@ export default {
 					return err
 				})
 		},
+		/**
+		 * @spec openspec/specs/ui-case-views/spec.md#REQ-004
+		 */
 		openLink(url, type = '') {
 			window.open(url, type)
 		},

--- a/src/views/statussen/StatusDetails.vue
+++ b/src/views/statussen/StatusDetails.vue
@@ -44,6 +44,9 @@ export default {
 	},
 	watch: {
 		statusId: {
+			/**
+			 * @spec openspec/specs/ui-case-views/spec.md#REQ-005
+			 */
 			handler(statusId) {
 				this.fetchData(statusId)
 			},
@@ -54,6 +57,9 @@ export default {
 		this.fetchData(this.statusItem)
 	},
 	methods: {
+		/**
+		 * @spec openspec/specs/ui-case-views/spec.md#REQ-001
+		 */
 		fetchData(statusId) {
 			this.loading = true
 			fetch(

--- a/src/views/statussen/StatussenList.vue
+++ b/src/views/statussen/StatussenList.vue
@@ -91,6 +91,9 @@ export default {
 		this.fetchData()
 	},
 	methods: {
+		/**
+		 * @spec openspec/specs/ui-case-views/spec.md#REQ-001
+		 */
 		fetchData(newPage) {
 			this.loading = true
 			fetch(
@@ -110,6 +113,9 @@ export default {
 					this.loading = false
 				})
 		},
+		/**
+		 * @spec openspec/specs/ui-case-views/spec.md#REQ-003
+		 */
 		clearText() {
 			this.search = ''
 		},

--- a/src/views/taken/TaakDetails.vue
+++ b/src/views/taken/TaakDetails.vue
@@ -148,6 +148,9 @@ export default {
 		}
 	},
 	watch: {
+		/**
+		 * @spec openspec/specs/ui-client-views/spec.md#REQ-005
+		 */
 		id(newId) {
 			this.fetchData(newId)
 		},
@@ -156,6 +159,9 @@ export default {
 		this.fetchData(this.id)
 	},
 	methods: {
+		/**
+		 * @spec openspec/specs/ui-client-views/spec.md#REQ-001
+		 */
 		async fetchData(id) {
 			this.loading = true
 
@@ -171,6 +177,9 @@ export default {
 				...(taakData.medewerker ? [this.fetchMedewerker(taakData.medewerker)] : []),
 			])
 		},
+		/**
+		 * @spec openspec/specs/ui-client-views/spec.md#REQ-001
+		 */
 		fetchAuditTrails(id) {
 			fetch(`/index.php/apps/zaakafhandelapp/api/taken/${id}/audit_trail`)
 				.then(response => response.json())
@@ -186,14 +195,23 @@ export default {
 		getMedewerkerName(medewerker) {
 			return `${medewerker?.voornaam} ${medewerker?.tussenvoegsel} ${medewerker?.achternaam}`
 		},
+		/**
+		 * @spec openspec/specs/ui-client-views/spec.md#REQ-005
+		 */
 		goToKlant() {
 			klantStore.setKlantItem(this.klant)
 			this.$router.push({ name: 'KlantDetail', params: { id: this.klant.id } })
 		},
+		/**
+		 * @spec openspec/specs/ui-client-views/spec.md#REQ-005
+		 */
 		goToMedewerker() {
 			medewerkerStore.setMedewerkerItem(this.medewerker)
 			this.$router.push({ name: 'MedewerkerDetail', params: { id: this.medewerker.id } })
 		},
+		/**
+		 * @spec openspec/specs/ui-client-views/spec.md#REQ-001
+		 */
 		fetchKlant(klant) {
 			this.klantLoading = true
 
@@ -212,6 +230,9 @@ export default {
 				})
 
 		},
+		/**
+		 * @spec openspec/specs/ui-client-views/spec.md#REQ-001
+		 */
 		fetchMedewerker(medewerker) {
 			this.medewerkerLoading = true
 

--- a/src/views/taken/TakenList.vue
+++ b/src/views/taken/TakenList.vue
@@ -110,6 +110,9 @@ export default {
 			users: null,
 		}
 	},
+	/**
+	 * @spec openspec/specs/ui-client-views/spec.md#REQ-005
+	 */
 	mounted() {
 		Promise.all([
 			this.getUsers(),
@@ -120,9 +123,15 @@ export default {
 		})
 	},
 	methods: {
+		/**
+		 * @spec openspec/specs/ui-client-views/spec.md#REQ-003
+		 */
 		clearText() {
 			this.search = ''
 		},
+		/**
+		 * @spec openspec/specs/ui-client-views/spec.md#REQ-005
+		 */
 		getUsers() {
 			fetch('/ocs/v1.php/cloud/users/details', {
 				method: 'GET',
@@ -135,10 +144,16 @@ export default {
 				this.users = Object.values(data.ocs.data.users)
 			})
 		},
+		/**
+		 * @spec openspec/specs/ui-client-views/spec.md#REQ-004
+		 */
 		openTaak(taak) {
 			taakStore.setTaakItem(taak)
 			this.$router.push({ params: { id: taak.id } })
 		},
+		/**
+		 * @spec openspec/specs/ui-client-views/spec.md#REQ-005
+		 */
 		getName(taak) {
 			const medewerker = this.users.find(user => user.email === taak.medewerker)
 			const klant = klantStore.klantenList.find(klant => klant.id === taak.klant)

--- a/src/views/taken/ZaakTaken.vue
+++ b/src/views/taken/ZaakTaken.vue
@@ -87,11 +87,17 @@ export default {
 		}
 	},
 	computed: {
+		/**
+		 * @spec openspec/specs/ui-client-views/spec.md#REQ-003
+		 */
 		filteredTakenList() {
 			return taakStore.takenList.filter((taak) => taak.zaak === this.zaakId)
 		},
 	},
 	watch: {
+		/**
+		 * @spec openspec/specs/ui-client-views/spec.md#REQ-002
+		 */
 		zaakId(newVal) {
 			this.fetchData()
 		},
@@ -100,6 +106,9 @@ export default {
 		this.fetchData()
 	},
 	methods: {
+		/**
+		 * @spec openspec/specs/ui-client-views/spec.md#REQ-001
+		 */
 		fetchData() {
 			this.loading = true
 
@@ -108,6 +117,9 @@ export default {
 					this.loading = false
 				})
 		},
+		/**
+		 * @spec openspec/specs/ui-client-views/spec.md#REQ-002
+		 */
 		toggleTaak(taak) {
 			if (taakStore.taakItem?.id === taak.id) {
 				taakStore.setTaakItem(null)
@@ -115,6 +127,9 @@ export default {
 				taakStore.setTaakItem(taak)
 			}
 		},
+		/**
+		 * @spec openspec/specs/ui-client-views/spec.md#REQ-003
+		 */
 		clearText() {
 			this.search = ''
 		},

--- a/src/views/widgets/ContactMomentenWidget.vue
+++ b/src/views/widgets/ContactMomentenWidget.vue
@@ -80,6 +80,9 @@ export default {
 		}
 	},
 	computed: {
+		/**
+		 * @spec openspec/specs/ui-dashboard-widgets/spec.md#REQ-003
+		 */
 		itemMenu() {
 			return {
 				show: {
@@ -101,6 +104,9 @@ export default {
 		this.fetchUser()
 	},
 	methods: {
+		/**
+		 * @spec openspec/specs/ui-dashboard-widgets/spec.md#REQ-001
+		 */
 		async fetchUser() {
 			this.loading = true
 
@@ -128,6 +134,9 @@ export default {
 			this.userEmail = medewerker.email
 			this.fetchContactMomentItems()
 		},
+		/**
+		 * @spec openspec/specs/ui-dashboard-widgets/spec.md#REQ-001
+		 */
 		fetchContactMomentItems() {
 			this.loading = true
 
@@ -167,6 +176,9 @@ export default {
 				})
 		},
 		// === ICONS ===
+		/**
+		 * @spec openspec/specs/ui-dashboard-widgets/spec.md#REQ-003
+		 */
 		getItemIcon() {
 			const theme = getTheme()
 
@@ -178,6 +190,9 @@ export default {
 
 			return theme === 'light' ? `${appLocation}/zaakafhandelapp/img/chat-outline-dark.svg` : `${appLocation}/zaakafhandelapp/img/chat-outline.svg`
 		},
+		/**
+		 * @spec openspec/specs/ui-dashboard-widgets/spec.md#REQ-003
+		 */
 		getItemPhoneIcon() {
 			const theme = getTheme()
 
@@ -189,6 +204,9 @@ export default {
 
 			return theme === 'light' ? `${appLocation}/zaakafhandelapp/img/phone-dark.svg` : `${appLocation}/zaakafhandelapp/img/phone.svg`
 		},
+		/**
+		 * @spec openspec/specs/ui-dashboard-widgets/spec.md#REQ-003
+		 */
 		getItemEmailIcon() {
 			const theme = getTheme()
 
@@ -200,6 +218,9 @@ export default {
 
 			return theme === 'light' ? `${appLocation}/zaakafhandelapp/img/email-outline-dark.svg` : `${appLocation}/zaakafhandelapp/img/email-outline.svg`
 		},
+		/**
+		 * @spec openspec/specs/ui-dashboard-widgets/spec.md#REQ-003
+		 */
 		getItemMailboxIcon() {
 			const theme = getTheme()
 
@@ -211,6 +232,9 @@ export default {
 
 			return theme === 'light' ? `${appLocation}/zaakafhandelapp/img/mailbox-open-outline-dark.svg` : `${appLocation}/zaakafhandelapp/img/mailbox-open-outline.svg`
 		},
+		/**
+		 * @spec openspec/specs/ui-dashboard-widgets/spec.md#REQ-003
+		 */
 		getItemAgentIcon() {
 			const theme = getTheme()
 
@@ -225,6 +249,8 @@ export default {
 		// === MODAL CONTROL ===
 		/**
 		 * Opens the contactmoment form modal in create/add mode
+		  *
+		  * @spec openspec/specs/ui-dashboard-widgets/spec.md#REQ-005
 		 */
 		openModal() {
 			this.isContactMomentFormOpen = true
@@ -233,6 +259,8 @@ export default {
 		},
 		/**
 		 * runs when the contact form modal closes
+		  *
+		  * @spec openspec/specs/ui-dashboard-widgets/spec.md#REQ-005
 		 */
 		closeModal() {
 			this.isContactMomentFormOpen = false
@@ -244,6 +272,8 @@ export default {
 		/**
 		 * runs when the user clicks on the show button, and opens the contactmoment form modal in view mode
 		 * @param {{id: number}} event - the contactmoment item received from the widget
+		  *
+		  * @spec openspec/specs/ui-dashboard-widgets/spec.md#REQ-004
 		 */
 		onShow(event) {
 			this.contactMomentId = event.id
@@ -253,6 +283,8 @@ export default {
 		/**
 		 * runs when the user clicks on the edit button, and opens the contactmoment form modal in edit mode
 		 * @param {{id: number}} event - the contactmoment item received from the widget
+		  *
+		  * @spec openspec/specs/ui-dashboard-widgets/spec.md#REQ-004
 		 */
 		onEdit(event) {
 			this.contactMomentId = event.id
@@ -262,6 +294,8 @@ export default {
 		/**
 		 * runs when the user clicks on the "sluiten" button, and changes the status of the contactmoment to 'gesloten'
 		 * @param {{id: number}} event - the contactmoment item received from the widget
+		  *
+		  * @spec openspec/specs/ui-dashboard-widgets/spec.md#REQ-004
 		 */
 		async onSluiten(event) {
 			const { data } = await contactMomentStore.getContactMoment(event.id)

--- a/src/views/widgets/OpenZakenWidget.vue
+++ b/src/views/widgets/OpenZakenWidget.vue
@@ -52,6 +52,9 @@ export default {
 	},
 
 	computed: {
+		/**
+		 * @spec openspec/specs/ui-dashboard-widgets/spec.md#REQ-001
+		 */
 		items() {
 			return this.zaakItems
 		},
@@ -62,6 +65,9 @@ export default {
 	},
 
 	methods: {
+		/**
+		 * @spec openspec/specs/ui-dashboard-widgets/spec.md#REQ-001
+		 */
 		fetchZaakItems() {
 			this.loading = true
 			zaakStore.refreshZakenList()
@@ -76,6 +82,9 @@ export default {
 					this.loading = false
 				})
 		},
+		/**
+		 * @spec openspec/specs/ui-dashboard-widgets/spec.md#REQ-003
+		 */
 		getItemIcon() {
 			const theme = getTheme()
 
@@ -87,9 +96,15 @@ export default {
 
 			return theme === 'light' ? `${appLocation}/zaakafhandelapp/img/briefcase-account-outline-dark.svg` : `${appLocation}/zaakafhandelapp/img/briefcase-account-outline.svg`
 		},
+		/**
+		 * @spec openspec/specs/ui-dashboard-widgets/spec.md#REQ-002
+		 */
 		search() {
 			console.info('click')
 		},
+		/**
+		 * @spec openspec/specs/ui-dashboard-widgets/spec.md#REQ-004
+		 */
 		onShow() {
 			window.open('/apps/opencatalogi/catalogi', '_self')
 		},

--- a/src/views/widgets/OrganisatiesWidget.vue
+++ b/src/views/widgets/OrganisatiesWidget.vue
@@ -78,9 +78,15 @@ export default {
 	},
 
 	computed: {
+		/**
+		 * @spec openspec/specs/ui-dashboard-widgets/spec.md#REQ-001
+		 */
 		items() {
 			return this.organisatieItems
 		},
+		/**
+		 * @spec openspec/specs/ui-dashboard-widgets/spec.md#REQ-003
+		 */
 		itemMenu() {
 			return {
 				show: {
@@ -96,6 +102,9 @@ export default {
 	},
 
 	methods: {
+		/**
+		 * @spec openspec/specs/ui-dashboard-widgets/spec.md#REQ-001
+		 */
 		fetchOrganisatieItems() {
 			this.loading = true
 			klantStore.searchOrganisations()
@@ -110,6 +119,9 @@ export default {
 					this.loading = false
 				})
 		},
+		/**
+		 * @spec openspec/specs/ui-dashboard-widgets/spec.md#REQ-002
+		 */
 		search() {
 			this.loading = true
 			klantStore.searchOrganisations(this.searchOrganisatie)
@@ -126,6 +138,9 @@ export default {
 					this.loading = false
 				})
 		},
+		/**
+		 * @spec openspec/specs/ui-dashboard-widgets/spec.md#REQ-003
+		 */
 		getItemIcon() {
 			const theme = getTheme()
 
@@ -137,6 +152,9 @@ export default {
 
 			return theme === 'light' ? `${appLocation}/zaakafhandelapp/img/office-building-outline-dark.svg` : `${appLocation}/zaakafhandelapp/img/office-building-outline.svg`
 		},
+		/**
+		 * @spec openspec/specs/ui-dashboard-widgets/spec.md#REQ-004
+		 */
 		onShow(item) {
 			klantStore.setWidgetKlantId(item.id)
 			this.isModalOpen = true

--- a/src/views/widgets/PersonenWidget.vue
+++ b/src/views/widgets/PersonenWidget.vue
@@ -120,6 +120,9 @@ export default {
 	},
 
 	computed: {
+		/**
+		 * @spec openspec/specs/ui-dashboard-widgets/spec.md#REQ-003
+		 */
 		itemMenu() {
 			return {
 				show: {
@@ -143,6 +146,9 @@ export default {
 	},
 
 	methods: {
+		/**
+		 * @spec openspec/specs/ui-dashboard-widgets/spec.md#REQ-005
+		 */
 		createKlantItems(klant) {
 			this.selectedKlantId = klant.id
 
@@ -153,6 +159,9 @@ export default {
 				avatarUrl: this.getItemIcon(),
 			}]
 		},
+		/**
+		 * @spec openspec/specs/ui-dashboard-widgets/spec.md#REQ-003
+		 */
 		getItemIcon() {
 			const theme = getTheme()
 
@@ -164,17 +173,29 @@ export default {
 
 			return theme === 'light' ? `${appLocation}/zaakafhandelapp/img/account-outline-dark.svg` : `${appLocation}/zaakafhandelapp/img/account-outline.svg`
 		},
+		/**
+		 * @spec openspec/specs/ui-dashboard-widgets/spec.md#REQ-005
+		 */
 		openSearchKlantModal() {
 			this.searchKlantModalOpen = true
 		},
+		/**
+		 * @spec openspec/specs/ui-dashboard-widgets/spec.md#REQ-005
+		 */
 		closeSearchKlantModal() {
 			this.searchKlantModalOpen = false
 		},
+		/**
+		 * @spec openspec/specs/ui-dashboard-widgets/spec.md#REQ-004
+		 */
 		onShow(item) {
 			klantStore.setWidgetKlantId(item.id)
 			this.isModalOpen = true
 			navigationStore.setModal('viewKlant')
 		},
+		/**
+		 * @spec openspec/specs/ui-dashboard-widgets/spec.md#REQ-001
+		 */
 		fetchZaakItems() {
 			this.loading = true
 			zaakStore.refreshZakenList()
@@ -182,6 +203,9 @@ export default {
 					this.loading = false
 				})
 		},
+		/**
+		 * @spec openspec/specs/ui-dashboard-widgets/spec.md#REQ-001
+		 */
 		fetchContactMomentenItems() {
 			this.loading = true
 			contactMomentStore.refreshContactMomentenList()
@@ -189,6 +213,9 @@ export default {
 					this.loading = false
 				})
 		},
+		/**
+		 * @spec openspec/specs/ui-dashboard-widgets/spec.md#REQ-001
+		 */
 		fetchTaakItems() {
 			this.loading = true
 			taakStore.refreshTakenList()

--- a/src/views/widgets/TakenWidget.vue
+++ b/src/views/widgets/TakenWidget.vue
@@ -82,9 +82,15 @@ export default {
 	},
 
 	computed: {
+		/**
+		 * @spec openspec/specs/ui-dashboard-widgets/spec.md#REQ-001
+		 */
 		items() {
 			return this.taakItems
 		},
+		/**
+		 * @spec openspec/specs/ui-dashboard-widgets/spec.md#REQ-003
+		 */
 		itemMenu() {
 			return {
 				show: {
@@ -108,6 +114,9 @@ export default {
 	},
 
 	methods: {
+		/**
+		 * @spec openspec/specs/ui-dashboard-widgets/spec.md#REQ-001
+		 */
 		async fetchUser() {
 			this.loading = true
 
@@ -136,6 +145,9 @@ export default {
 			this.userEmail = medewerker.email
 			this.fetchTaakItems()
 		},
+		/**
+		 * @spec openspec/specs/ui-dashboard-widgets/spec.md#REQ-001
+		 */
 		fetchTaakItems() {
 
 			this.loading = true
@@ -152,6 +164,9 @@ export default {
 					this.loading = false
 				})
 		},
+		/**
+		 * @spec openspec/specs/ui-dashboard-widgets/spec.md#REQ-003
+		 */
 		getItemIcon() {
 			const theme = getTheme()
 
@@ -163,21 +178,33 @@ export default {
 
 			return theme === 'light' ? `${appLocation}/zaakafhandelapp/img/calendar-month-outline-dark.svg` : `${appLocation}/zaakafhandelapp/img/calendar-month-outline.svg`
 		},
+		/**
+		 * @spec openspec/specs/ui-dashboard-widgets/spec.md#REQ-005
+		 */
 		openModal() {
 			this.isModalOpen = true
 			this.taakId = null
 			taakStore.setTaakItem(null)
 			navigationStore.setModal('editTaak')
 		},
+		/**
+		 * @spec openspec/specs/ui-dashboard-widgets/spec.md#REQ-005
+		 */
 		closeModal() {
 			this.isModalOpen = false
 			navigationStore.setModal(null)
 		},
+		/**
+		 * @spec openspec/specs/ui-dashboard-widgets/spec.md#REQ-004
+		 */
 
 		onShow(event) {
 			this.taakId = event.id
 			this.isModalOpen = true
 		},
+		/**
+		 * @spec openspec/specs/ui-dashboard-widgets/spec.md#REQ-004
+		 */
 
 		async onCloseStatus(event) {
 			// change status to 'gesloten'
@@ -200,6 +227,9 @@ export default {
 					}
 				})
 		},
+		/**
+		 * @spec openspec/specs/ui-dashboard-widgets/spec.md#REQ-004
+		 */
 		async onHandledStatus(event) {
 			// change status to 'afgerond'
 			const { data } = await taakStore.getTaak(event.id)

--- a/src/views/widgets/ZakenWidget.vue
+++ b/src/views/widgets/ZakenWidget.vue
@@ -59,6 +59,9 @@ export default {
 		}
 	},
 	computed: {
+		/**
+		 * @spec openspec/specs/ui-dashboard-widgets/spec.md#REQ-001
+		 */
 		items() {
 			return this.zaakItems
 		},
@@ -67,6 +70,9 @@ export default {
 		this.fetchZaakItems()
 	},
 	methods: {
+		/**
+		 * @spec openspec/specs/ui-dashboard-widgets/spec.md#REQ-001
+		 */
 		fetchZaakItems() {
 			this.loading = true
 			zaakStore.refreshZakenList()
@@ -81,15 +87,24 @@ export default {
 					this.loading = false
 				})
 		},
+		/**
+		 * @spec openspec/specs/ui-dashboard-widgets/spec.md#REQ-005
+		 */
 		openModal() {
 			this.isModalOpen = true
 			zaakStore.setZaakItem(null)
 			navigationStore.setModal('zaakForm')
 		},
+		/**
+		 * @spec openspec/specs/ui-dashboard-widgets/spec.md#REQ-005
+		 */
 		closeModal() {
 			this.isModalOpen = false
 			navigationStore.setModal(null)
 		},
+		/**
+		 * @spec openspec/specs/ui-dashboard-widgets/spec.md#REQ-003
+		 */
 		getItemIcon() {
 			const theme = getTheme()
 
@@ -101,9 +116,15 @@ export default {
 
 			return theme === 'light' ? `${appLocation}/zaakafhandelapp/img/briefcase-account-outline-dark.svg` : `${appLocation}/zaakafhandelapp/img/briefcase-account-outline.svg`
 		},
+		/**
+		 * @spec openspec/specs/ui-dashboard-widgets/spec.md#REQ-002
+		 */
 		search() {
 			console.info('click')
 		},
+		/**
+		 * @spec openspec/specs/ui-dashboard-widgets/spec.md#REQ-004
+		 */
 		onShow() {
 			window.open('/apps/opencatalogi/catalogi', '_self')
 		},

--- a/src/views/zaakTypen/ZaakTypeDetails.vue
+++ b/src/views/zaakTypen/ZaakTypeDetails.vue
@@ -177,6 +177,9 @@ export default {
 		}
 	},
 	watch: {
+		/**
+		 * @spec openspec/specs/ui-case-views/spec.md#REQ-005
+		 */
 		id(newId) {
 			this.fetchData(newId)
 		},
@@ -185,6 +188,9 @@ export default {
 		this.fetchData(this.id)
 	},
 	methods: {
+		/**
+		 * @spec openspec/specs/ui-case-views/spec.md#REQ-001
+		 */
 		fetchData(id) {
 			this.loading = true
 

--- a/src/views/zaakTypen/ZaakTypenList.vue
+++ b/src/views/zaakTypen/ZaakTypenList.vue
@@ -111,6 +111,9 @@ export default {
 			loading: false,
 		}
 	},
+	/**
+	 * @spec openspec/specs/ui-case-views/spec.md#REQ-005
+	 */
 	mounted() {
 		this.loading = true
 
@@ -124,10 +127,16 @@ export default {
 			})
 	},
 	methods: {
+		/**
+		 * @spec openspec/specs/ui-case-views/spec.md#REQ-004
+		 */
 		openZaakType(zaaktype) {
 			zaakTypeStore.setZaakTypeItem(zaaktype)
 			this.$router.push({ name: 'ZaaktypeDetail', params: { id: zaaktype.id } })
 		},
+		/**
+		 * @spec openspec/specs/ui-case-views/spec.md#REQ-003
+		 */
 		clearText() {
 			this.search = ''
 		},

--- a/src/views/zaken/ZaakDetails.vue
+++ b/src/views/zaken/ZaakDetails.vue
@@ -269,20 +269,32 @@ export default {
 		}
 	},
 	computed: {
+		/**
+		 * @spec openspec/specs/ui-case-views/spec.md#REQ-005
+		 */
 		zaakType() {
 			return zaakTypeStore.zaakTypeList.find((zaakType) => zaakType.id === zaakStore.zaakItem.zaaktype || Symbol('no zaaktype id'))
 		},
 	},
 	watch: {
+		/**
+		 * @spec openspec/specs/ui-case-views/spec.md#REQ-005
+		 */
 		id(newId) {
 			this.fetchData(newId)
 		},
 	},
+	/**
+	 * @spec openspec/specs/ui-case-views/spec.md#REQ-005
+	 */
 	mounted() {
 		this.fetchData(this.id)
 		zaakTypeStore.refreshZaakTypenList()
 	},
 	methods: {
+		/**
+		 * @spec openspec/specs/ui-case-views/spec.md#REQ-001
+		 */
 		fetchData(id) {
 			this.loading = true
 
@@ -293,6 +305,9 @@ export default {
 				this.loading = false
 			})
 		},
+		/**
+		 * @spec openspec/specs/ui-case-views/spec.md#REQ-001
+		 */
 		fetchAuditTrails(id) {
 
 			fetch(`/index.php/apps/zaakafhandelapp/api/zaken/${id}/audit_trail`)
@@ -305,6 +320,9 @@ export default {
 				.finally(() => {
 				})
 		},
+		/**
+		 * @spec openspec/specs/ui-case-views/spec.md#REQ-005
+		 */
 		goToZaakType(zaakType) {
 			zaakTypeStore.setZaakTypeItem(zaakType)
 			this.$router.push({ name: 'ZaaktypeDetail', params: { id: zaakType.id } })

--- a/src/views/zaken/ZakenList.vue
+++ b/src/views/zaken/ZakenList.vue
@@ -114,6 +114,9 @@ export default {
 			zakenList: [],
 		}
 	},
+	/**
+	 * @spec openspec/specs/ui-case-views/spec.md#REQ-005
+	 */
 	mounted() {
 		this.loading = true
 
@@ -125,9 +128,15 @@ export default {
 		})
 	},
 	methods: {
+		/**
+		 * @spec openspec/specs/ui-case-views/spec.md#REQ-003
+		 */
 		clearText() {
 			this.search = ''
 		},
+		/**
+		 * @spec openspec/specs/ui-case-views/spec.md#REQ-004
+		 */
 		openZaak(zaak) {
 			zaakStore.setZaakItem(zaak)
 			this.$router.push({ params: { id: zaak.id } })

--- a/src/views/zaken/ZakenZaken.vue
+++ b/src/views/zaken/ZakenZaken.vue
@@ -74,6 +74,9 @@ export default {
 		}
 	},
 	watch: {
+		/**
+		 * @spec openspec/specs/ui-case-views/spec.md#REQ-002
+		 */
 		zaakId(newVal) {
 			this.fetchData(newVal)
 		},
@@ -82,6 +85,9 @@ export default {
 		this.fetchData(this.zaakId)
 	},
 	methods: {
+		/**
+		 * @spec openspec/specs/ui-case-views/spec.md#REQ-001
+		 */
 		fetchData() {
 			this.loading = true
 
@@ -90,9 +96,15 @@ export default {
 					this.loading = false
 				})
 		},
+		/**
+		 * @spec openspec/specs/ui-case-views/spec.md#REQ-002
+		 */
 		toggleZaak(zaak) {
 			// TODO: toggle zaak in local component
 		},
+		/**
+		 * @spec openspec/specs/ui-case-views/spec.md#REQ-003
+		 */
 		clearText() {
 			this.search = ''
 		},


### PR DESCRIPTION
## Retrofit — Reverse-Spec to zero uncovered

Brings `zaakafhandelapp` to **0 uncovered spec-coverage methods** (gate-16), down from **628** (175 backend + 453 frontend).

### What this PR does
- Adds **13 capability specs** under `openspec/specs/` describing observed behavior:
  - **Backend (ZGW):** `zgw-zaak-management`, `zgw-related-resources`, `zgw-client-interaction`, `zgw-object-data-access`, `zgw-case-lifecycle`, `app-configuration`
  - **Frontend:** `ui-case-views`, `ui-client-views`, `ui-modals`, `ui-dashboard-widgets`, `ui-search-navigation`, `state-stores`, `domain-entities`
- Annotates **625 methods** with `@spec openspec/specs/<cap>/spec.md#REQ-NNN` (pure docblock additions; 1772 insertions / 0 deletions)
- **2 methods excluded** with reasons: `App.vue::provide` (DI plumbing), `App.vue::translateForApp` (i18n wrapper)

### What this PR does NOT do
- No code behavior changes — only docblock `@spec` annotations
- No silent bug fixes — observed-behavior-not-aspirational

### Verification
- coverage script `--mode report` → **uncovered 0**
- `php -l` passes on every `lib/**/*.php`
- Original CRLF line endings preserved (additive-only diff)