### PR TITLE
[change request] zaakafhandelapp notifications (deprecated — confirm scope)

### DIFF
--- a/openspec/changes/zaakafhandelapp-notifications/.openspec.yaml
+++ b/openspec/changes/zaakafhandelapp-notifications/.openspec.yaml
@@ -1,0 +1,2 @@
+schema: spec-driven
+created: 2026-05-25

--- a/openspec/changes/zaakafhandelapp-notifications/proposal.md
+++ b/openspec/changes/zaakafhandelapp-notifications/proposal.md
@@ -1,0 +1,77 @@
+---
+kind: config
+depends_on: [notification-updated-field-change-condition]
+---
+
+# Zaakafhandelapp Notifications
+
+## ⚠ ZAA IS DEPRECATED — recommendation: do NOT implement here
+
+Zaakafhandelapp is **deprecated**, superseded by **procest** (case management /
+zaakgericht-werken) and **pipelinq** (CRM / requests). The fleet notification
+analysis (`hydra/openspec/fleet-notification-plan.md`, zaakafhandelapp row)
+flags it explicitly: *"confirm whether to wire at all vs route to
+procest/pipelinq."*
+
+**Recommendation: do NOT add notification wiring to ZAA.** Route all
+case-handling notification effort to procest + pipelinq, which carry the active
+data model and are greenfield-ready in the same plan. This change request exists
+to **document the would-be rule set for completeness** and to force an explicit
+scope decision — not as an endorsement to implement. The first task in tasks.md
+is a DECISION task; if the decision is "route to procest/pipelinq" (the
+recommendation), this change is closed without implementation and the rules
+below are carried into the procest/pipelinq notification changes instead.
+
+ZAA has **no local register JSON** — it is a ZGW case-handling front-end over
+**runtime OpenRegister registers**. So the schema slugs below are marked
+**"(runtime OR register — confirm slugs)"**: there is no in-repo schema file to
+annotate; rules would have to be applied to the runtime register schemas, which
+is itself an argument for routing the effort to the apps that own those schemas.
+
+## Why (the underlying need, to be served by procest/pipelinq)
+
+Municipal case workers need to know when a case transitions, a case is closed, a
+task is assigned or overdue, a decision is recorded, or a role is assigned.
+These are real needs — but in the deprecated app they have no durable home.
+
+## Would-be rule set (documented for completeness; target = procest/pipelinq)
+
+Declared as `x-openregister-notifications`, subjects bilingual nl/en,
+metadata-only. Status-change rules use `updated`+`condition` (per
+`notification-updated-field-change-condition`).
+
+- **Case status transition** (`zaak` runtime OR register — confirm slug):
+  `transition` (named ZGW status action) **or** `updated`+`condition`
+  `{"field":"status","operator":"changed"}` → `{"kind":"field","field":"assignee"}`
+  + case-handling group.
+- **Case closed** (`zaak`): `updated`+`condition`
+  `{"field":"status","operator":"equals","value":"afgehandeld"}` →
+  `{"kind":"field","field":"assignee"}` + case-handling group.
+- **Task assigned** (`taak` runtime OR register — confirm slug): `created` (or
+  `updated`+`condition` on assignee) → `{"kind":"field","field":"assignee"}`.
+- **Task overdue** (`taak`): `scheduled` deadline check against the task due
+  date → `{"kind":"field","field":"assignee"}`.
+- **Decision recorded** (`besluit` runtime OR register — confirm slug):
+  `created` → case owner + relevant group.
+- **Role assigned** (`rol` runtime OR register — confirm slug): `created` →
+  `{"kind":"field","field":"assignee"}`.
+
+## Capabilities
+
+### Added Capabilities
+
+- `notifications`: documents the case-handling notification rule set that ZAA
+  *would* declare (case transition/closed, task assigned/overdue, decision,
+  role). **Recommended NOT to implement in ZAA (deprecated); route to procest +
+  pipelinq.** Gated on an explicit scope decision.
+
+## Impact
+
+- **Recommendation:** no code/config change in ZAA. The rules are carried into
+  procest + pipelinq notification changes instead.
+- **If ZAA were wired anyway:** rules would attach to runtime OR register
+  schemas (no in-repo register JSON), with slugs confirmed at apply time —
+  another reason the recommendation is to route elsewhere.
+- **Engine dependency:** status-change rules require
+  `notification-updated-field-change-condition` (archived in openregister).
+- **No** external-email channel needed — recipients are internal uids/groups.

