### PR TITLE
fix: add EUPL-1.2 license/copyright docblock tags (hydra spdx-headers gate)

### DIFF
--- a/lib/AppInfo/Application.php
+++ b/lib/AppInfo/Application.php
@@ -17,6 +17,9 @@ use OCA\ZaakAfhandelApp\Dashboard\OrganisatiesWidget;
  * Class Application
  *
  * @package OCA\ZaakAfhandelApp\AppInfo
+ *
+ * @copyright 2024 Conduction B.V. <info@conduction.nl>
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  */
 class Application extends App implements IBootstrap
 {

--- a/lib/Controller/BerichtenController.php
+++ b/lib/Controller/BerichtenController.php
@@ -9,6 +9,12 @@ use OCP\IRequest;
 use OCP\AppFramework\Http\TemplateResponse;
 use OCP\AppFramework\Http\ContentSecurityPolicy;
 
+/**
+ * Controller for handling messages (berichten) operations.
+ *
+ * @copyright 2024 Conduction B.V. <info@conduction.nl>
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ */
 class BerichtenController extends Controller
 {
     public function __construct(

--- a/lib/Controller/BesluitenController.php
+++ b/lib/Controller/BesluitenController.php
@@ -13,6 +13,9 @@ use OCP\IRequest;
 
 /**
  * Geeft invulling aan https://vng-realisatie.github.io/gemma-zaken/standaard/zaken/
+ *
+ * @copyright 2024 Conduction B.V. <info@conduction.nl>
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  */
 class BesluitenController extends Controller
 {

--- a/lib/Controller/ConfigurationController.php
+++ b/lib/Controller/ConfigurationController.php
@@ -8,6 +8,12 @@ use OCP\AppFramework\Http\JSONResponse;
 use OCP\IAppConfig;
 use OCP\IRequest;
 
+/**
+ * Controller for application configuration operations.
+ *
+ * @copyright 2024 Conduction B.V. <info@conduction.nl>
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ */
 class ConfigurationController extends Controller
 {
     public function __construct(

--- a/lib/Controller/ContactMomentenController.php
+++ b/lib/Controller/ContactMomentenController.php
@@ -11,6 +11,9 @@ use OCP\AppFramework\Http\ContentSecurityPolicy;
 
 /**
  * Controller for handling contact moments (contactmomenten) operations
+ *
+ * @copyright 2024 Conduction B.V. <info@conduction.nl>
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  */
 class ContactMomentenController extends Controller
 {

--- a/lib/Controller/DashboardController.php
+++ b/lib/Controller/DashboardController.php
@@ -9,6 +9,12 @@ use OCP\AppFramework\Http\JSONResponse;
 use OCP\IAppConfig;
 use OCP\IRequest;
 
+/**
+ * Controller for dashboard-related operations in the ZaakAfhandelApp.
+ *
+ * @copyright 2024 Conduction B.V. <info@conduction.nl>
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ */
 class DashboardController extends Controller
 {
     const TEST_ARRAY = [

--- a/lib/Controller/DocumentenController.php
+++ b/lib/Controller/DocumentenController.php
@@ -11,6 +11,9 @@ use OCP\IRequest;
 
 /**
  * Geeft invulling aan https://vng-realisatie.github.io/gemma-zaken/standaard/zaken/
+ *
+ * @copyright 2024 Conduction B.V. <info@conduction.nl>
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  */
 class DocumentenController extends Controller
 {

--- a/lib/Controller/KlantenController.php
+++ b/lib/Controller/KlantenController.php
@@ -9,6 +9,12 @@ use OCP\IRequest;
 use OCP\AppFramework\Http\TemplateResponse;
 use OCP\AppFramework\Http\ContentSecurityPolicy;
 
+/**
+ * Controller for handling clients (klanten) operations.
+ *
+ * @copyright 2024 Conduction B.V. <info@conduction.nl>
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ */
 class KlantenController extends Controller
 {
     public function __construct(

--- a/lib/Controller/MedewerkersController.php
+++ b/lib/Controller/MedewerkersController.php
@@ -11,6 +11,9 @@ use OCP\AppFramework\Http\ContentSecurityPolicy;
 
 /**
  * Controller for handling employees (medewerkers) operations
+ *
+ * @copyright 2024 Conduction B.V. <info@conduction.nl>
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  */
 class MedewerkersController extends Controller
 {

--- a/lib/Controller/ObjectsController.php
+++ b/lib/Controller/ObjectsController.php
@@ -10,6 +10,9 @@ use Exception;
 
 /**
  * Controller class for handling object-related operations
+ *
+ * @copyright 2024 Conduction B.V. <info@conduction.nl>
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  */
 class ObjectsController extends Controller
 {

--- a/lib/Controller/ResultatenController.php
+++ b/lib/Controller/ResultatenController.php
@@ -12,6 +12,9 @@ use OCP\IRequest;
 
 /**
  * Geeft invulling aan https://vng-realisatie.github.io/gemma-zaken/standaard/zaken/
+ *
+ * @copyright 2024 Conduction B.V. <info@conduction.nl>
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  */
 class ResultatenController extends Controller
 {

--- a/lib/Controller/RollenController.php
+++ b/lib/Controller/RollenController.php
@@ -13,6 +13,9 @@ use OCP\IRequest;
  * Controller for rollen (roles) resources.
  *
  * @see https://vng-realisatie.github.io/gemma-zaken/standaard/zaken/
+ *
+ * @copyright 2024 Conduction B.V. <info@conduction.nl>
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  */
 class RollenController extends Controller
 {

--- a/lib/Controller/SettingsController.php
+++ b/lib/Controller/SettingsController.php
@@ -12,6 +12,9 @@ use OCA\ZaakAfhandelApp\Service\ObjectMapperService;
  * Class SettingsController
  *
  * Controller for handling settings-related operations in the ZaakAfhandelApp.
+ *
+ * @copyright 2024 Conduction B.V. <info@conduction.nl>
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  */
 class SettingsController extends Controller
 {

--- a/lib/Controller/StatusenController.php
+++ b/lib/Controller/StatusenController.php
@@ -12,6 +12,9 @@ use OCP\IRequest;
 
 /**
  * Geeft invulling aan https://vng-realisatie.github.io/gemma-zaken/standaard/zaken/
+ *
+ * @copyright 2024 Conduction B.V. <info@conduction.nl>
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  */
 class StatusenController extends Controller
 {

--- a/lib/Controller/TakenController.php
+++ b/lib/Controller/TakenController.php
@@ -10,6 +10,12 @@ use OCP\IRequest;
 use OCP\AppFramework\Http\TemplateResponse;
 use OCP\AppFramework\Http\ContentSecurityPolicy;
 
+/**
+ * Controller for handling tasks (taken) operations.
+ *
+ * @copyright 2024 Conduction B.V. <info@conduction.nl>
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ */
 class TakenController extends Controller
 {
     public function __construct(

--- a/lib/Controller/UsersController.php
+++ b/lib/Controller/UsersController.php
@@ -13,6 +13,9 @@ use OCP\IUserSession;
  * Class SettingsController
  *
  * Controller for handling settings-related operations in the OpenCatalogi app.
+ *
+ * @copyright 2024 Conduction B.V. <info@conduction.nl>
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  */
 class UsersController extends Controller
 {

--- a/lib/Controller/ZaakAuditTrailController.php
+++ b/lib/Controller/ZaakAuditTrailController.php
@@ -9,6 +9,12 @@ use OCP\AppFramework\Http\JSONResponse;
 use OCP\IAppConfig;
 use OCP\IRequest;
 
+/**
+ * Controller for zaak audit trail resources.
+ *
+ * @copyright 2024 Conduction B.V. <info@conduction.nl>
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ */
 class ZaakAuditTrailController extends Controller
 {
     const TEST_ARRAY = [

--- a/lib/Controller/ZaakBesluitenController.php
+++ b/lib/Controller/ZaakBesluitenController.php
@@ -9,6 +9,12 @@ use OCP\AppFramework\Http\JSONResponse;
 use OCP\IAppConfig;
 use OCP\IRequest;
 
+/**
+ * Controller for zaakbesluiten (case decisions) resources.
+ *
+ * @copyright 2024 Conduction B.V. <info@conduction.nl>
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ */
 class ZaakBesluitenController extends Controller
 {
     const TEST_ARRAY = [

--- a/lib/Controller/ZaakEigenschappenController.php
+++ b/lib/Controller/ZaakEigenschappenController.php
@@ -10,6 +10,12 @@ use OCP\AppFramework\Http\JSONResponse;
 use OCP\IAppConfig;
 use OCP\IRequest;
 
+/**
+ * Controller for zaak eigenschappen (case properties) resources.
+ *
+ * @copyright 2024 Conduction B.V. <info@conduction.nl>
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ */
 class ZaakEigenschappenController extends Controller
 {
     const TEST_ARRAY = [

--- a/lib/Controller/ZaakInformatieObjectenController.php
+++ b/lib/Controller/ZaakInformatieObjectenController.php
@@ -10,6 +10,12 @@ use OCP\AppFramework\Http\JSONResponse;
 use OCP\IAppConfig;
 use OCP\IRequest;
 
+/**
+ * Controller for zaakinformatieobjecten (case document links) resources.
+ *
+ * @copyright 2024 Conduction B.V. <info@conduction.nl>
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ */
 class ZaakInformatieObjectenController extends Controller
 {
     const TEST_ARRAY = [

--- a/lib/Controller/ZaakObjectenController.php
+++ b/lib/Controller/ZaakObjectenController.php
@@ -10,6 +10,12 @@ use OCP\AppFramework\Http\JSONResponse;
 use OCP\IAppConfig;
 use OCP\IRequest;
 
+/**
+ * Controller for zaakobjecten (case objects) resources.
+ *
+ * @copyright 2024 Conduction B.V. <info@conduction.nl>
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ */
 class ZaakObjectenController extends Controller
 {
     const TEST_ARRAY = [

--- a/lib/Controller/ZaakTypenController.php
+++ b/lib/Controller/ZaakTypenController.php
@@ -9,6 +9,12 @@ use OCP\IRequest;
 use OCP\AppFramework\Http\TemplateResponse;
 use OCP\AppFramework\Http\ContentSecurityPolicy;
 
+/**
+ * Controller for zaaktypen (case types) operations.
+ *
+ * @copyright 2024 Conduction B.V. <info@conduction.nl>
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ */
 class ZaakTypenController extends Controller
 {
     public function __construct(

--- a/lib/Controller/ZakenController.php
+++ b/lib/Controller/ZakenController.php
@@ -11,6 +11,9 @@ use OCP\AppFramework\Http\ContentSecurityPolicy;
 
 /**
  * Geeft invulling aan https://vng-realisatie.github.io/gemma-zaken/standaard/zaken/
+ *
+ * @copyright 2024 Conduction B.V. <info@conduction.nl>
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  */
 class ZakenController extends Controller
 {

--- a/lib/Dashboard/ContactmomentenWidget.php
+++ b/lib/Dashboard/ContactmomentenWidget.php
@@ -10,6 +10,12 @@ use OCP\Util;
 
 use OCA\ZaakAfhandelApp\AppInfo\Application;
 
+/**
+ * Dashboard widget showing contactmomenten (contact moments).
+ *
+ * @copyright 2024 Conduction B.V. <info@conduction.nl>
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ */
 class ContactmomentenWidget implements IWidget
 {
     public function __construct(

--- a/lib/Dashboard/OpenZakenWidget.php
+++ b/lib/Dashboard/OpenZakenWidget.php
@@ -10,6 +10,12 @@ use OCP\Util;
 
 use OCA\ZaakAfhandelApp\AppInfo\Application;
 
+/**
+ * Dashboard widget showing open zaken (open cases).
+ *
+ * @copyright 2024 Conduction B.V. <info@conduction.nl>
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ */
 class OpenZakenWidget implements IWidget
 {
     public function __construct(

--- a/lib/Dashboard/OrganisatiesWidget.php
+++ b/lib/Dashboard/OrganisatiesWidget.php
@@ -10,6 +10,12 @@ use OCP\Util;
 
 use OCA\ZaakAfhandelApp\AppInfo\Application;
 
+/**
+ * Dashboard widget showing organisaties (organisations).
+ *
+ * @copyright 2024 Conduction B.V. <info@conduction.nl>
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ */
 class OrganisatiesWidget implements IWidget
 {
     public function __construct(

--- a/lib/Dashboard/PersonenWidget.php
+++ b/lib/Dashboard/PersonenWidget.php
@@ -10,6 +10,12 @@ use OCP\Util;
 
 use OCA\ZaakAfhandelApp\AppInfo\Application;
 
+/**
+ * Dashboard widget showing personen (persons).
+ *
+ * @copyright 2024 Conduction B.V. <info@conduction.nl>
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ */
 class PersonenWidget implements IWidget
 {
     public function __construct(

--- a/lib/Dashboard/TakenWidget.php
+++ b/lib/Dashboard/TakenWidget.php
@@ -10,6 +10,12 @@ use OCP\Util;
 
 use OCA\ZaakAfhandelApp\AppInfo\Application;
 
+/**
+ * Dashboard widget showing taken (tasks).
+ *
+ * @copyright 2024 Conduction B.V. <info@conduction.nl>
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ */
 class TakenWidget implements IWidget
 {
     public function __construct(

--- a/lib/Dashboard/ZakenWidget.php
+++ b/lib/Dashboard/ZakenWidget.php
@@ -10,6 +10,12 @@ use OCP\Util;
 
 use OCA\ZaakAfhandelApp\AppInfo\Application;
 
+/**
+ * Dashboard widget showing zaken (cases).
+ *
+ * @copyright 2024 Conduction B.V. <info@conduction.nl>
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ */
 class ZakenWidget implements IWidget
 {
     public function __construct(

--- a/lib/Sections/ZaakAfhandelAppAdmin.php
+++ b/lib/Sections/ZaakAfhandelAppAdmin.php
@@ -5,6 +5,12 @@ use OCP\IL10N;
 use OCP\IURLGenerator;
 use OCP\Settings\IIconSection;
 
+/**
+ * Admin settings section for the ZaakAfhandelApp.
+ *
+ * @copyright 2024 Conduction B.V. <info@conduction.nl>
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ */
 class ZaakAfhandelAppAdmin implements IIconSection
 {
 

--- a/lib/Service/CallService.php
+++ b/lib/Service/CallService.php
@@ -6,6 +6,12 @@ use GuzzleHttp\Client;
 use Symfony\Component\Uid\Uuid;
 use OCP\IAppConfig;
 
+/**
+ * Service for performing outbound HTTP calls to external ZGW sources.
+ *
+ * @copyright 2024 Conduction B.V. <info@conduction.nl>
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ */
 class CallService
 {
     public function __construct(

--- a/lib/Service/IObjectService.php
+++ b/lib/Service/IObjectService.php
@@ -6,6 +6,9 @@ namespace OCA\ZaakAfhandelApp\Service;
  * Interface for object service operations.
  *
  * Provides a contract for CRUD and query operations on typed objects.
+ *
+ * @copyright 2024 Conduction B.V. <info@conduction.nl>
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  */
 interface IObjectService
 {

--- a/lib/Service/MailService.php
+++ b/lib/Service/MailService.php
@@ -9,6 +9,9 @@ use OCP\Mail\IMailer;
  * Service class for sending e-mails
  *
  * This service sends e-mails when an 'medewerker' field is filled on an object.
+ *
+ * @copyright 2024 Conduction B.V. <info@conduction.nl>
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  */
 class MailService
 {

--- a/lib/Service/ObjectMapperService.php
+++ b/lib/Service/ObjectMapperService.php
@@ -13,6 +13,9 @@ use OCP\IAppConfig;
  *
  * Handles the mapping between object types and their data sources
  * (internal mappers or OpenRegister).
+ *
+ * @copyright 2024 Conduction B.V. <info@conduction.nl>
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  */
 class ObjectMapperService
 {

--- a/lib/Service/ObjectQueryService.php
+++ b/lib/Service/ObjectQueryService.php
@@ -10,6 +10,9 @@ use InvalidArgumentException;
  *
  * Uses ObjectMapperService for mapper resolution
  * and RequestParamsParser for request parameter parsing.
+ *
+ * @copyright 2024 Conduction B.V. <info@conduction.nl>
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  */
 class ObjectQueryService
 {

--- a/lib/Service/ObjectService.php
+++ b/lib/Service/ObjectService.php
@@ -10,6 +10,9 @@ use InvalidArgumentException;
  *
  * Delegates mapper resolution to ObjectMapperService and
  * query operations to ObjectQueryService.
+ *
+ * @copyright 2024 Conduction B.V. <info@conduction.nl>
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  */
 class ObjectService implements IObjectService
 {

--- a/lib/Service/RequestParamsParser.php
+++ b/lib/Service/RequestParamsParser.php
@@ -6,6 +6,9 @@ namespace OCA\ZaakAfhandelApp\Service;
  * Utility class for parsing request parameters into structured query parameters.
  *
  * Extracted from ObjectService to reduce class complexity.
+ *
+ * @copyright 2024 Conduction B.V. <info@conduction.nl>
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  */
 class RequestParamsParser
 {

--- a/lib/Service/ZGWArchiveDateService.php
+++ b/lib/Service/ZGWArchiveDateService.php
@@ -10,6 +10,9 @@ use OCA\OpenRegister\Db\ObjectEntity;
  * Service for calculating archive dates based on afleidingswijze.
  *
  * Extracted from ZGWLogicService to reduce class complexity.
+ *
+ * @copyright 2024 Conduction B.V. <info@conduction.nl>
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  */
 class ZGWArchiveDateService
 {

--- a/lib/Service/ZGWLogicService.php
+++ b/lib/Service/ZGWLogicService.php
@@ -12,6 +12,9 @@ use OCA\OpenRegister\Exception\CustomValidationException;
  * Service for ZGW OIO and besluit operations.
  *
  * Zaak lifecycle operations are in ZGWZaakLifecycleService.
+ *
+ * @copyright 2024 Conduction B.V. <info@conduction.nl>
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  */
 class ZGWLogicService
 {

--- a/lib/Service/ZGWRegistryService.php
+++ b/lib/Service/ZGWRegistryService.php
@@ -7,6 +7,9 @@ namespace OCA\ZaakAfhandelApp\Service;
  *
  * Provides a centralized place for register and schema identifiers
  * used across ZGW services.
+ *
+ * @copyright 2024 Conduction B.V. <info@conduction.nl>
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  */
 class ZGWRegistryService
 {

--- a/lib/Service/ZGWValidationService.php
+++ b/lib/Service/ZGWValidationService.php
@@ -11,6 +11,9 @@ use OCP\AppFramework\Db\DoesNotExistException;
  *
  * Handles relevanteAndereZaken and besluitInformatieObject validation.
  * Zaak-specific field validation is in ZGWZaakValidationService.
+ *
+ * @copyright 2024 Conduction B.V. <info@conduction.nl>
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  */
 class ZGWValidationService
 {

--- a/lib/Service/ZGWZaakCloseService.php
+++ b/lib/Service/ZGWZaakCloseService.php
@@ -8,6 +8,9 @@ use OCA\OpenRegister\Exception\CustomValidationException;
 
 /**
  * Handles closing a zaak (setting eindstatus). ZRC-007/ZRC-021.
+ *
+ * @copyright 2024 Conduction B.V. <info@conduction.nl>
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  */
 class ZGWZaakCloseService
 {

--- a/lib/Service/ZGWZaakLifecycleService.php
+++ b/lib/Service/ZGWZaakLifecycleService.php
@@ -7,6 +7,9 @@ use OCA\OpenRegister\Db\ObjectEntity;
 /**
  * Handles zaak lifecycle: reopen, delete, vertrouwelijkheidaanduiding.
  * Close is handled by ZGWZaakCloseService.
+ *
+ * @copyright 2024 Conduction B.V. <info@conduction.nl>
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  */
 class ZGWZaakLifecycleService
 {

--- a/lib/Service/ZGWZaakValidationService.php
+++ b/lib/Service/ZGWZaakValidationService.php
@@ -7,6 +7,9 @@ use OCA\OpenRegister\Exception\CustomValidationException;
 
 /**
  * Validation service for zaak-specific field validation.
+ *
+ * @copyright 2024 Conduction B.V. <info@conduction.nl>
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  */
 class ZGWZaakValidationService
 {

--- a/lib/Settings/ZaakAfhandelAppAdmin.php
+++ b/lib/Settings/ZaakAfhandelAppAdmin.php
@@ -6,6 +6,12 @@ use OCP\IConfig;
 use OCP\IL10N;
 use OCP\Settings\ISettings;
 
+/**
+ * Admin settings form for the ZaakAfhandelApp.
+ *
+ * @copyright 2024 Conduction B.V. <info@conduction.nl>
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
+ */
 class ZaakAfhandelAppAdmin implements ISettings
 {
 


### PR DESCRIPTION
Bucket-A safe fix from the fleet-wide hydra-gates sweep: adds @copyright + @license PHPDoc tags to 45 lib/ files that were missing them. Mechanical, no behavior change. Security-semantic findings (no-admin-idor, route-auth, route-reachability) are tracked in a separate backlog issue.