### PR TITLE
fix: return-type lie + dead event handlers (fleet quality sweep)

### DIFF
--- a/lib/EventListener/ZaakRegisterEventListener.php
+++ b/lib/EventListener/ZaakRegisterEventListener.php
@@ -35,14 +35,6 @@ use Psr\Log\LoggerInterface;
 class ZaakRegisterEventListener implements IEventListener
 {
 
-    private const EVENT_HANDLERS = [
-        ObjectCreatedEvent::class  => 'handleObjectCreated',
-        ObjectUpdatedEvent::class  => 'handleObjectUpdated',
-        ObjectDeletedEvent::class  => 'handleObjectDeleted',
-        ObjectCreatingEvent::class => 'handleObjectCreating',
-        ObjectUpdatingEvent::class => 'handleObjectUpdating',
-    ];
-
     public function __construct(
         private readonly ZGWLogicService $logicService,
         private readonly ZGWZaakLifecycleService $lifecycleService,
@@ -56,9 +48,16 @@ class ZaakRegisterEventListener implements IEventListener
     public function handle(Event $event): void
     {
         try {
-            $handler = self::EVENT_HANDLERS[get_class($event)] ?? null;
-            if ($handler !== null) {
-                $this->$handler($event);
+            if ($event instanceof ObjectCreatedEvent) {
+                $this->handleObjectCreated($event);
+            } elseif ($event instanceof ObjectUpdatedEvent) {
+                $this->handleObjectUpdated($event);
+            } elseif ($event instanceof ObjectDeletedEvent) {
+                $this->handleObjectDeleted($event);
+            } elseif ($event instanceof ObjectCreatingEvent) {
+                $this->handleObjectCreating($event);
+            } elseif ($event instanceof ObjectUpdatingEvent) {
+                $this->handleObjectUpdating($event);
             }
         } catch (CustomValidationException $e) {
             throw $e;

--- a/lib/Service/ZGWLogicService.php
+++ b/lib/Service/ZGWLogicService.php
@@ -155,7 +155,7 @@ class ZGWLogicService
 
     private function rewriteInternalReference(string $internalReference): string
     {
-        return $this->getObjectByEndpointUrl($internalReference);
+        return $this->getObjectByEndpointUrl($internalReference)->getUuid() ?? $internalReference;
     }//end rewriteInternalReference()
     /**
      * @spec openspec/specs/zgw-case-lifecycle/spec.md#REQ-001

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -131,28 +131,10 @@ parameters:
 			path: lib/Dashboard/ZakenWidget.php
 
 		-
-			message: '#^Offset class\-string\<OCP\\EventDispatcher\\Event\> on array\{OCA\\OpenRegister\\Event\\ObjectCreatedEvent\: ''handleObjectCreated'', OCA\\OpenRegister\\Event\\ObjectUpdatedEvent\: ''handleObjectUpdated'', OCA\\OpenRegister\\Event\\ObjectDeletedEvent\: ''handleObjectDeleted'', OCA\\OpenRegister\\Event\\ObjectCreatingEvent\: ''handleObjectCreating'', OCA\\OpenRegister\\Event\\ObjectUpdatingEvent\: ''handleObjectUpdating''\} on left side of \?\? does not exist\.$#'
-			identifier: nullCoalesce.offset
-			count: 1
-			path: lib/EventListener/ZaakRegisterEventListener.php
-
-		-
-			message: '#^Strict comparison using \!\=\= between null and null will always evaluate to false\.$#'
-			identifier: notIdentical.alwaysFalse
-			count: 1
-			path: lib/EventListener/ZaakRegisterEventListener.php
-
-		-
 			message: '#^PHPDoc tag @param references unknown parameter\: \$objectService$#'
 			identifier: parameter.notFound
 			count: 1
 			path: lib/Service/ZGWArchiveDateService.php
-
-		-
-			message: '#^Method OCA\\ZaakAfhandelApp\\Service\\ZGWLogicService\:\:rewriteInternalReference\(\) should return string but returns OCA\\OpenRegister\\Db\\ObjectEntity\.$#'
-			identifier: return.type
-			count: 1
-			path: lib/Service/ZGWLogicService.php
 
 		-
 			message: '#^Property OCA\\ZaakAfhandelApp\\Settings\\ZaakAfhandelAppAdmin\:\:\$l is never read, only written\.$#'


### PR DESCRIPTION
## Summary

- **Return-type lie fixed** (`ZGWLogicService::rewriteInternalReference`): method was declared `: string` but returned an `ObjectEntity` directly from `getObjectByEndpointUrl()`. Its sole caller appends the result to `informatieobjecttypen` — an array of UUID strings (as confirmed by the matching filter in `deleteZaakTypeInformatieObjecttype` which compares against `$iotArray['id']`). Fix: call `->getUuid()` on the entity and fall back to the original reference on null.

- **Event handler dispatch made static-analysis-visible** (`ZaakRegisterEventListener`): the five handlers (`handleObjectCreated/Updated/Deleted/Creating/Updating`) were fully wired — `handle()` dispatched to them via a `string[]` map using `$this->$handler($event)`. PHPStan cannot follow dynamic string-method calls, so two false-positive baseline suppressions were added instead of verifying the wiring. Replaced the string-dispatch map with explicit `instanceof` branches; PHPStan can now resolve all five call-sites and confirm they are reachable. Removed the three now-unnecessary baseline entries (2 EventListener + 1 ZGWLogicService return.type).

## Conclusion on event handlers
The handlers were **wired, not orphaned** — they were already called via the dynamic dispatch map. The fix converts the dispatch to explicit `instanceof` chains so static analysis confirms the wiring rather than silencing it.

## Test plan
- [x] `php -l` passes on both edited files
- [x] `vendor/bin/phpstan analyse --memory-limit=1G` → **0 errors**
- [ ] Existing PHPUnit suite passes (no logic changed, only dispatch style)