--- a/openspec/changes/zaakafhandelapp-notifications/specs/notifications/spec.md
+++ b/openspec/changes/zaakafhandelapp-notifications/specs/notifications/spec.md
@@ -1,0 +1,41 @@
+## ADDED Requirements
+
+### Requirement: The case-handling notification scope MUST be decided before any wiring
+Because Zaakafhandelapp is deprecated (superseded by procest + pipelinq), the project MUST make an explicit decision on whether case-handling notifications are wired in ZAA at all, or routed to procest + pipelinq, before any notification rule is attached. The recommended outcome is to route to procest + pipelinq and NOT implement in ZAA. This change MUST NOT attach notification rules to ZAA until that decision explicitly chooses ZAA.
+
+#### Scenario: Scope decision routes the effort to procest/pipelinq (recommended)
+- GIVEN Zaakafhandelapp is deprecated and procest + pipelinq own the active case-management data model
+- WHEN the notification scope decision is made
+- THEN the recommended outcome MUST be to NOT implement notifications in ZAA
+- AND the documented rule set MUST be carried into the procest and pipelinq notification changes instead
+- AND this ZAA change MUST be closed without attaching rules to ZAA
+
+#### Scenario: Scope decision (if it nevertheless chooses ZAA) records runtime register slugs
+- GIVEN ZAA has no local register JSON and uses runtime OpenRegister registers
+- WHEN the decision instead chooses to wire ZAA directly
+- THEN the canonical runtime OR register slugs for `zaak`, `taak`, `besluit`, and `rol` MUST be confirmed before any rule is attached
+- AND only then may the documented rules be applied
+
+### Requirement: The case-handling notification rule set MUST be documented for completeness
+For completeness, the change MUST document the case-handling notification rules that ZAA would declare via `x-openregister-notifications`, consumed by the OpenRegister `notificatie-engine`: case status transition, case closed, task assigned, task overdue, decision recorded, and role assigned. All subjects MUST be bilingual (`nl`/`en`) and metadata-only. Status-change rules MUST use the `updated` trigger with a field-change `condition` (per `notification-updated-field-change-condition`); deadline rules MUST use the `scheduled` trigger. This documentation MUST NOT be construed as an instruction to implement in ZAA.
+
+#### Scenario: Case status transition would notify the assignee
+- GIVEN the `zaak` schema (runtime OR register — slug confirmed) declares a transition rule (named ZGW status action) or an `updated`+`condition` `{"field":"status","operator":"changed"}` rule with recipients `{"kind":"field","field":"assignee"}` plus a case-handling group
+- WHEN a case's status changes
+- THEN the engine would deliver a notification to the case assignee and the case-handling group
+- AND the subject would be available in both `nl` and `en` and contain only metadata
+
+#### Scenario: Case closed would notify the assignee
+- GIVEN the `zaak` schema declares an `updated`+`condition` `{"field":"status","operator":"equals","value":"afgehandeld"}` rule with recipients `{"kind":"field","field":"assignee"}`
+- WHEN a case's status changes to `afgehandeld`
+- THEN the engine would deliver a case-closed notification to the case assignee
+
+#### Scenario: Task assigned and task overdue would notify the assignee
+- GIVEN the `taak` schema declares a `created` (or `updated`+`condition` on assignee) rule and a `scheduled` deadline rule against the task due date, both with recipients `{"kind":"field","field":"assignee"}`
+- WHEN a task is assigned, and separately when it passes its due date
+- THEN the engine would deliver an assignment notification and an overdue notification to the task assignee respectively
+
+#### Scenario: Decision recorded and role assigned would notify the relevant recipients
+- GIVEN the `besluit` schema declares a `created` rule (→ case owner + group) and the `rol` schema declares a `created` rule (→ `{"kind":"field","field":"assignee"}`)
+- WHEN a decision is recorded, and separately when a role is assigned
+- THEN the engine would deliver the corresponding notifications to the case owner/group and the assigned role holder respectively

