### PR TITLE
fix(security): clear Bucket-B (ADR-023 + auth/routing)

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -6,27 +6,25 @@ return [
 		'zaken' => ['url' => 'api/zrc/zaken'],
 		'resultaten' => ['url' => 'api/zrc/resultaten'],
 		'rollen' => ['url' => 'api/zrc/rollen'],
-		'statussen' => ['url' => 'api/zrc/statussen'],
-		'zaakinformatieobjecten' => ['url' => 'api/zrc/zaakinformatieobjecten'],
-		'zaakobjecten' => ['url' => 'api/zrc/zaakobjecten'],
-		'zaakbesluiten' => ['url' => 'api/zrc/zaken/{zaak_uuid}/besluiten'],
-		'zaakeigenschappen' => ['url' => 'api/zrc/zaken/{zaak_uuid}/eigenschappen'],
-		'zaakaudittrail' => ['url' => 'api/zrc/zaken/{zaak_uuid}/audit_trail'],
+		'statusen' => ['url' => 'api/zrc/statussen'],
+		'zaakInformatieObjecten' => ['url' => 'api/zrc/zaakinformatieobjecten'],
+		'zaakObjecten' => ['url' => 'api/zrc/zaakobjecten'],
+		'zaakBesluiten' => ['url' => 'api/zrc/zaken/{zaak_uuid}/besluiten'],
+		'zaakEigenschappen' => ['url' => 'api/zrc/zaken/{zaak_uuid}/eigenschappen'],
+		'zaakAuditTrail' => ['url' => 'api/zrc/zaken/{zaak_uuid}/audit_trail'],
 		// Conform https://vng-realisatie.github.io/gemma-zaken/standaard/catalogi/redoc-1.3.1
-		'zaakTypen' => ['url' => 'api/ztc'],
+		'zaakTypen' => ['url' => 'api/ztc/zaaktypen'],
 		// Conform https://vng-realisatie.github.io/gemma-zaken/standaard/documenten/redoc-1.5.0
 		'documenten' => ['url' => 'api/drc'],
 		// Conform https://vng-realisatie.github.io/gemma-zaken/standaard/besluiten/redoc-1.0.2
 		'besluiten' => ['url' => 'api/brc'],
 		// Conform ???
-		'zaakTypen' => ['url' => 'api/ztc/zaaktypen'],
-		// Conform ???
 		'taken' => ['url' => 'api/taken'],
 		'klanten' => ['url' => 'api/klanten'],
 		'berichten' => ['url' => 'api/berichten'],
-		'contactmomenten' => ['url' => 'api/contactmomenten'],
+		'contactMomenten' => ['url' => 'api/contactmomenten'],
 		'medewerkers' => ['url' => 'api/medewerkers'],
-
+		'dashboard' => ['url' => 'api/dashboard'],
 	],
 	'routes' => [
 		// Audit trail routes
@@ -51,8 +49,8 @@ return [
 		['name' => 'zaken#page', 'postfix'  => 'details', 'url' => '/zaken/{id}', 'verb' => 'GET'],
 		['name' => 'rollen#page', 'url' => '/rollen', 'verb' => 'GET'],
 		['name' => 'rollen#page', 'postfix'  => 'details', 'url' => '/rollen/{id}', 'verb' => 'GET'],
-		['name' => 'statussen#page', 'url' => '/statussen', 'verb' => 'GET'],
-		['name' => 'zaakinformatieobjecten#page', 'url' => '/zaakinformatieobjecten', 'verb' => 'GET'],
+		['name' => 'statusen#page', 'url' => '/statussen', 'verb' => 'GET'],
+		['name' => 'zaakInformatieObjecten#page', 'url' => '/zaakinformatieobjecten', 'verb' => 'GET'],
 		['name' => 'zaakTypen#page','url' => '/zaaktypen', 'verb' => 'GET'],
 		['name' => 'zaakTypen#page','postfix' => 'details', 'url' => '/zaaktypen/{id}', 'verb' => 'GET'],
 		['name' => 'taken#page','url' => '/taken', 'verb' => 'GET'],
@@ -72,7 +70,7 @@ return [
 		['name' => 'preferences#setPreference', 'url' => '/api/preferences/{key}', 'verb' => 'PUT'],
 		// User
 		['name' => 'users#me', 'url' => '/me', 'verb' => 'GET'],
-		// Object API routes	
+		// Object API routes
 		['name' => 'objects#index', 'url' => 'api/objects/{objectType}', 'verb' => 'GET'],
 		['name' => 'objects#create', 'url' => 'api/objects/{objectType}', 'verb' => 'POST'],
 		['name' => 'objects#show', 'url' => 'api/objects/{objectType}/{id}', 'verb' => 'GET'],

--- a/lib/Controller/BerichtenController.php
+++ b/lib/Controller/BerichtenController.php
@@ -4,10 +4,12 @@ namespace OCA\ZaakAfhandelApp\Controller;
 
 use OCA\ZaakAfhandelApp\Service\ObjectService;
 use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\IRequest;
 use OCP\AppFramework\Http\TemplateResponse;
 use OCP\AppFramework\Http\ContentSecurityPolicy;
+use OCP\IUserSession;
 
 /**
  * Controller for handling messages (berichten) operations.
@@ -21,6 +23,7 @@ class BerichtenController extends Controller
         $appName,
         IRequest $request,
         private readonly ObjectService $objectService,
+        private readonly IUserSession $userSession,
     ) {
         parent::__construct($appName, $request);
     }//end __construct()
@@ -37,6 +40,10 @@ class BerichtenController extends Controller
      */
     public function index(): JSONResponse
     {
+        if ($this->userSession->getUser() === null) {
+            return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
+        }
+
          // Retrieve all request parameters
          $requestParams = $this->request->getParams();
 
@@ -97,6 +104,10 @@ class BerichtenController extends Controller
      */
     public function show(string $id): JSONResponse
     {
+        if ($this->userSession->getUser() === null) {
+            return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
+        }
+
         // Fetch the catalog object by its ID
         $object = $this->objectService->getObject('berichten', $id);
 
@@ -116,6 +127,10 @@ class BerichtenController extends Controller
      */
     public function create(): JSONResponse
     {
+        if ($this->userSession->getUser() === null) {
+            return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
+        }
+
         // Get all parameters from the request
         $data = $this->request->getParams();
 
@@ -141,6 +156,10 @@ class BerichtenController extends Controller
      */
     public function update(string $id): JSONResponse
     {
+        if ($this->userSession->getUser() === null) {
+            return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
+        }
+
         // Get all parameters from the request
         $data = $this->request->getParams();
 
@@ -163,6 +182,10 @@ class BerichtenController extends Controller
      */
     public function destroy(string $id): JSONResponse
     {
+        if ($this->userSession->getUser() === null) {
+            return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
+        }
+
         // Delete the catalog object
         $result = $this->objectService->deleteObject('berichten', $id);
 
@@ -170,18 +193,22 @@ class BerichtenController extends Controller
         return new JSONResponse(['success' => $result], $result === true ? 200 : 404);
     }//end destroy()
 
-        /**
-         * Get audit trail for a specific klant
-         *
-         * @NoAdminRequired
-         * @NoCSRFRequired
-         *
-         * @return JSONResponse
-          *
-          * @spec openspec/specs/zgw-client-interaction/spec.md#REQ-004
-         */
+    /**
+     * Get audit trail for a specific klant
+     *
+     * @NoAdminRequired
+     * @NoCSRFRequired
+     *
+     * @return JSONResponse
+      *
+      * @spec openspec/specs/zgw-client-interaction/spec.md#REQ-004
+     */
     public function getAuditTrail(string $id): JSONResponse
     {
+        if ($this->userSession->getUser() === null) {
+            return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
+        }
+
         $auditTrail = $this->objectService->getAuditTrail('berichten', $id);
         return new JSONResponse($auditTrail);
     }//end getAuditTrail()

--- a/lib/Controller/BesluitenController.php
+++ b/lib/Controller/BesluitenController.php
@@ -2,13 +2,14 @@
 
 namespace OCA\ZaakAfhandelApp\Controller;
 
-use GuzzleHttp\Client;
 use OCA\ZaakAfhandelApp\Service\CallService;
 use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\TemplateResponse;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\IAppConfig;
 use OCP\IRequest;
+use OCP\IUserSession;
 
 
 /**
@@ -45,7 +46,8 @@ class BesluitenController extends Controller
     public function __construct(
         $appName,
         IRequest $request,
-        private readonly IAppConfig $config
+        private readonly IAppConfig $config,
+        private readonly IUserSession $userSession,
     ) {
         parent::__construct($appName, $request);
     }//end __construct()
@@ -64,7 +66,6 @@ class BesluitenController extends Controller
     public function page(): TemplateResponse
     {
         return new TemplateResponse(
-            // Application::APP_ID,
             'zaakafhandelapp',
             'index',
             []
@@ -83,6 +84,10 @@ class BesluitenController extends Controller
      */
     public function index(CallService $callService): JSONResponse
     {
+        if ($this->userSession->getUser() === null) {
+            return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
+        }
+
         $results = $callService->index(source: 'brc', endpoint: 'besluiten');
         return new JSONResponse($results);
     }//end index()
@@ -99,6 +104,10 @@ class BesluitenController extends Controller
      */
     public function show(string $id, CallService $callService): JSONResponse
     {
+        if ($this->userSession->getUser() === null) {
+            return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
+        }
+
         $results = $callService->show(source: 'brc', endpoint: 'besluiten', id: $id);
         return new JSONResponse($results);
     }//end show()
@@ -115,6 +124,10 @@ class BesluitenController extends Controller
      */
     public function create(CallService $callService): JSONResponse
     {
+        if ($this->userSession->getUser() === null) {
+            return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
+        }
+
         // get post from requests
         $body    = $this->request->getParams();
         $results = $callService->create(source: 'brc', endpoint: 'besluiten', data: $body);
@@ -133,6 +146,10 @@ class BesluitenController extends Controller
      */
     public function update(string $id, CallService $callService): JSONResponse
     {
+        if ($this->userSession->getUser() === null) {
+            return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
+        }
+
         $body    = $this->request->getParams();
         $results = $callService->update(source: 'brc', endpoint: 'besluiten', data: $body, id: $id);
         return new JSONResponse($results);
@@ -150,6 +167,10 @@ class BesluitenController extends Controller
      */
     public function destroy(string $id, CallService $callService): JSONResponse
     {
+        if ($this->userSession->getUser() === null) {
+            return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
+        }
+
         $callService->destroy(source: 'brc', endpoint: 'besluiten', id: $id);
 
         return new JSONResponse([]);

--- a/lib/Controller/ConfigurationController.php
+++ b/lib/Controller/ConfigurationController.php
@@ -3,10 +3,12 @@
 namespace OCA\ZaakAfhandelApp\Controller;
 
 use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\TemplateResponse;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\IAppConfig;
 use OCP\IRequest;
+use OCP\IUserSession;
 
 /**
  * Controller for application configuration operations.
@@ -19,7 +21,8 @@ class ConfigurationController extends Controller
     public function __construct(
         $appName,
         private readonly IAppConfig $config,
-        IRequest $request
+        IRequest $request,
+        private readonly IUserSession $userSession,
     ) {
         parent::__construct($appName, $request);
     }//end __construct()
@@ -32,6 +35,9 @@ class ConfigurationController extends Controller
      */
     public function index(): JSONResponse
     {
+        if ($this->userSession->getUser() === null) {
+            return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
+        }
 
         $data     = [];
         $defaults = [
@@ -84,6 +90,10 @@ class ConfigurationController extends Controller
      */
     public function create(): JSONResponse
     {
+        if ($this->userSession->getUser() === null) {
+            return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
+        }
+
         $data = $this->request->getParams();
 
         // We should filter out unwanted values before this

--- a/lib/Controller/ContactMomentenController.php
+++ b/lib/Controller/ContactMomentenController.php
@@ -4,10 +4,12 @@ namespace OCA\ZaakAfhandelApp\Controller;
 
 use OCA\ZaakAfhandelApp\Service\ObjectService;
 use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\IRequest;
 use OCP\AppFramework\Http\TemplateResponse;
 use OCP\AppFramework\Http\ContentSecurityPolicy;
+use OCP\IUserSession;
 
 /**
  * Controller for handling contact moments (contactmomenten) operations
@@ -21,6 +23,7 @@ class ContactMomentenController extends Controller
         $appName,
         IRequest $request,
         private readonly ObjectService $objectService,
+        private readonly IUserSession $userSession,
     ) {
         parent::__construct($appName, $request);
     }//end __construct()
@@ -37,6 +40,10 @@ class ContactMomentenController extends Controller
      */
     public function index(): JSONResponse
     {
+        if ($this->userSession->getUser() === null) {
+            return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
+        }
+
          // Retrieve all request parameters
          $requestParams = $this->request->getParams();
 
@@ -97,6 +104,10 @@ class ContactMomentenController extends Controller
      */
     public function show(string $id): JSONResponse
     {
+        if ($this->userSession->getUser() === null) {
+            return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
+        }
+
         // Fetch the contact moment by its ID
         $object = $this->objectService->getObject('contactmomenten', $id);
 
@@ -116,6 +127,10 @@ class ContactMomentenController extends Controller
      */
     public function create(): JSONResponse
     {
+        if ($this->userSession->getUser() === null) {
+            return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
+        }
+
         // Get all parameters from the request
         $data = $this->request->getParams();
 
@@ -141,6 +156,10 @@ class ContactMomentenController extends Controller
      */
     public function update(string $id): JSONResponse
     {
+        if ($this->userSession->getUser() === null) {
+            return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
+        }
+
         // Get all parameters from the request
         $data = $this->request->getParams();
 
@@ -163,6 +182,10 @@ class ContactMomentenController extends Controller
      */
     public function destroy(string $id): JSONResponse
     {
+        if ($this->userSession->getUser() === null) {
+            return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
+        }
+
         // Delete the contact moment
         $result = $this->objectService->deleteObject('contactmomenten', $id);
 
@@ -182,6 +205,10 @@ class ContactMomentenController extends Controller
      */
     public function getAuditTrail(string $id): JSONResponse
     {
+        if ($this->userSession->getUser() === null) {
+            return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
+        }
+
         $auditTrail = $this->objectService->getAuditTrail('contactmomenten', $id);
         return new JSONResponse($auditTrail);
     }//end getAuditTrail()

--- a/lib/Controller/DashboardController.php
+++ b/lib/Controller/DashboardController.php
@@ -2,12 +2,14 @@
 
 namespace OCA\ZaakAfhandelApp\Controller;
 
-use GuzzleHttp\Client;
 use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\TemplateResponse;
 use OCP\AppFramework\Http\JSONResponse;
+use OCP\AppFramework\Http\ContentSecurityPolicy;
 use OCP\IAppConfig;
 use OCP\IRequest;
+use OCP\IUserSession;
 
 /**
  * Controller for dashboard-related operations in the ZaakAfhandelApp.
@@ -43,7 +45,8 @@ class DashboardController extends Controller
     public function __construct(
         $appName,
         IRequest $request,
-        private readonly IAppConfig $config
+        private readonly IAppConfig $config,
+        private readonly IUserSession $userSession,
     ) {
         parent::__construct($appName, $request);
     }//end __construct()
@@ -62,7 +65,6 @@ class DashboardController extends Controller
     public function page(): TemplateResponse
     {
         return new TemplateResponse(
-            // Application::APP_ID,
             'zaakafhandelapp',
             'index',
             []
@@ -81,6 +83,10 @@ class DashboardController extends Controller
      */
     public function index(): JSONResponse
     {
+        if ($this->userSession->getUser() === null) {
+            return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
+        }
+
         $results = ["results" => self::TEST_ARRAY];
         return new JSONResponse($results);
     }//end index()
@@ -97,6 +103,10 @@ class DashboardController extends Controller
      */
     public function show(string $id): JSONResponse
     {
+        if ($this->userSession->getUser() === null) {
+            return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
+        }
+
         $result = self::TEST_ARRAY[$id];
         return new JSONResponse($result);
     }//end show()
@@ -113,6 +123,10 @@ class DashboardController extends Controller
      */
     public function create(): JSONResponse
     {
+        if ($this->userSession->getUser() === null) {
+            return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
+        }
+
         // get post from requests
         return new JSONResponse([]);
     }//end create()
@@ -129,6 +143,10 @@ class DashboardController extends Controller
      */
     public function update(string $id): JSONResponse
     {
+        if ($this->userSession->getUser() === null) {
+            return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
+        }
+
         $result = self::TEST_ARRAY[$id];
         return new JSONResponse($result);
     }//end update()
@@ -145,6 +163,10 @@ class DashboardController extends Controller
      */
     public function destroy(string $id): JSONResponse
     {
+        if ($this->userSession->getUser() === null) {
+            return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
+        }
+
         return new JSONResponse([]);
     }//end destroy()
 }//end class

--- a/lib/Controller/DocumentenController.php
+++ b/lib/Controller/DocumentenController.php
@@ -2,12 +2,13 @@
 
 namespace OCA\ZaakAfhandelApp\Controller;
 
-use GuzzleHttp\Client;
 use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\TemplateResponse;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\IAppConfig;
 use OCP\IRequest;
+use OCP\IUserSession;
 
 /**
  * Geeft invulling aan https://vng-realisatie.github.io/gemma-zaken/standaard/zaken/
@@ -22,7 +23,8 @@ class DocumentenController extends Controller
     public function __construct(
         string $appName,
         IRequest $request,
-        private readonly IAppConfig $config
+        private readonly IAppConfig $config,
+        private readonly IUserSession $userSession,
     ) {
         parent::__construct($appName, $request);
     }//end __construct()
@@ -41,7 +43,6 @@ class DocumentenController extends Controller
     public function page(): TemplateResponse
     {
         return new TemplateResponse(
-            // Application::APP_ID,
             'zaakafhandelapp',
             'index',
             []
@@ -60,6 +61,10 @@ class DocumentenController extends Controller
      */
     public function index(): JSONResponse
     {
+        if ($this->userSession->getUser() === null) {
+            return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
+        }
+
         $results = ["results" => self::TEST_ARRAY];
         return new JSONResponse($results);
     }//end index()
@@ -76,6 +81,10 @@ class DocumentenController extends Controller
      */
     public function show(string $id): JSONResponse
     {
+        if ($this->userSession->getUser() === null) {
+            return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
+        }
+
         $result = self::TEST_ARRAY[$id];
         return new JSONResponse($result);
     }//end show()
@@ -92,6 +101,10 @@ class DocumentenController extends Controller
      */
     public function create(): JSONResponse
     {
+        if ($this->userSession->getUser() === null) {
+            return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
+        }
+
         // get post from requests
         return new JSONResponse([]);
     }//end create()
@@ -108,6 +121,10 @@ class DocumentenController extends Controller
      */
     public function update(string $id): JSONResponse
     {
+        if ($this->userSession->getUser() === null) {
+            return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
+        }
+
         $result = self::TEST_ARRAY[$id];
         return new JSONResponse($result);
     }//end update()
@@ -124,6 +141,10 @@ class DocumentenController extends Controller
      */
     public function destroy(string $id): JSONResponse
     {
+        if ($this->userSession->getUser() === null) {
+            return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
+        }
+
         return new JSONResponse([]);
     }//end destroy()
 }//end class

--- a/lib/Controller/KlantenController.php
+++ b/lib/Controller/KlantenController.php
@@ -4,10 +4,12 @@ namespace OCA\ZaakAfhandelApp\Controller;
 
 use OCA\ZaakAfhandelApp\Service\ObjectService;
 use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\IRequest;
 use OCP\AppFramework\Http\TemplateResponse;
 use OCP\AppFramework\Http\ContentSecurityPolicy;
+use OCP\IUserSession;
 
 /**
  * Controller for handling clients (klanten) operations.
@@ -21,6 +23,7 @@ class KlantenController extends Controller
         $appName,
         IRequest $request,
         private readonly ObjectService $objectService,
+        private readonly IUserSession $userSession,
     ) {
         parent::__construct($appName, $request);
     }//end __construct()
@@ -37,6 +40,10 @@ class KlantenController extends Controller
      */
     public function index(): JSONResponse
     {
+        if ($this->userSession->getUser() === null) {
+            return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
+        }
+
         // Retrieve all request parameters
         $requestParams = $this->request->getParams();
 
@@ -97,6 +104,10 @@ class KlantenController extends Controller
      */
     public function show(string $id): JSONResponse
     {
+        if ($this->userSession->getUser() === null) {
+            return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
+        }
+
         // Fetch the catalog object by its ID
         $object = $this->objectService->getObject('klanten', $id);
 
@@ -116,6 +127,10 @@ class KlantenController extends Controller
      */
     public function create(): JSONResponse
     {
+        if ($this->userSession->getUser() === null) {
+            return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
+        }
+
         // Get all parameters from the request
         $data = $this->request->getParams();
 
@@ -141,6 +156,10 @@ class KlantenController extends Controller
      */
     public function update(string $id): JSONResponse
     {
+        if ($this->userSession->getUser() === null) {
+            return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
+        }
+
         // Get all parameters from the request
         $data = $this->request->getParams();
 
@@ -163,6 +182,10 @@ class KlantenController extends Controller
      */
     public function destroy(string $id): JSONResponse
     {
+        if ($this->userSession->getUser() === null) {
+            return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
+        }
+
         // Delete the catalog object
         $result = $this->objectService->deleteObject('klanten', $id);
 
@@ -182,6 +205,10 @@ class KlantenController extends Controller
      */
     public function getZaken(string $id): JSONResponse
     {
+        if ($this->userSession->getUser() === null) {
+            return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
+        }
+
         $requestParams = ['klant' => $id];
         $zaken         = $this->objectService->getResultArrayForRequest('zaken', $requestParams);
         return new JSONResponse($zaken);
@@ -199,6 +226,10 @@ class KlantenController extends Controller
      */
     public function getTaken(string $id): JSONResponse
     {
+        if ($this->userSession->getUser() === null) {
+            return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
+        }
+
         $requestParams = ['klant' => $id];
         $taken         = $this->objectService->getResultArrayForRequest('taken', $requestParams);
         return new JSONResponse($taken);
@@ -216,6 +247,10 @@ class KlantenController extends Controller
      */
     public function getBerichten(string $id): JSONResponse
     {
+        if ($this->userSession->getUser() === null) {
+            return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
+        }
+
         $requestParams = ['gebruikerID' => $id];
         $berichten     = $this->objectService->getResultArrayForRequest('klanten', $requestParams);
         return new JSONResponse($berichten);
@@ -233,6 +268,10 @@ class KlantenController extends Controller
      */
     public function getContactmomenten(string $id): JSONResponse
     {
+        if ($this->userSession->getUser() === null) {
+            return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
+        }
+
         $requestParams   = ['klant' => $id];
         $contactmomenten = $this->objectService->getResultArrayForRequest('contactmomenten', $requestParams);
         return new JSONResponse($contactmomenten);
@@ -250,6 +289,10 @@ class KlantenController extends Controller
      */
     public function getAuditTrail(string $id): JSONResponse
     {
+        if ($this->userSession->getUser() === null) {
+            return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
+        }
+
         $auditTrail = $this->objectService->getAuditTrail('klanten', $id);
         return new JSONResponse($auditTrail);
     }//end getAuditTrail()

--- a/lib/Controller/MedewerkersController.php
+++ b/lib/Controller/MedewerkersController.php
@@ -4,10 +4,12 @@ namespace OCA\ZaakAfhandelApp\Controller;
 
 use OCA\ZaakAfhandelApp\Service\ObjectService;
 use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\IRequest;
 use OCP\AppFramework\Http\TemplateResponse;
 use OCP\AppFramework\Http\ContentSecurityPolicy;
+use OCP\IUserSession;
 
 /**
  * Controller for handling employees (medewerkers) operations
@@ -21,6 +23,7 @@ class MedewerkersController extends Controller
         $appName,
         IRequest $request,
         private readonly ObjectService $objectService,
+        private readonly IUserSession $userSession,
     ) {
         parent::__construct($appName, $request);
     }//end __construct()
@@ -37,6 +40,10 @@ class MedewerkersController extends Controller
      */
     public function index(): JSONResponse
     {
+        if ($this->userSession->getUser() === null) {
+            return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
+        }
+
          // Retrieve all request parameters
          $requestParams = $this->request->getParams();
 
@@ -97,6 +104,10 @@ class MedewerkersController extends Controller
      */
     public function show(string $id): JSONResponse
     {
+        if ($this->userSession->getUser() === null) {
+            return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
+        }
+
         // Fetch the employee by its ID
         $object = $this->objectService->getObject('medewerkers', $id);
 
@@ -116,6 +127,10 @@ class MedewerkersController extends Controller
      */
     public function create(): JSONResponse
     {
+        if ($this->userSession->getUser() === null) {
+            return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
+        }
+
         // Get all parameters from the request
         $data = $this->request->getParams();
 
@@ -141,6 +156,10 @@ class MedewerkersController extends Controller
      */
     public function update(string $id): JSONResponse
     {
+        if ($this->userSession->getUser() === null) {
+            return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
+        }
+
         // Get all parameters from the request
         $data = $this->request->getParams();
 
@@ -163,6 +182,10 @@ class MedewerkersController extends Controller
      */
     public function destroy(string $id): JSONResponse
     {
+        if ($this->userSession->getUser() === null) {
+            return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
+        }
+
         // Delete the employee
         $result = $this->objectService->deleteObject('medewerkers', $id);
 
@@ -182,6 +205,10 @@ class MedewerkersController extends Controller
      */
     public function getAuditTrail(string $id): JSONResponse
     {
+        if ($this->userSession->getUser() === null) {
+            return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
+        }
+
         $auditTrail = $this->objectService->getAuditTrail('medewerkers', $id);
         return new JSONResponse($auditTrail);
     }//end getAuditTrail()

--- a/lib/Controller/ObjectsController.php
+++ b/lib/Controller/ObjectsController.php
@@ -4,8 +4,10 @@ namespace OCA\ZaakAfhandelApp\Controller;
 
 use OCA\ZaakAfhandelApp\Service\ObjectService;
 use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\IRequest;
+use OCP\IUserSession;
 use Exception;
 
 /**
@@ -19,7 +21,8 @@ class ObjectsController extends Controller
     public function __construct(
         $appName,
         IRequest $request,
-        private readonly ObjectService $objectService
+        private readonly ObjectService $objectService,
+        private readonly IUserSession $userSession,
     ) {
         parent::__construct($appName, $request);
     }//end __construct()
@@ -38,6 +41,10 @@ class ObjectsController extends Controller
      */
     public function index(string $objectType): JSONResponse
     {
+        if ($this->userSession->getUser() === null) {
+            return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
+        }
+
         // Retrieve all request parameters
         $requestParams = $this->request->getParams();
 
@@ -63,6 +70,10 @@ class ObjectsController extends Controller
      */
     public function show(string $objectType, string $id): JSONResponse
     {
+        if ($this->userSession->getUser() === null) {
+            return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
+        }
+
         try {
             // Retrieve all request parameters
             $requestParams = $this->request->getParams();
@@ -98,6 +109,10 @@ class ObjectsController extends Controller
      */
     public function create(string $objectType): JSONResponse
     {
+        if ($this->userSession->getUser() === null) {
+            return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
+        }
+
         try {
             // Get all parameters from the request
             $data = $this->request->getParams();
@@ -130,6 +145,10 @@ class ObjectsController extends Controller
      */
     public function update(string $objectType, string $id): JSONResponse
     {
+        if ($this->userSession->getUser() === null) {
+            return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
+        }
+
         try {
             // Get all parameters from the request
             $data = $this->request->getParams();
@@ -162,6 +181,10 @@ class ObjectsController extends Controller
      */
     public function destroy(string $objectType, string $id): JSONResponse
     {
+        if ($this->userSession->getUser() === null) {
+            return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
+        }
+
         try {
             // Delete the object
             $result = $this->objectService->deleteObject($objectType, $id);
@@ -188,6 +211,10 @@ class ObjectsController extends Controller
      */
     public function getAuditTrail(string $objectType, string $id): JSONResponse
     {
+        if ($this->userSession->getUser() === null) {
+            return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
+        }
+
         try {
             $auditTrail = $this->objectService->getAuditTrail($objectType, $id);
             return new JSONResponse($auditTrail);
@@ -211,6 +238,10 @@ class ObjectsController extends Controller
      */
     public function getRelations(string $objectType, string $id): JSONResponse
     {
+        if ($this->userSession->getUser() === null) {
+            return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
+        }
+
         try {
             // Fetch the object by its ID
             $relations = $this->objectService->getRelations($objectType, $id);
@@ -237,6 +268,10 @@ class ObjectsController extends Controller
      */
     public function getUses(string $objectType, string $id): JSONResponse
     {
+        if ($this->userSession->getUser() === null) {
+            return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
+        }
+
         $uses = $this->objectService->getUses($objectType, $id);
         return new JSONResponse($uses);
     }//end getUses()

--- a/lib/Controller/ResultatenController.php
+++ b/lib/Controller/ResultatenController.php
@@ -2,13 +2,14 @@
 
 namespace OCA\ZaakAfhandelApp\Controller;
 
-use GuzzleHttp\Client;
 use OCA\ZaakAfhandelApp\Service\CallService;
 use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\TemplateResponse;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\IAppConfig;
 use OCP\IRequest;
+use OCP\IUserSession;
 
 /**
  * Geeft invulling aan https://vng-realisatie.github.io/gemma-zaken/standaard/zaken/
@@ -18,33 +19,11 @@ use OCP\IRequest;
  */
 class ResultatenController extends Controller
 {
-    const TEST_ARRAY = [
-        "5137a1e5-b54d-43ad-abd1-4b5bff5fcd3f" => [
-            "id"      => "5137a1e5-b54d-43ad-abd1-4b5bff5fcd3f",
-            "name"    => "Github",
-            "summary" => "summary for one",
-        ],
-        "4c3edd34-a90d-4d2a-8894-adb5836ecde8" => [
-            "id"      => "4c3edd34-a90d-4d2a-8894-adb5836ecde8",
-            "name"    => "Gitlab",
-            "summary" => "summary for two",
-        ],
-        "15551d6f-44e3-43f3-a9d2-59e583c91eb0" => [
-            "id"      => "15551d6f-44e3-43f3-a9d2-59e583c91eb0",
-            "name"    => "Woo",
-            "summary" => "summary for two",
-        ],
-        "0a3a0ffb-dc03-4aae-b207-0ed1502e60da" => [
-            "id"      => "0a3a0ffb-dc03-4aae-b207-0ed1502e60da",
-            "name"    => "Decat",
-            "summary" => "summary for two",
-        ],
-    ];
-
     public function __construct(
         $appName,
         IRequest $request,
-        private readonly IAppConfig $config
+        private readonly IAppConfig $config,
+        private readonly IUserSession $userSession,
     ) {
         parent::__construct($appName, $request);
     }//end __construct()
@@ -63,7 +42,6 @@ class ResultatenController extends Controller
     public function pages(): TemplateResponse
     {
         return new TemplateResponse(
-            // Application::APP_ID,
             'zaakafhandelapp',
             'index',
             []
@@ -82,6 +60,10 @@ class ResultatenController extends Controller
      */
     public function index(CallService $callService): JSONResponse
     {
+        if ($this->userSession->getUser() === null) {
+            return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
+        }
+
         $results = $callService->index(source: 'zrc', endpoint: 'resultaten');
         return new JSONResponse($results);
     }//end index()
@@ -98,6 +80,10 @@ class ResultatenController extends Controller
      */
     public function show(string $id, CallService $callService): JSONResponse
     {
+        if ($this->userSession->getUser() === null) {
+            return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
+        }
+
         $results = $callService->show(source: 'zrc', endpoint: 'resultaten', id: $id);
         return new JSONResponse($results);
     }//end show()
@@ -114,6 +100,10 @@ class ResultatenController extends Controller
      */
     public function create(CallService $callService): JSONResponse
     {
+        if ($this->userSession->getUser() === null) {
+            return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
+        }
+
         // get post from requests
         $body    = $this->request->getParams();
         $results = $callService->create(source: 'zrc', endpoint: 'resultaten', data: $body);
@@ -132,6 +122,10 @@ class ResultatenController extends Controller
      */
     public function update(string $id, CallService $callService): JSONResponse
     {
+        if ($this->userSession->getUser() === null) {
+            return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
+        }
+
         $body    = $this->request->getParams();
         $results = $callService->update(source: 'zrc', endpoint: 'resultaten', data: $body, id: $id);
         return new JSONResponse($results);
@@ -149,6 +143,10 @@ class ResultatenController extends Controller
      */
     public function destroy(string $id, CallService $callService): JSONResponse
     {
+        if ($this->userSession->getUser() === null) {
+            return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
+        }
+
         $callService->destroy(source: 'zrc', endpoint: 'resultaten', id: $id);
 
         return new JSONResponse([]);

--- a/lib/Controller/RollenController.php
+++ b/lib/Controller/RollenController.php
@@ -4,10 +4,12 @@ namespace OCA\ZaakAfhandelApp\Controller;
 
 use OCA\ZaakAfhandelApp\Service\CallService;
 use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\TemplateResponse;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\IAppConfig;
 use OCP\IRequest;
+use OCP\IUserSession;
 
 /**
  * Controller for rollen (roles) resources.
@@ -22,14 +24,16 @@ class RollenController extends Controller
     /**
      * RollenController constructor.
      *
-     * @param string     $appName The application name
-     * @param IRequest   $request The request object
-     * @param IAppConfig $config  The app configuration
+     * @param string       $appName     The application name
+     * @param IRequest     $request     The request object
+     * @param IAppConfig   $config      The app configuration
+     * @param IUserSession $userSession The user session
      */
     public function __construct(
         $appName,
         IRequest $request,
-        private readonly IAppConfig $config
+        private readonly IAppConfig $config,
+        private readonly IUserSession $userSession,
     ) {
         parent::__construct($appName, $request);
     }//end __construct()
@@ -63,6 +67,10 @@ class RollenController extends Controller
      */
     public function index(CallService $callService): JSONResponse
     {
+        if ($this->userSession->getUser() === null) {
+            return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
+        }
+
         $results = $callService->index(source: 'zrc', endpoint: 'rollen');
         return new JSONResponse($results);
     }//end index()
@@ -82,6 +90,10 @@ class RollenController extends Controller
      */
     public function show(string $id, CallService $callService): JSONResponse
     {
+        if ($this->userSession->getUser() === null) {
+            return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
+        }
+
         $results = $callService->show(source: 'zrc', endpoint: 'rollen', id: $id);
         return new JSONResponse($results);
     }//end show()
@@ -100,6 +112,10 @@ class RollenController extends Controller
      */
     public function create(CallService $callService): JSONResponse
     {
+        if ($this->userSession->getUser() === null) {
+            return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
+        }
+
         $body    = $this->request->getParams();
         $results = $callService->create(source: 'zrc', endpoint: 'rollen', data: $body);
         return new JSONResponse($results);
@@ -120,6 +136,10 @@ class RollenController extends Controller
      */
     public function update(string $id, CallService $callService): JSONResponse
     {
+        if ($this->userSession->getUser() === null) {
+            return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
+        }
+
         $body    = $this->request->getParams();
         $results = $callService->update(source: 'zrc', endpoint: 'rollen', data: $body, id: $id);
         return new JSONResponse($results);
@@ -140,6 +160,10 @@ class RollenController extends Controller
      */
     public function destroy(string $id, CallService $callService): JSONResponse
     {
+        if ($this->userSession->getUser() === null) {
+            return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
+        }
+
         $callService->destroy(source: 'zrc', endpoint: 'rollen', id: $id);
         return new JSONResponse([]);
     }//end destroy()

--- a/lib/Controller/StatusenController.php
+++ b/lib/Controller/StatusenController.php
@@ -2,13 +2,14 @@
 
 namespace OCA\ZaakAfhandelApp\Controller;
 
-use GuzzleHttp\Client;
 use OCA\ZaakAfhandelApp\Service\CallService;
 use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\TemplateResponse;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\IAppConfig;
 use OCP\IRequest;
+use OCP\IUserSession;
 
 /**
  * Geeft invulling aan https://vng-realisatie.github.io/gemma-zaken/standaard/zaken/
@@ -18,33 +19,11 @@ use OCP\IRequest;
  */
 class StatusenController extends Controller
 {
-    const TEST_ARRAY = [
-        "5137a1e5-b54d-43ad-abd1-4b5bff5fcd3f" => [
-            "id"      => "5137a1e5-b54d-43ad-abd1-4b5bff5fcd3f",
-            "name"    => "Github",
-            "summary" => "summary for one",
-        ],
-        "4c3edd34-a90d-4d2a-8894-adb5836ecde8" => [
-            "id"      => "4c3edd34-a90d-4d2a-8894-adb5836ecde8",
-            "name"    => "Gitlab",
-            "summary" => "summary for two",
-        ],
-        "15551d6f-44e3-43f3-a9d2-59e583c91eb0" => [
-            "id"      => "15551d6f-44e3-43f3-a9d2-59e583c91eb0",
-            "name"    => "Woo",
-            "summary" => "summary for two",
-        ],
-        "0a3a0ffb-dc03-4aae-b207-0ed1502e60da" => [
-            "id"      => "0a3a0ffb-dc03-4aae-b207-0ed1502e60da",
-            "name"    => "Decat",
-            "summary" => "summary for two",
-        ],
-    ];
-
     public function __construct(
         $appName,
         IRequest $request,
-        private readonly IAppConfig $config
+        private readonly IAppConfig $config,
+        private readonly IUserSession $userSession,
     ) {
         parent::__construct($appName, $request);
     }//end __construct()
@@ -63,7 +42,6 @@ class StatusenController extends Controller
     public function page(): TemplateResponse
     {
         return new TemplateResponse(
-            // Application::APP_ID,
             'zaakafhandelapp',
             'index',
             []
@@ -82,6 +60,10 @@ class StatusenController extends Controller
      */
     public function index(CallService $callService): JSONResponse
     {
+        if ($this->userSession->getUser() === null) {
+            return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
+        }
+
         $results = $callService->index(source: 'zrc', endpoint: 'statussen');
         return new JSONResponse($results);
     }//end index()
@@ -98,6 +80,10 @@ class StatusenController extends Controller
      */
     public function show(string $id, CallService $callService): JSONResponse
     {
+        if ($this->userSession->getUser() === null) {
+            return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
+        }
+
         $results = $callService->show(source: 'zrc', endpoint: 'statussen', id: $id);
         return new JSONResponse($results);
     }//end show()
@@ -114,6 +100,10 @@ class StatusenController extends Controller
      */
     public function create(CallService $callService): JSONResponse
     {
+        if ($this->userSession->getUser() === null) {
+            return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
+        }
+
         // get post from requests
         $body    = $this->request->getParams();
         $results = $callService->create(source: 'zrc', endpoint: 'statussen', data: $body);
@@ -132,6 +122,10 @@ class StatusenController extends Controller
      */
     public function update(string $id, CallService $callService): JSONResponse
     {
+        if ($this->userSession->getUser() === null) {
+            return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
+        }
+
         $body    = $this->request->getParams();
         $results = $callService->update(source: 'zrc', endpoint: 'statussen', data: $body, id: $id);
         return new JSONResponse($results);
@@ -149,6 +143,10 @@ class StatusenController extends Controller
      */
     public function destroy(string $id, CallService $callService): JSONResponse
     {
+        if ($this->userSession->getUser() === null) {
+            return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
+        }
+
         $callService->destroy(source: 'zrc', endpoint: 'statussen', id: $id);
 
         return new JSONResponse([]);

--- a/lib/Controller/TakenController.php
+++ b/lib/Controller/TakenController.php
@@ -5,10 +5,12 @@ namespace OCA\ZaakAfhandelApp\Controller;
 use OCA\ZaakAfhandelApp\Service\MailService;
 use OCA\ZaakAfhandelApp\Service\ObjectService;
 use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\IRequest;
 use OCP\AppFramework\Http\TemplateResponse;
 use OCP\AppFramework\Http\ContentSecurityPolicy;
+use OCP\IUserSession;
 
 /**
  * Controller for handling tasks (taken) operations.
@@ -23,6 +25,7 @@ class TakenController extends Controller
         IRequest $request,
         private readonly MailService $mailService,
         private readonly ObjectService $objectService,
+        private readonly IUserSession $userSession,
     ) {
         parent::__construct($appName, $request);
     }//end __construct()
@@ -39,6 +42,10 @@ class TakenController extends Controller
      */
     public function index(): JSONResponse
     {
+        if ($this->userSession->getUser() === null) {
+            return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
+        }
+
         // Retrieve all request parameters.
         $requestParams = $this->request->getParams();
 
@@ -102,6 +109,10 @@ class TakenController extends Controller
      */
     public function show(string $id): JSONResponse
     {
+        if ($this->userSession->getUser() === null) {
+            return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
+        }
+
         // Fetch the catalog object by its ID.
         $object = $this->objectService->getObject('taken', $id);
 
@@ -121,6 +132,10 @@ class TakenController extends Controller
      */
     public function create(): JSONResponse
     {
+        if ($this->userSession->getUser() === null) {
+            return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
+        }
+
         // Get all parameters from the request.
         $data = $this->request->getParams();
 
@@ -150,6 +165,10 @@ class TakenController extends Controller
      */
     public function update(string $id): JSONResponse
     {
+        if ($this->userSession->getUser() === null) {
+            return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
+        }
+
         // Get all parameters from the request.
         $data = $this->request->getParams();
 
@@ -183,6 +202,10 @@ class TakenController extends Controller
      */
     public function destroy(string $id): JSONResponse
     {
+        if ($this->userSession->getUser() === null) {
+            return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
+        }
+
         // Delete the catalog object.
         $result = $this->objectService->deleteObject('taken', $id);
 
@@ -204,6 +227,10 @@ class TakenController extends Controller
      */
     public function getAuditTrail(string $id): JSONResponse
     {
+        if ($this->userSession->getUser() === null) {
+            return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
+        }
+
         $auditTrail = $this->objectService->getAuditTrail('taken', $id);
         return new JSONResponse($auditTrail);
     }//end getAuditTrail()

--- a/lib/Controller/UsersController.php
+++ b/lib/Controller/UsersController.php
@@ -4,15 +4,16 @@ namespace OCA\ZaakAfhandelApp\Controller;
 
 use OCP\IAppConfig;
 use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\TemplateResponse;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\IRequest;
 use OCP\IUserSession;
 
 /**
- * Class SettingsController
+ * Class UsersController
  *
- * Controller for handling settings-related operations in the OpenCatalogi app.
+ * Controller for handling user-related operations in the ZaakAfhandelApp.
  *
  * @copyright 2024 Conduction B.V. <info@conduction.nl>
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
@@ -20,11 +21,12 @@ use OCP\IUserSession;
 class UsersController extends Controller
 {
     /**
-     * SettingsController constructor.
+     * UsersController constructor.
      *
-     * @param string     $appName The name of the app
-     * @param IAppConfig $config  The app configuration
-     * @param IRequest   $request The request object
+     * @param string       $appName     The name of the app
+     * @param IAppConfig   $config      The app configuration
+     * @param IRequest     $request     The request object
+     * @param IUserSession $userSession The user session
      */
     public function __construct(
         $appName,
@@ -49,6 +51,9 @@ class UsersController extends Controller
     {
         // Get the current user
         $currentUser = $this->userSession->getUser();
+        if ($currentUser === null) {
+            return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
+        }
 
         try {
             $data = [

--- a/lib/Controller/ZaakAuditTrailController.php
+++ b/lib/Controller/ZaakAuditTrailController.php
@@ -2,12 +2,13 @@
 
 namespace OCA\ZaakAfhandelApp\Controller;
 
-use GuzzleHttp\Client;
 use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\TemplateResponse;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\IAppConfig;
 use OCP\IRequest;
+use OCP\IUserSession;
 
 /**
  * Controller for zaak audit trail resources.
@@ -43,7 +44,8 @@ class ZaakAuditTrailController extends Controller
     public function __construct(
         $appName,
         IRequest $request,
-        private readonly IAppConfig $config
+        private readonly IAppConfig $config,
+        private readonly IUserSession $userSession,
     ) {
         parent::__construct($appName, $request);
     }//end __construct()
@@ -62,7 +64,6 @@ class ZaakAuditTrailController extends Controller
     public function page(): TemplateResponse
     {
         return new TemplateResponse(
-            // Application::APP_ID,
             'zaakafhandelapp',
             'index',
             []
@@ -81,6 +82,10 @@ class ZaakAuditTrailController extends Controller
      */
     public function index(): JSONResponse
     {
+        if ($this->userSession->getUser() === null) {
+            return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
+        }
+
         $results = ["results" => self::TEST_ARRAY];
         return new JSONResponse($results);
     }//end index()
@@ -97,6 +102,10 @@ class ZaakAuditTrailController extends Controller
      */
     public function show(string $id): JSONResponse
     {
+        if ($this->userSession->getUser() === null) {
+            return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
+        }
+
         $result = self::TEST_ARRAY[$id];
         return new JSONResponse($result);
     }//end show()
@@ -113,6 +122,10 @@ class ZaakAuditTrailController extends Controller
      */
     public function create(): JSONResponse
     {
+        if ($this->userSession->getUser() === null) {
+            return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
+        }
+
         // get post from requests
         return new JSONResponse([]);
     }//end create()
@@ -129,6 +142,10 @@ class ZaakAuditTrailController extends Controller
      */
     public function update(string $id): JSONResponse
     {
+        if ($this->userSession->getUser() === null) {
+            return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
+        }
+
         $result = self::TEST_ARRAY[$id];
         return new JSONResponse($result);
     }//end update()
@@ -145,6 +162,10 @@ class ZaakAuditTrailController extends Controller
      */
     public function destroy(string $id): JSONResponse
     {
+        if ($this->userSession->getUser() === null) {
+            return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
+        }
+
         return new JSONResponse([]);
     }//end destroy()
 }//end class

--- a/lib/Controller/ZaakBesluitenController.php
+++ b/lib/Controller/ZaakBesluitenController.php
@@ -2,12 +2,13 @@
 
 namespace OCA\ZaakAfhandelApp\Controller;
 
-use GuzzleHttp\Client;
 use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\TemplateResponse;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\IAppConfig;
 use OCP\IRequest;
+use OCP\IUserSession;
 
 /**
  * Controller for zaakbesluiten (case decisions) resources.
@@ -43,7 +44,8 @@ class ZaakBesluitenController extends Controller
     public function __construct(
         $appName,
         IRequest $request,
-        private readonly IAppConfig $config
+        private readonly IAppConfig $config,
+        private readonly IUserSession $userSession,
     ) {
         parent::__construct($appName, $request);
     }//end __construct()
@@ -62,7 +64,6 @@ class ZaakBesluitenController extends Controller
     public function page(): TemplateResponse
     {
         return new TemplateResponse(
-            // Application::APP_ID,
             'zaakafhandelapp',
             'index',
             []
@@ -81,6 +82,10 @@ class ZaakBesluitenController extends Controller
      */
     public function index(): JSONResponse
     {
+        if ($this->userSession->getUser() === null) {
+            return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
+        }
+
         $results = ["results" => self::TEST_ARRAY];
         return new JSONResponse($results);
     }//end index()
@@ -97,6 +102,10 @@ class ZaakBesluitenController extends Controller
      */
     public function show(string $id): JSONResponse
     {
+        if ($this->userSession->getUser() === null) {
+            return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
+        }
+
         $result = self::TEST_ARRAY[$id];
         return new JSONResponse($result);
     }//end show()
@@ -113,6 +122,10 @@ class ZaakBesluitenController extends Controller
      */
     public function create(): JSONResponse
     {
+        if ($this->userSession->getUser() === null) {
+            return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
+        }
+
         // get post from requests
         return new JSONResponse([]);
     }//end create()
@@ -129,6 +142,10 @@ class ZaakBesluitenController extends Controller
      */
     public function update(string $id): JSONResponse
     {
+        if ($this->userSession->getUser() === null) {
+            return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
+        }
+
         $result = self::TEST_ARRAY[$id];
         return new JSONResponse($result);
     }//end update()
@@ -145,6 +162,10 @@ class ZaakBesluitenController extends Controller
      */
     public function destroy(string $id): JSONResponse
     {
+        if ($this->userSession->getUser() === null) {
+            return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
+        }
+
         return new JSONResponse([]);
     }//end destroy()
 }//end class

--- a/lib/Controller/ZaakEigenschappenController.php
+++ b/lib/Controller/ZaakEigenschappenController.php
@@ -2,13 +2,14 @@
 
 namespace OCA\ZaakAfhandelApp\Controller;
 
-use GuzzleHttp\Client;
 use OCA\ZaakAfhandelApp\Service\CallService;
 use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\TemplateResponse;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\IAppConfig;
 use OCP\IRequest;
+use OCP\IUserSession;
 
 /**
  * Controller for zaak eigenschappen (case properties) resources.
@@ -18,33 +19,11 @@ use OCP\IRequest;
  */
 class ZaakEigenschappenController extends Controller
 {
-    const TEST_ARRAY = [
-        "5137a1e5-b54d-43ad-abd1-4b5bff5fcd3f" => [
-            "id"      => "5137a1e5-b54d-43ad-abd1-4b5bff5fcd3f",
-            "name"    => "Zaakt type 1",
-            "summary" => "summary for one",
-        ],
-        "4c3edd34-a90d-4d2a-8894-adb5836ecde8" => [
-            "id"      => "4c3edd34-a90d-4d2a-8894-adb5836ecde8",
-            "name"    => "Zaakt type 12",
-            "summary" => "summary for two",
-        ],
-        "15551d6f-44e3-43f3-a9d2-59e583c91eb0" => [
-            "id"      => "15551d6f-44e3-43f3-a9d2-59e583c91eb0",
-            "name"    => "Zaakt type 3",
-            "summary" => "summary for two",
-        ],
-        "0a3a0ffb-dc03-4aae-b207-0ed1502e60da" => [
-            "id"      => "0a3a0ffb-dc03-4aae-b207-0ed1502e60da",
-            "name"    => "Zaakt type 4",
-            "summary" => "summary for two",
-        ],
-    ];
-
     public function __construct(
         $appName,
         IRequest $request,
-        private readonly IAppConfig $config
+        private readonly IAppConfig $config,
+        private readonly IUserSession $userSession,
     ) {
         parent::__construct($appName, $request);
     }//end __construct()
@@ -63,7 +42,6 @@ class ZaakEigenschappenController extends Controller
     public function page(): TemplateResponse
     {
         return new TemplateResponse(
-            // Application::APP_ID,
             'zaakafhandelapp',
             'index',
             []
@@ -82,6 +60,10 @@ class ZaakEigenschappenController extends Controller
      */
     public function index(CallService $callService, string $zaakId): JSONResponse
     {
+        if ($this->userSession->getUser() === null) {
+            return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
+        }
+
         $results = $callService->index(source: 'zrc', endpoint: "zaken/$zaakId/zaakeigenschappen");
         return new JSONResponse($results);
     }//end index()
@@ -98,6 +80,10 @@ class ZaakEigenschappenController extends Controller
      */
     public function show(string $id, CallService $callService, string $zaakId): JSONResponse
     {
+        if ($this->userSession->getUser() === null) {
+            return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
+        }
+
         $results = $callService->show(source: 'zrc', endpoint: "zaken/$zaakId/zaakeigenschappen", id: $id);
         return new JSONResponse($results);
     }//end show()
@@ -114,6 +100,10 @@ class ZaakEigenschappenController extends Controller
      */
     public function create(CallService $callService, string $zaakId): JSONResponse
     {
+        if ($this->userSession->getUser() === null) {
+            return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
+        }
+
         // get post from requests
         $body    = $this->request->getParams();
         $results = $callService->create(source: 'zrc', endpoint: "zaken/$zaakId/zaakeigenschappen", data: $body);
@@ -132,6 +122,10 @@ class ZaakEigenschappenController extends Controller
      */
     public function update(string $id, CallService $callService, string $zaakId): JSONResponse
     {
+        if ($this->userSession->getUser() === null) {
+            return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
+        }
+
         $body    = $this->request->getParams();
         $results = $callService->update(source: 'zrc', endpoint: "zaken/$zaakId/zaakeigenschappen", data: $body, id: $id);
         return new JSONResponse($results);
@@ -149,6 +143,10 @@ class ZaakEigenschappenController extends Controller
      */
     public function destroy(string $id, CallService $callService, string $zaakId): JSONResponse
     {
+        if ($this->userSession->getUser() === null) {
+            return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
+        }
+
         $callService->destroy(source: 'zrc', endpoint: "zaken/$zaakId/zaakeigenschappen", id: $id);
 
         return new JSONResponse([]);

--- a/lib/Controller/ZaakInformatieObjectenController.php
+++ b/lib/Controller/ZaakInformatieObjectenController.php
@@ -2,13 +2,14 @@
 
 namespace OCA\ZaakAfhandelApp\Controller;
 
-use GuzzleHttp\Client;
 use OCA\ZaakAfhandelApp\Service\CallService;
 use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\TemplateResponse;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\IAppConfig;
 use OCP\IRequest;
+use OCP\IUserSession;
 
 /**
  * Controller for zaakinformatieobjecten (case document links) resources.
@@ -18,33 +19,11 @@ use OCP\IRequest;
  */
 class ZaakInformatieObjectenController extends Controller
 {
-    const TEST_ARRAY = [
-        "5137a1e5-b54d-43ad-abd1-4b5bff5fcd3f" => [
-            "id"      => "5137a1e5-b54d-43ad-abd1-4b5bff5fcd3f",
-            "name"    => "Zaakt type 1",
-            "summary" => "summary for one",
-        ],
-        "4c3edd34-a90d-4d2a-8894-adb5836ecde8" => [
-            "id"      => "4c3edd34-a90d-4d2a-8894-adb5836ecde8",
-            "name"    => "Zaakt type 12",
-            "summary" => "summary for two",
-        ],
-        "15551d6f-44e3-43f3-a9d2-59e583c91eb0" => [
-            "id"      => "15551d6f-44e3-43f3-a9d2-59e583c91eb0",
-            "name"    => "Zaakt type 3",
-            "summary" => "summary for two",
-        ],
-        "0a3a0ffb-dc03-4aae-b207-0ed1502e60da" => [
-            "id"      => "0a3a0ffb-dc03-4aae-b207-0ed1502e60da",
-            "name"    => "Zaakt type 4",
-            "summary" => "summary for two",
-        ],
-    ];
-
     public function __construct(
         $appName,
         IRequest $request,
-        private readonly IAppConfig $config
+        private readonly IAppConfig $config,
+        private readonly IUserSession $userSession,
     ) {
         parent::__construct($appName, $request);
     }//end __construct()
@@ -63,7 +42,6 @@ class ZaakInformatieObjectenController extends Controller
     public function page(): TemplateResponse
     {
         return new TemplateResponse(
-        // Application::APP_ID,
             'zaakafhandelapp',
             'index',
             []
@@ -82,6 +60,10 @@ class ZaakInformatieObjectenController extends Controller
      */
     public function index(CallService $callService): JSONResponse
     {
+        if ($this->userSession->getUser() === null) {
+            return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
+        }
+
         $results = $callService->index(source: 'zrc', endpoint: 'zaakinformatieobjecten');
         return new JSONResponse($results);
     }//end index()
@@ -98,6 +80,10 @@ class ZaakInformatieObjectenController extends Controller
      */
     public function show(string $id, CallService $callService): JSONResponse
     {
+        if ($this->userSession->getUser() === null) {
+            return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
+        }
+
         $results = $callService->show(source: 'zrc', endpoint: 'zaakinformatieobjecten', id: $id);
         return new JSONResponse($results);
     }//end show()
@@ -114,6 +100,10 @@ class ZaakInformatieObjectenController extends Controller
      */
     public function create(CallService $callService): JSONResponse
     {
+        if ($this->userSession->getUser() === null) {
+            return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
+        }
+
         // get post from requests
         $body    = $this->request->getParams();
         $results = $callService->create(source: 'zrc', endpoint: 'zaakinformatieobjecten', data: $body);
@@ -132,6 +122,10 @@ class ZaakInformatieObjectenController extends Controller
      */
     public function update(string $id, CallService $callService): JSONResponse
     {
+        if ($this->userSession->getUser() === null) {
+            return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
+        }
+
         $body    = $this->request->getParams();
         $results = $callService->update(source: 'zrc', endpoint: 'zaakinformatieobjecten', data: $body, id: $id);
         return new JSONResponse($results);
@@ -149,6 +143,10 @@ class ZaakInformatieObjectenController extends Controller
      */
     public function destroy(string $id, CallService $callService): JSONResponse
     {
+        if ($this->userSession->getUser() === null) {
+            return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
+        }
+
         $callService->destroy(source: 'zrc', endpoint: 'zaakinformatieobjecten', id: $id);
 
         return new JSONResponse([]);

--- a/lib/Controller/ZaakObjectenController.php
+++ b/lib/Controller/ZaakObjectenController.php
@@ -2,13 +2,14 @@
 
 namespace OCA\ZaakAfhandelApp\Controller;
 
-use GuzzleHttp\Client;
 use OCA\ZaakAfhandelApp\Service\CallService;
 use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\TemplateResponse;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\IAppConfig;
 use OCP\IRequest;
+use OCP\IUserSession;
 
 /**
  * Controller for zaakobjecten (case objects) resources.
@@ -18,33 +19,11 @@ use OCP\IRequest;
  */
 class ZaakObjectenController extends Controller
 {
-    const TEST_ARRAY = [
-        "5137a1e5-b54d-43ad-abd1-4b5bff5fcd3f" => [
-            "id"      => "5137a1e5-b54d-43ad-abd1-4b5bff5fcd3f",
-            "name"    => "Zaakt type 1",
-            "summary" => "summary for one",
-        ],
-        "4c3edd34-a90d-4d2a-8894-adb5836ecde8" => [
-            "id"      => "4c3edd34-a90d-4d2a-8894-adb5836ecde8",
-            "name"    => "Zaakt type 12",
-            "summary" => "summary for two",
-        ],
-        "15551d6f-44e3-43f3-a9d2-59e583c91eb0" => [
-            "id"      => "15551d6f-44e3-43f3-a9d2-59e583c91eb0",
-            "name"    => "Zaakt type 3",
-            "summary" => "summary for two",
-        ],
-        "0a3a0ffb-dc03-4aae-b207-0ed1502e60da" => [
-            "id"      => "0a3a0ffb-dc03-4aae-b207-0ed1502e60da",
-            "name"    => "Zaakt type 4",
-            "summary" => "summary for two",
-        ],
-    ];
-
     public function __construct(
         $appName,
         IRequest $request,
-        private readonly IAppConfig $config
+        private readonly IAppConfig $config,
+        private readonly IUserSession $userSession,
     ) {
         parent::__construct($appName, $request);
     }//end __construct()
@@ -63,7 +42,6 @@ class ZaakObjectenController extends Controller
     public function page(): TemplateResponse
     {
         return new TemplateResponse(
-            // Application::APP_ID,
             'zaakafhandelapp',
             'index',
             []
@@ -82,6 +60,10 @@ class ZaakObjectenController extends Controller
      */
     public function index(CallService $callService): JSONResponse
     {
+        if ($this->userSession->getUser() === null) {
+            return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
+        }
+
         $results = $callService->index(source: 'zrc', endpoint: 'zaakobjecten');
         return new JSONResponse($results);
     }//end index()
@@ -98,6 +80,10 @@ class ZaakObjectenController extends Controller
      */
     public function show(string $id, CallService $callService): JSONResponse
     {
+        if ($this->userSession->getUser() === null) {
+            return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
+        }
+
         $results = $callService->show(source: 'zrc', endpoint: 'zaakobjecten', id: $id);
         return new JSONResponse($results);
     }//end show()
@@ -114,6 +100,10 @@ class ZaakObjectenController extends Controller
      */
     public function create(CallService $callService): JSONResponse
     {
+        if ($this->userSession->getUser() === null) {
+            return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
+        }
+
         // get post from requests
         $body    = $this->request->getParams();
         $results = $callService->create(source: 'zrc', endpoint: 'zaakobjecten', data: $body);
@@ -132,6 +122,10 @@ class ZaakObjectenController extends Controller
      */
     public function update(string $id, CallService $callService): JSONResponse
     {
+        if ($this->userSession->getUser() === null) {
+            return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
+        }
+
         $body    = $this->request->getParams();
         $results = $callService->update(source: 'zrc', endpoint: 'zaakobjecten', data: $body, id: $id);
         return new JSONResponse($results);
@@ -149,6 +143,10 @@ class ZaakObjectenController extends Controller
      */
     public function destroy(string $id, CallService $callService): JSONResponse
     {
+        if ($this->userSession->getUser() === null) {
+            return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
+        }
+
         $callService->destroy(source: 'zrc', endpoint: 'zaakobjecten', id: $id);
 
         return new JSONResponse([]);

--- a/lib/Controller/ZaakTypenController.php
+++ b/lib/Controller/ZaakTypenController.php
@@ -4,10 +4,12 @@ namespace OCA\ZaakAfhandelApp\Controller;
 
 use OCA\ZaakAfhandelApp\Service\ObjectService;
 use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\IRequest;
 use OCP\AppFramework\Http\TemplateResponse;
 use OCP\AppFramework\Http\ContentSecurityPolicy;
+use OCP\IUserSession;
 
 /**
  * Controller for zaaktypen (case types) operations.
@@ -21,6 +23,7 @@ class ZaakTypenController extends Controller
         $appName,
         IRequest $request,
         private readonly ObjectService $objectService,
+        private readonly IUserSession $userSession,
     ) {
         parent::__construct($appName, $request);
     }//end __construct()
@@ -37,6 +40,10 @@ class ZaakTypenController extends Controller
      */
     public function index(): JSONResponse
     {
+        if ($this->userSession->getUser() === null) {
+            return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
+        }
+
          // Retrieve all request parameters
          $requestParams = $this->request->getParams();
 
@@ -97,6 +104,10 @@ class ZaakTypenController extends Controller
      */
     public function show(string $id): JSONResponse
     {
+        if ($this->userSession->getUser() === null) {
+            return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
+        }
+
         // Fetch the catalog object by its ID
         $object = $this->objectService->getObject('zaaktypen', $id);
 
@@ -116,6 +127,10 @@ class ZaakTypenController extends Controller
      */
     public function create(): JSONResponse
     {
+        if ($this->userSession->getUser() === null) {
+            return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
+        }
+
         // Get all parameters from the request
         $data = $this->request->getParams();
 
@@ -141,6 +156,10 @@ class ZaakTypenController extends Controller
      */
     public function update(string $id): JSONResponse
     {
+        if ($this->userSession->getUser() === null) {
+            return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
+        }
+
         // Get all parameters from the request
         $data = $this->request->getParams();
 
@@ -168,6 +187,10 @@ class ZaakTypenController extends Controller
      */
     public function destroy(string $id): JSONResponse
     {
+        if ($this->userSession->getUser() === null) {
+            return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
+        }
+
         // Delete the catalog object
         $result = $this->objectService->deleteObject('zaaktypen', $id);
 

--- a/lib/Controller/ZakenController.php
+++ b/lib/Controller/ZakenController.php
@@ -4,10 +4,12 @@ namespace OCA\ZaakAfhandelApp\Controller;
 
 use OCA\ZaakAfhandelApp\Service\ObjectService;
 use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\IRequest;
 use OCP\AppFramework\Http\TemplateResponse;
 use OCP\AppFramework\Http\ContentSecurityPolicy;
+use OCP\IUserSession;
 
 /**
  * Geeft invulling aan https://vng-realisatie.github.io/gemma-zaken/standaard/zaken/
@@ -21,6 +23,7 @@ class ZakenController extends Controller
         $appName,
         IRequest $request,
         private readonly ObjectService $objectService,
+        private readonly IUserSession $userSession,
     ) {
         parent::__construct($appName, $request);
     }//end __construct()
@@ -37,6 +40,10 @@ class ZakenController extends Controller
      */
     public function index(): JSONResponse
     {
+        if ($this->userSession->getUser() === null) {
+            return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
+        }
+
          // Retrieve all request parameters
         $requestParams = $this->request->getParams();
 
@@ -97,6 +104,10 @@ class ZakenController extends Controller
      */
     public function show(string $id): JSONResponse
     {
+        if ($this->userSession->getUser() === null) {
+            return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
+        }
+
         // Fetch the catalog object by its ID
         $object = $this->objectService->getObject('zaken', $id);
 
@@ -116,6 +127,10 @@ class ZakenController extends Controller
      */
     public function create(): JSONResponse
     {
+        if ($this->userSession->getUser() === null) {
+            return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
+        }
+
         // Get all parameters from the request
         $data = $this->request->getParams();
 
@@ -141,6 +156,10 @@ class ZakenController extends Controller
      */
     public function update(string $id): JSONResponse
     {
+        if ($this->userSession->getUser() === null) {
+            return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
+        }
+
         // Get all parameters from the request
         $data = $this->request->getParams();
 
@@ -163,6 +182,10 @@ class ZakenController extends Controller
      */
     public function destroy(string $id): JSONResponse
     {
+        if ($this->userSession->getUser() === null) {
+            return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
+        }
+
         // Delete the catalog object
         $result = $this->objectService->deleteObject('zaken', $id);
 
@@ -170,18 +193,22 @@ class ZakenController extends Controller
         return new JSONResponse(['success' => $result], $result === true ? 200 : 404);
     }//end destroy()
 
-        /**
-         * Get audit trail for a specific klant
-         *
-         * @NoAdminRequired
-         * @NoCSRFRequired
-         *
-         * @return JSONResponse
-          *
-          * @spec openspec/specs/zgw-zaak-management/spec.md#REQ-004
-         */
+    /**
+     * Get audit trail for a specific zaak
+     *
+     * @NoAdminRequired
+     * @NoCSRFRequired
+     *
+     * @return JSONResponse
+      *
+      * @spec openspec/specs/zgw-zaak-management/spec.md#REQ-004
+     */
     public function getAuditTrail(string $id): JSONResponse
     {
+        if ($this->userSession->getUser() === null) {
+            return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
+        }
+
         $auditTrail = $this->objectService->getAuditTrail('zaken', $id);
         return new JSONResponse($auditTrail);
     }//end getAuditTrail()


### PR DESCRIPTION
## Summary

- **Gate 5 (route-auth) BEFORE→AFTER**: 2 failures → 0. Fixed resource key names in `appinfo/routes.php` to match actual controller class names (`statussen`→`statusen`, `zaakinformatieobjecten`→`zaakInformatieObjecten`, `contactmomenten`→`contactMomenten`, `zaakaudittrail`→`zaakAuditTrail`, `zaakbesluiten`→`zaakBesluiten`, `zaakeigenschappen`→`zaakEigenschappen`, `zaakobjecten`→`zaakObjecten`). Added `dashboard` resource. Updated page route names for `statusen#page` and `zaakInformatieObjecten#page`.
- **Gate 7 (no-admin-idor) BEFORE→AFTER**: 111 failures → 0. Added `IUserSession` injection and `Http::STATUS_UNAUTHORIZED` null-guard at the top of every `@NoAdminRequired` non-`TemplateResponse` method across all 22 affected controllers. `TemplateResponse`-returning `page()` methods are exempted per gate rules (NC middleware already ensures authenticated user).
- **Gate 14 (route-reachability) BEFORE→AFTER**: 47 failures → 0. Fixed as a side-effect of the resource key renames — controllers whose camelCase slugs now match their resource entries are correctly exempted from invariant 1. `DashboardController` added to resources to cover its CRUD methods.
- **Gates 6, 9**: Were already PASS before this PR.

## Posture summary

All ZGW CRUD controllers (Zaken, Klanten, Berichten, ContactMomenten, Medewerkers, etc.) are user-facing OR data access endpoints → `#[NoAdminRequired]` + 401-guard posture (OR data-RBAC scopes cover object-level access). No `requireAction` / ADR-023 kit needed — ZGW resources have no cross-object admin actions.

## Routes changed

Resource keys renamed in `appinfo/routes.php` to match PascalCase controller names (no URL changes — all `'url'` values preserved). Two page route names updated: `statussen#page`→`statusen#page`, `zaakinformatieobjecten#page`→`zaakInformatieObjecten#page`. Added `dashboard` resource with URL `api/dashboard`.

## Kit ported?

No ADR-023 `ActionAuthService` kit needed. All methods are standard ZGW CRUD — guard is a user-null check, not action RBAC.

## Gate-17 status

PASS (was already passing before).

## PHPStan result

**0 errors** — run confirmed after `composer install --ignore-platform-reqs`.

## Flagged items

None. All 18 Hydra gates green.

Refs: #260