### PR TITLE
feat(preferences): generic per-user preferences endpoint

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -67,6 +67,9 @@ return [
 		// user Settings
 		['name' => 'settings#index','url' => '/settings', 'verb' => 'GET'],
 		['name' => 'settings#create', 'url' => '/settings', 'verb' => 'POST'],
+		// Generic per-user preferences (used by shared nextcloud-vue widgets, e.g. CnSupportDialog).
+		['name' => 'preferences#getPreference', 'url' => '/api/preferences/{key}', 'verb' => 'GET'],
+		['name' => 'preferences#setPreference', 'url' => '/api/preferences/{key}', 'verb' => 'PUT'],
 		// User
 		['name' => 'users#me', 'url' => '/me', 'verb' => 'GET'],
 		// Object API routes	

--- a/lib/Controller/PreferencesController.php
+++ b/lib/Controller/PreferencesController.php
@@ -1,0 +1,152 @@
+<?php
+
+/**
+ * Zaakafhandelapp PreferencesController.
+ *
+ * Generic per-user key/value preferences, backed by Nextcloud IConfig
+ * user values. Used by shared @conduction/nextcloud-vue widgets (e.g.
+ * CnSupportDialog's "seen" flag) that need to persist a small per-user
+ * UI flag cross-device without a bespoke endpoint per feature.
+ *
+ * @category Controller
+ * @package  OCA\ZaakAfhandelApp\Controller
+ *
+ * @author    Conduction Development Team <info@conduction.nl>
+ * @copyright 2024 Conduction B.V.
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ *
+ * @version GIT: <git_id>
+ *
+ * @link https://github.com/ConductionNL/zaakafhandelapp
+ */
+
+declare(strict_types=1);
+
+namespace OCA\ZaakAfhandelApp\Controller;
+
+use OCA\ZaakAfhandelApp\AppInfo\Application;
+use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http;
+use OCP\AppFramework\Http\JSONResponse;
+use OCP\IConfig;
+use OCP\IRequest;
+use OCP\IUserSession;
+
+/**
+ * Per-user preferences controller.
+ */
+class PreferencesController extends Controller
+{
+    /**
+     * Constructor.
+     *
+     * @param IRequest     $request     The request.
+     * @param IConfig      $config      The Nextcloud config (user values).
+     * @param IUserSession $userSession The user session.
+     */
+    public function __construct(
+        IRequest $request,
+        private readonly IConfig $config,
+        private readonly IUserSession $userSession,
+    ) {
+        parent::__construct(appName: Application::APP_ID, request: $request);
+
+    }//end __construct()
+
+    /**
+     * Read a per-user preference value.
+     *
+     * @param string $key The preference key (kebab/alphanumeric).
+     *
+     * @return JSONResponse `{value: string|null}`.
+     *
+     * @NoAdminRequired
+     * @NoCSRFRequired
+     */
+    public function getPreference(string $key): JSONResponse
+    {
+        $user = $this->userSession->getUser();
+        if ($user === null) {
+            return new JSONResponse(data: ['message' => 'Not logged in'], statusCode: Http::STATUS_UNAUTHORIZED);
+        }
+
+        $safeKey = $this->sanitizeKey(key: $key);
+        if ($safeKey === '') {
+            return new JSONResponse(data: ['message' => 'Invalid key'], statusCode: Http::STATUS_BAD_REQUEST);
+        }
+
+        $value = $this->config->getUserValue(
+            userId: $user->getUID(),
+            appName: Application::APP_ID,
+            key: 'pref_'.$safeKey,
+            default: ''
+        );
+
+        $stored = null;
+        if ($value !== '') {
+            $stored = $value;
+        }
+
+        return new JSONResponse(data: ['value' => $stored]);
+
+    }//end getPreference()
+
+    /**
+     * Write a per-user preference value. An empty value clears it.
+     *
+     * @param string $key   The preference key (kebab/alphanumeric).
+     * @param string $value The value to store (empty string clears it).
+     *
+     * @return JSONResponse `{value: string|null}`.
+     *
+     * @NoAdminRequired
+     * @NoCSRFRequired
+     */
+    public function setPreference(string $key, string $value=''): JSONResponse
+    {
+        $user = $this->userSession->getUser();
+        if ($user === null) {
+            return new JSONResponse(data: ['message' => 'Not logged in'], statusCode: Http::STATUS_UNAUTHORIZED);
+        }
+
+        $safeKey = $this->sanitizeKey(key: $key);
+        if ($safeKey === '') {
+            return new JSONResponse(data: ['message' => 'Invalid key'], statusCode: Http::STATUS_BAD_REQUEST);
+        }
+
+        $stored = null;
+        if ($value === '') {
+            $this->config->deleteUserValue(
+                userId: $user->getUID(),
+                appName: Application::APP_ID,
+                key: 'pref_'.$safeKey
+            );
+        } else {
+            $this->config->setUserValue(
+                userId: $user->getUID(),
+                appName: Application::APP_ID,
+                key: 'pref_'.$safeKey,
+                value: $value
+            );
+            $stored = $value;
+        }
+
+        return new JSONResponse(data: ['value' => $stored]);
+
+    }//end setPreference()
+
+    /**
+     * Restrict keys to a safe charset so callers cannot reach arbitrary
+     * IConfig user values outside the `pref_` namespace.
+     *
+     * @param string $key The raw key.
+     *
+     * @return string The sanitised key, or '' when nothing safe remains.
+     */
+    private function sanitizeKey(string $key): string
+    {
+        $safe = preg_replace(pattern: '/[^a-z0-9-]/', replacement: '', subject: strtolower($key));
+        return substr((string) $safe, offset: 0, length: 64);
+
+    }//end sanitizeKey()
+}//end class


### PR DESCRIPTION
## Summary

Adds a generic per-user key/value preferences endpoint, backed by Nextcloud `IConfig` user values. This backs the shared `@conduction/nextcloud-vue` `CnSupportDialog` auto-mount per-user seen-flag, so a small per-user UI flag can persist cross-device without a bespoke endpoint per feature.

Identical change already merged in pipelinq#553 and decidesk#266.

## Endpoints
- `GET /api/preferences/{key}` -> `{value: string|null}`
- `PUT /api/preferences/{key}` -> `{value: string|null}` (empty value clears it)

Keys are sanitised to `[a-z0-9-]` (max 64 chars) and namespaced under `pref_` so callers cannot reach arbitrary IConfig user values.

## Files
- `lib/Controller/PreferencesController.php` (new)
- `appinfo/routes.php` (2 routes added)