--- a/openspec/changes/zaakafhandelapp-notifications/tasks.md
+++ b/openspec/changes/zaakafhandelapp-notifications/tasks.md
@@ -1,0 +1,27 @@
+## 1. DECISION — confirm scope before any wiring (BLOCKING)
+
+- [ ] 1.1 Confirm whether case-handling notifications are wired in ZAA at all, or routed to procest + pipelinq. **Recommended: route to procest + pipelinq; do NOT implement in ZAA (deprecated).**
+- [ ] 1.2 If the decision is "route to procest/pipelinq" (recommended): close this change without implementation and carry the documented rule set into the procest + pipelinq notification changes. STOP here.
+- [ ] 1.3 If the decision nevertheless chooses ZAA: confirm the canonical runtime OpenRegister register slugs for `zaak`, `taak`, `besluit`, `rol` (ZAA has no local register JSON), and confirm `notification-updated-field-change-condition` is deployed.
+
+## 2. Documented rule set (reference only unless 1.3 is chosen)
+
+- [ ] 2.1 Case status transition — `transition` (ZGW status action) or `updated`+`condition` `{"field":"status","operator":"changed"}` → `{"kind":"field","field":"assignee"}` + case-handling group.
+- [ ] 2.2 Case closed — `updated`+`condition` equals `afgehandeld` → `{"kind":"field","field":"assignee"}`.
+- [ ] 2.3 Task assigned — `created` (or `updated`+`condition` on assignee) → `{"kind":"field","field":"assignee"}`.
+- [ ] 2.4 Task overdue — `scheduled` against the task due date → `{"kind":"field","field":"assignee"}`.
+- [ ] 2.5 Decision recorded — `created` → case owner + group.
+- [ ] 2.6 Role assigned — `created` → `{"kind":"field","field":"assignee"}`.
+
+## 3. If implemented (only if 1.3 chosen)
+
+- [ ] 3.1 Apply the rules to the confirmed runtime OR register schemas; bilingual nl/en, metadata-only subjects.
+- [ ] 3.2 Validate rule shapes against OpenRegister's `NotificationAnnotationValidator`.
+- [ ] 3.3 Browser-verify a representative rule dispatches end-to-end.
+
+## Acceptance criteria
+
+- An explicit scope decision is recorded (recommended: route to procest/pipelinq, do NOT implement in ZAA).
+- The case-handling rule set is documented for completeness (case transition/closed, task assigned/overdue, decision, role).
+- No notification rules are attached to ZAA unless the decision explicitly chooses ZAA and confirms the runtime register slugs.
+- If implemented, all subjects are bilingual (nl/en) and metadata-only; no app-local notification service code (ADR-031).


### PR DESCRIPTION
## Summary

OpenSpec change request for case-handling notifications via the OpenRegister notification engine (`x-openregister-notifications`, `kind: config`).

**Change:** `openspec/changes/zaakafhandelapp-notifications/` — `openspec validate --strict` passes.

## ⚠ ZAA is deprecated — recommendation: do NOT implement here

Zaakafhandelapp is superseded by **procest** (case management) + **pipelinq** (CRM/requests). The fleet plan (`hydra/openspec/fleet-notification-plan.md`, zaakafhandelapp row) flags this explicitly: *"confirm whether to wire at all vs route to procest/pipelinq."*

**Recommendation: route the notification effort to procest + pipelinq and do NOT add wiring to ZAA.** This change request documents the would-be rule set for completeness and forces an explicit scope decision — the first task in `tasks.md` is a **DECISION task**.

ZAA has **no local register JSON** (runtime OR registers), so the schema slugs (`zaak`/`taak`/`besluit`/`rol`) are marked "(runtime OR register — confirm slugs)" — another reason to route to the apps that own those schemas.

## Documented rule set (target = procest/pipelinq)

- Case status transition / case closed → assignee + case-handling group
- Task assigned (created) / task overdue (scheduled) → assignee
- Decision recorded (created) → owner + group
- Role assigned (created) → assignee

Status-change rules use the `updated`+`condition` field-change support (depends on openregister `notification-updated-field-change-condition`). Subjects bilingual (nl/en), metadata-only.

Draft — do not merge. Pending the scope decision; recommended outcome is to close without implementing in ZAA.