### PR TITLE
fix(security): P0 credential exfiltration, stub audit data, and master-data ACL (#267 #268 #269)

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -1,32 +1,34 @@
 <?php
 
 return [
-	 'resources' => [
+	'resources' => [
 		// Conform https://vng-realisatie.github.io/gemma-zaken/standaard/zaken/redoc-1.5.1
-	 	'zaken' => ['url' => 'api/zrc/zaken'],
-	 	'resultaten' => ['url' => 'api/zrc/resultaten'],
-	 	'rollen' => ['url' => 'api/zrc/rollen'],
-	 	'statussen' => ['url' => 'api/zrc/statussen'],
-	 	'zaakinformatieobjecten' => ['url' => 'api/zrc/zaakinformatieobjecten'],
-	 	'zaakobjecten' => ['url' => 'api/zrc/zaakobjecten'],
-		// Removed zaakbesluiten and zaakaudittrail resource routes: controllers return 501
-		// until a real OR-backed implementation is in place (issue #268).
-	 	'zaakeigenschappen' => ['url' => 'api/zrc/zaken/{zaak_uuid}/eigenschappen'],
+		'zaken' => ['url' => 'api/zrc/zaken'],
+		'resultaten' => ['url' => 'api/zrc/resultaten'],
+		'rollen' => ['url' => 'api/zrc/rollen'],
+		'statusen' => ['url' => 'api/zrc/statussen'],
+		'zaakInformatieObjecten' => ['url' => 'api/zrc/zaakinformatieobjecten'],
+		'zaakObjecten' => ['url' => 'api/zrc/zaakobjecten'],
+		// zaakBesluiten and zaakAuditTrail resource routes removed (issue #268):
+		// controllers return 501 until a real OR-backed implementation is in place.
+		'zaakEigenschappen' => ['url' => 'api/zrc/zaken/{zaak_uuid}/eigenschappen'],
 		// Conform https://vng-realisatie.github.io/gemma-zaken/standaard/catalogi/redoc-1.3.1
-	 	'zaakTypen' => ['url' => 'api/ztc/zaaktypen'],
+		'zaakTypen' => ['url' => 'api/ztc/zaaktypen'],
 		// Conform https://vng-realisatie.github.io/gemma-zaken/standaard/documenten/redoc-1.5.0
-		// Removed documenten resource route: controller returns 501 until a real
-		// DRC-backed implementation is in place (issue #268).
+		// documenten resource route removed (issue #268): controller returns 501 until real DRC
+		// implementation is in place.
 		// Conform https://vng-realisatie.github.io/gemma-zaken/standaard/besluiten/redoc-1.0.2
-	 	'besluiten' => ['url' => 'api/brc'],
+		'besluiten' => ['url' => 'api/brc'],
 		// Conform ???
-	 	'taken' => ['url' => 'api/taken'],
-	 	'klanten' => ['url' => 'api/klanten'],
-	 	'berichten' => ['url' => 'api/berichten'],
-
-	 ],
+		'taken' => ['url' => 'api/taken'],
+		'klanten' => ['url' => 'api/klanten'],
+		'berichten' => ['url' => 'api/berichten'],
+		'contactMomenten' => ['url' => 'api/contactmomenten'],
+		'medewerkers' => ['url' => 'api/medewerkers'],
+		'dashboard' => ['url' => 'api/dashboard'],
+	],
 	'routes' => [
-		// Audit trail routes (read-only — real data from ObjectService)
+		// Audit trail routes
 		['name' => 'zaken#getAuditTrail', 'url' => '/api/zaken/{id}/audit_trail', 'verb' => 'GET'],
 		['name' => 'klanten#getAuditTrail', 'url' => '/api/klanten/{id}/audit_trail', 'verb' => 'GET'],
 		['name' => 'berichten#getAuditTrail', 'url' => '/api/berichten/{id}/audit_trail', 'verb' => 'GET'],
@@ -42,16 +44,41 @@ return [
 		['name' => 'dashboard#page', 'url' => '/', 'verb' => 'GET'],
 		['name' => 'configuration#index', 'url' => '/api/configuration', 'verb' => 'GET'],
 		['name' => 'configuration#create', 'url' => '/api/configuration', 'verb' => 'POST'],
+		['name' => 'contactMomenten#page', 'url' => '/contactmomenten', 'verb' => 'GET'],
+		['name' => 'contactMomenten#page', 'postfix' => 'details', 'url' => '/contactmomenten/{id}', 'verb' => 'GET'],
 		['name' => 'zaken#page', 'url' => '/zaken', 'verb' => 'GET'],
+		['name' => 'zaken#page', 'postfix'  => 'details', 'url' => '/zaken/{id}', 'verb' => 'GET'],
 		['name' => 'rollen#page', 'url' => '/rollen', 'verb' => 'GET'],
-		['name' => 'statussen#page', 'url' => '/statussen', 'verb' => 'GET'],
-		['name' => 'zaakinformatieobjecten#page', 'url' => '/zaakinformatieobjecten', 'verb' => 'GET'],
-		['name' => 'zaakTypen#page','url' => '/zaak_typen', 'verb' => 'GET'],
+		['name' => 'rollen#page', 'postfix'  => 'details', 'url' => '/rollen/{id}', 'verb' => 'GET'],
+		['name' => 'statusen#page', 'url' => '/statussen', 'verb' => 'GET'],
+		['name' => 'zaakInformatieObjecten#page', 'url' => '/zaakinformatieobjecten', 'verb' => 'GET'],
+		['name' => 'zaakTypen#page','url' => '/zaaktypen', 'verb' => 'GET'],
+		['name' => 'zaakTypen#page','postfix' => 'details', 'url' => '/zaaktypen/{id}', 'verb' => 'GET'],
 		['name' => 'taken#page','url' => '/taken', 'verb' => 'GET'],
+		['name' => 'taken#page','postfix' => 'details', 'url' => '/taken/{id}', 'verb' => 'GET'],
 		['name' => 'klanten#page','url' => '/klanten', 'verb' => 'GET'],
-		['name' => 'berichten#index','url' => '/berichten', 'verb' => 'GET'],
+		['name' => 'klanten#page','postfix' => 'details', 'url' => '/klanten/{id}', 'verb' => 'GET'],
+		['name' => 'medewerkers#page','url' => '/medewerkers', 'verb' => 'GET'],
+		['name' => 'medewerkers#page','postfix' => 'details', 'url' => '/medewerkers/{id}', 'verb' => 'GET'],
+		['name' => 'berichten#page','url' => '/berichten', 'verb' => 'GET'],
+		['name' => 'berichten#page','postfix' => 'details', 'url' => '/berichten/{id}', 'verb' => 'GET'],
+		['name' => 'dashboard#page', 'postfix' => 'search', 'url' => '/zoeken', 'verb' => 'GET'],
 		// user Settings
 		['name' => 'settings#index','url' => '/settings', 'verb' => 'GET'],
 		['name' => 'settings#create', 'url' => '/settings', 'verb' => 'POST'],
+		// Generic per-user preferences (used by shared nextcloud-vue widgets, e.g. CnSupportDialog).
+		['name' => 'preferences#getPreference', 'url' => '/api/preferences/{key}', 'verb' => 'GET'],
+		['name' => 'preferences#setPreference', 'url' => '/api/preferences/{key}', 'verb' => 'PUT'],
+		// User
+		['name' => 'users#me', 'url' => '/me', 'verb' => 'GET'],
+		// Object API routes
+		['name' => 'objects#index', 'url' => 'api/objects/{objectType}', 'verb' => 'GET'],
+		['name' => 'objects#create', 'url' => 'api/objects/{objectType}', 'verb' => 'POST'],
+		['name' => 'objects#show', 'url' => 'api/objects/{objectType}/{id}', 'verb' => 'GET'],
+		['name' => 'objects#update', 'url' => 'api/objects/{objectType}/{id}', 'verb' => 'PUT'],
+		['name' => 'objects#destroy', 'url' => 'api/objects/{objectType}/{id}', 'verb' => 'DELETE'],
+		['name' => 'objects#getAuditTrail', 'url' => 'api/objects/{objectType}/{id}/audit', 'verb' => 'GET'],
+		['name' => 'objects#getRelations', 'url' => 'api/objects/{objectType}/{id}/relations', 'verb' => 'GET'],
+		['name' => 'objects#getUses', 'url' => 'api/objects/{objectType}/{id}/uses', 'verb' => 'GET']
 	]
 ];

--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -9,36 +9,35 @@ return [
 	 	'statussen' => ['url' => 'api/zrc/statussen'],
 	 	'zaakinformatieobjecten' => ['url' => 'api/zrc/zaakinformatieobjecten'],
 	 	'zaakobjecten' => ['url' => 'api/zrc/zaakobjecten'],
-	 	'zaakbesluiten' => ['url' => 'api/zrc/zaken/{zaak_uuid}/besluiten'],
+		// Removed zaakbesluiten and zaakaudittrail resource routes: controllers return 501
+		// until a real OR-backed implementation is in place (issue #268).
 	 	'zaakeigenschappen' => ['url' => 'api/zrc/zaken/{zaak_uuid}/eigenschappen'],
-	 	'zaakaudittrail' => ['url' => 'api/zrc/zaken/{zaak_uuid}/audit_trail'],
 		// Conform https://vng-realisatie.github.io/gemma-zaken/standaard/catalogi/redoc-1.3.1
-	 	'zaakTypen' => ['url' => 'api/ztc'],
+	 	'zaakTypen' => ['url' => 'api/ztc/zaaktypen'],
 		// Conform https://vng-realisatie.github.io/gemma-zaken/standaard/documenten/redoc-1.5.0
-	 	'documenten' => ['url' => 'api/drc'],
+		// Removed documenten resource route: controller returns 501 until a real
+		// DRC-backed implementation is in place (issue #268).
 		// Conform https://vng-realisatie.github.io/gemma-zaken/standaard/besluiten/redoc-1.0.2
 	 	'besluiten' => ['url' => 'api/brc'],
 		// Conform ???
-	 	'zaakTypen' => ['url' => 'api/ztc/zaaktypen'],
-		 // Conform ???
 	 	'taken' => ['url' => 'api/taken'],
 	 	'klanten' => ['url' => 'api/klanten'],
 	 	'berichten' => ['url' => 'api/berichten'],
-		
+
 	 ],
 	'routes' => [
-		// Audit trail routes
+		// Audit trail routes (read-only — real data from ObjectService)
 		['name' => 'zaken#getAuditTrail', 'url' => '/api/zaken/{id}/audit_trail', 'verb' => 'GET'],
 		['name' => 'klanten#getAuditTrail', 'url' => '/api/klanten/{id}/audit_trail', 'verb' => 'GET'],
 		['name' => 'berichten#getAuditTrail', 'url' => '/api/berichten/{id}/audit_trail', 'verb' => 'GET'],
 		['name' => 'taken#getAuditTrail', 'url' => '/api/taken/{id}/audit_trail', 'verb' => 'GET'],
-		
+
 		// Overige klant routes
 		['name' => 'klanten#getContactmomenten', 'url' => '/api/klanten/{id}/contactmomenten', 'verb' => 'GET'],
 		['name' => 'klanten#getTaken', 'url' => '/api/klanten/{id}/taken', 'verb' => 'GET'],
 		['name' => 'klanten#getBerichten', 'url' => '/api/klanten/{id}/berichten', 'verb' => 'GET'],
-		['name' => 'klanten#getZaken', 'url' => '/api/klanten/{id}/zaken', 'verb' => 'GET'],	
-			
+		['name' => 'klanten#getZaken', 'url' => '/api/klanten/{id}/zaken', 'verb' => 'GET'],
+
 		// Page routes
 		['name' => 'dashboard#page', 'url' => '/', 'verb' => 'GET'],
 		['name' => 'configuration#index', 'url' => '/api/configuration', 'verb' => 'GET'],
@@ -46,7 +45,7 @@ return [
 		['name' => 'zaken#page', 'url' => '/zaken', 'verb' => 'GET'],
 		['name' => 'rollen#page', 'url' => '/rollen', 'verb' => 'GET'],
 		['name' => 'statussen#page', 'url' => '/statussen', 'verb' => 'GET'],
-		['name' => 'zaakinformatieobjecten#page', 'url' => '/zaakinformatieobjecten', 'verb' => 'GET'],		
+		['name' => 'zaakinformatieobjecten#page', 'url' => '/zaakinformatieobjecten', 'verb' => 'GET'],
 		['name' => 'zaakTypen#page','url' => '/zaak_typen', 'verb' => 'GET'],
 		['name' => 'taken#page','url' => '/taken', 'verb' => 'GET'],
 		['name' => 'klanten#page','url' => '/klanten', 'verb' => 'GET'],

--- a/lib/Controller/ConfigurationController.php
+++ b/lib/Controller/ConfigurationController.php
@@ -3,20 +3,27 @@
 namespace OCA\ZaakAfhandelApp\Controller;
 
 use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\IAppConfig;
 use OCP\IRequest;
+use OCP\IUserSession;
 
 /**
- * Controller for reading and writing ZGW service configuration.
+ * Controller for application configuration operations.
  *
- * Both GET and POST require admin privileges: the configuration contains
- * service-account API keys that must never be exposed to regular users.
+ * Both GET and POST require admin: the configuration holds ZGW service-account
+ * API keys that must never be exposed to non-admin users (issue #267).
+ *
+ * @copyright 2024 Conduction B.V. <info@conduction.nl>
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  */
 class ConfigurationController extends Controller
 {
     /**
      * Keys that hold credentials — returned as "***" on read.
+     *
+     * @var string[]
      */
     private const CREDENTIAL_KEYS = [
         'drcKey',
@@ -30,7 +37,9 @@ class ConfigurationController extends Controller
     ];
 
     /**
-     * Exhaustive allow-list of keys that may be written via POST.
+     * Exhaustive allow-list of keys accepted on POST.
+     *
+     * @var string[]
      */
     private const WRITABLE_KEYS = [
         'drcLocation',
@@ -66,7 +75,8 @@ class ConfigurationController extends Controller
     public function __construct(
         $appName,
         private readonly IAppConfig $config,
-        IRequest $request
+        IRequest $request,
+        private readonly IUserSession $userSession,
     ) {
         parent::__construct($appName, $request);
     }//end __construct()
@@ -74,26 +84,25 @@ class ConfigurationController extends Controller
     /**
      * Return the current configuration.
      *
-     * Credential fields are redacted: only their presence (non-empty) is
-     * indicated. This prevents exfiltration of API keys.
+     * Credential fields are redacted (returned as "***") so that API keys are
+     * never transmitted to the browser. Admin-only: @NoAdminRequired omitted.
      *
      * @NoCSRFRequired
      *
-     * @return JSONResponse
+     * @spec openspec/specs/app-configuration/spec.md#REQ-001
      */
     public function index(): JSONResponse
     {
+        if ($this->userSession->getUser() === null) {
+            return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
+        }
+
         $defaults = array_fill_keys(self::WRITABLE_KEYS, '');
 
         $data = [];
         foreach ($defaults as $key => $default) {
-            $value = $this->config->getValueString('zaakafhandelapp', $key, $default);
-            // Redact credential values so they are never transmitted to the client.
-            if (in_array($key, self::CREDENTIAL_KEYS, true)) {
-                $data[$key] = $value !== '' ? '***' : '';
-            } else {
-                $data[$key] = $value;
-            }
+            $value      = $this->config->getValueString('zaakafhandelapp', $key, $default);
+            $data[$key] = in_array($key, self::CREDENTIAL_KEYS, true) ? ($value !== '' ? '***' : '') : $value;
         }
 
         return new JSONResponse($data);
@@ -102,15 +111,19 @@ class ConfigurationController extends Controller
     /**
      * Persist configuration values supplied by an admin.
      *
-     * Only keys present in WRITABLE_KEYS are accepted; all other keys in the
-     * request body are silently ignored.
+     * Only keys present in WRITABLE_KEYS are accepted; all others are ignored.
+     * Credential values are redacted in the response. Admin-only: @NoAdminRequired omitted.
      *
      * @NoCSRFRequired
      *
-     * @return JSONResponse
+     * @spec openspec/specs/app-configuration/spec.md#REQ-001
      */
     public function create(): JSONResponse
     {
+        if ($this->userSession->getUser() === null) {
+            return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
+        }
+
         $requestData = $this->request->getParams();
 
         $data = [];
@@ -120,12 +133,9 @@ class ConfigurationController extends Controller
             }
 
             $this->config->setValueString('zaakafhandelapp', $key, (string) $requestData[$key]);
-            // Redact credential values in the response.
-            if (in_array($key, self::CREDENTIAL_KEYS, true)) {
-                $data[$key] = '***';
-            } else {
-                $data[$key] = $this->config->getValueString('zaakafhandelapp', $key);
-            }
+            $data[$key] = in_array($key, self::CREDENTIAL_KEYS, true)
+                ? '***'
+                : $this->config->getValueString('zaakafhandelapp', $key);
         }
 
         return new JSONResponse($data);

--- a/lib/Controller/ConfigurationController.php
+++ b/lib/Controller/ConfigurationController.php
@@ -3,87 +3,131 @@
 namespace OCA\ZaakAfhandelApp\Controller;
 
 use OCP\AppFramework\Controller;
-use OCP\AppFramework\Http\TemplateResponse;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\IAppConfig;
 use OCP\IRequest;
 
+/**
+ * Controller for reading and writing ZGW service configuration.
+ *
+ * Both GET and POST require admin privileges: the configuration contains
+ * service-account API keys that must never be exposed to regular users.
+ */
 class ConfigurationController extends Controller
 {
-	public function __construct(
-		$appName,
-		IAppConfig $config,
-		IRequest $request
-	) {
-		parent::__construct($appName, $request);
-		$this->config = $config;
-		$this->request = $request;
-	}
+    /**
+     * Keys that hold credentials — returned as "***" on read.
+     */
+    private const CREDENTIAL_KEYS = [
+        'drcKey',
+        'orcKey',
+        'zrcKey',
+        'ztcKey',
+        'brcKey',
+        'klantenKey',
+        'elasticKey',
+        'mongodbKey',
+    ];
 
-	/**
-	 * @NoAdminRequired
-	 * @NoCSRFRequired
-	 */
-	public function index(): JSONResponse
-	{
+    /**
+     * Exhaustive allow-list of keys that may be written via POST.
+     */
+    private const WRITABLE_KEYS = [
+        'drcLocation',
+        'drcKey',
+        'drcAuthType',
+        'orcLocation',
+        'orcKey',
+        'orcAuthType',
+        'zrcLocation',
+        'zrcKey',
+        'zrcAuthType',
+        'ztcLocation',
+        'ztcKey',
+        'ztcAuthType',
+        'brcLocation',
+        'brcKey',
+        'brcAuthType',
+        'klantenLocation',
+        'klantenKey',
+        'klantenAuthType',
+        'elasticLocation',
+        'elasticKey',
+        'mongodbLocation',
+        'mongodbKey',
+        'mongodbCluster',
+        'organisationName',
+        'organisationOIN',
+        'organisationPKI',
+        'organisationRSIN',
+        'organisationKVK',
+    ];
 
-		$data = [];
-		$defaults = [
-		// Getting the config
-			'drcLocation'=>'',
-			'drcKey'=>'',
-			'drcAuthType'=>'',
-			'orcLocation'=>'',
-			'orcKey'=>'',
-			'orcAuthType'=>'',
-			'zrcLocation'=>'',
-			'zrcKey'=>'',
-			'zrcAuthType'=>'',
-			'ztcLocation'=>'',
-			'ztcKey'=>'',
-			'ztcAuthType'=>'',
-			'brcLocation' => '',
-			'brcKey'=>'',
-			'brcAuthType'=>'',
-			'klantenLocation'=> '',
-			'klantenKey'=>'',
-			'klantenAuthType'=>'',
-			'elasticLocation'=>'',
-			'elasticKey'=>'',
-			'mongodbLocation'=>'',
-			'mongodbKey'=>'',
-			'mongodbCluster'=>'',
-			'organisationName'=>'',
-			'organisationOIN'=>'',
-			'organisationPKI'=>'',
-			'organisationRSIN'=>'',
-			'organisationKVK'=>''
-		];
+    public function __construct(
+        $appName,
+        private readonly IAppConfig $config,
+        IRequest $request
+    ) {
+        parent::__construct($appName, $request);
+    }//end __construct()
 
-		// We should filter out unwanted values before this
-		foreach($defaults as $key => $value){
-			$data[$key] =  $this->config->getValueString('zaakafhandelapp', $key, $value);
-		}
+    /**
+     * Return the current configuration.
+     *
+     * Credential fields are redacted: only their presence (non-empty) is
+     * indicated. This prevents exfiltration of API keys.
+     *
+     * @NoCSRFRequired
+     *
+     * @return JSONResponse
+     */
+    public function index(): JSONResponse
+    {
+        $defaults = array_fill_keys(self::WRITABLE_KEYS, '');
 
-		return new JSONResponse($data);
-	}
+        $data = [];
+        foreach ($defaults as $key => $default) {
+            $value = $this->config->getValueString('zaakafhandelapp', $key, $default);
+            // Redact credential values so they are never transmitted to the client.
+            if (in_array($key, self::CREDENTIAL_KEYS, true)) {
+                $data[$key] = $value !== '' ? '***' : '';
+            } else {
+                $data[$key] = $value;
+            }
+        }
 
-	/**
-	 * Handling the post request
-	 *
-	 * @NoAdminRequired
-	 * @NoCSRFRequired
-	 */
-	public function create(): JSONResponse
-	{
-		$data = $this->request->getParams();
+        return new JSONResponse($data);
+    }//end index()
 
-		// We should filter out unwanted values before this
-		foreach($data as $key => $value){
-			$this->config->setValueString('zaakafhandelapp', $key, $value);
-			$data[$key] =  $this->config->getValueString('zaakafhandelapp', $key);
-		}
+    /**
+     * Persist configuration values supplied by an admin.
+     *
+     * Only keys present in WRITABLE_KEYS are accepted; all other keys in the
+     * request body are silently ignored.
+     *
+     * @NoCSRFRequired
+     *
+     * @return JSONResponse
+     */
+    public function create(): JSONResponse
+    {
+        $requestData = $this->request->getParams();
 
-		return new JSONResponse($data);
-	}
-}
+        $data = [];
+        foreach (self::WRITABLE_KEYS as $key) {
+            if (!array_key_exists($key, $requestData)) {
+                continue;
+            }
+
+            $this->config->setValueString('zaakafhandelapp', $key, (string) $requestData[$key]);
+            // Redact credential values in the response.
+            if (in_array($key, self::CREDENTIAL_KEYS, true)) {
+                $data[$key] = '***';
+            } else {
+                $data[$key] = $this->config->getValueString('zaakafhandelapp', $key);
+            }
+        }
+
+        return new JSONResponse($data);
+    }//end create()
+}//end class

--- a/lib/Controller/DocumentenController.php
+++ b/lib/Controller/DocumentenController.php
@@ -4,36 +4,44 @@ namespace OCA\ZaakAfhandelApp\Controller;
 
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
-use OCP\AppFramework\Http\JSONResponse;
 use OCP\AppFramework\Http\TemplateResponse;
+use OCP\AppFramework\Http\JSONResponse;
+use OCP\IAppConfig;
 use OCP\IRequest;
+use OCP\IUserSession;
 
 /**
  * Stub controller for the ZGW documenten resource.
  *
  * Geeft invulling aan https://vng-realisatie.github.io/gemma-zaken/standaard/documenten/
  *
- * Real documenten data has not yet been implemented. All data endpoints
- * return 501 Not Implemented so that clients never receive fabricated test
- * data in place of real DRC document records.
+ * Real documenten data has not yet been implemented. All data endpoints return
+ * 501 Not Implemented so that clients never receive fabricated test data in place
+ * of real DRC document records (issue #268).
  *
- * Routes for these endpoints have been removed from appinfo/routes.php until
- * a real implementation backed by ObjectService is in place.
+ * @copyright 2024 Conduction B.V. <info@conduction.nl>
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  */
 class DocumentenController extends Controller
 {
     public function __construct(
         string $appName,
-        IRequest $request
+        IRequest $request,
+        private readonly IAppConfig $config,
+        private readonly IUserSession $userSession,
     ) {
         parent::__construct($appName, $request);
     }//end __construct()
 
     /**
+     * This returns the template of the main app's page.
+     *
      * @NoAdminRequired
      * @NoCSRFRequired
      *
      * @return TemplateResponse
+     *
+     * @spec openspec/specs/zgw-related-resources/spec.md#REQ-003
      */
     public function page(): TemplateResponse
     {
@@ -45,13 +53,21 @@ class DocumentenController extends Controller
     }//end page()
 
     /**
+     * Return (and search) all objects.
+     *
      * @NoAdminRequired
      * @NoCSRFRequired
      *
      * @return JSONResponse
+     *
+     * @spec openspec/specs/zgw-related-resources/spec.md#REQ-001
      */
     public function index(): JSONResponse
     {
+        if ($this->userSession->getUser() === null) {
+            return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
+        }
+
         return new JSONResponse(
             ['error' => 'Documenten is not yet implemented.'],
             Http::STATUS_NOT_IMPLEMENTED
@@ -59,13 +75,21 @@ class DocumentenController extends Controller
     }//end index()
 
     /**
+     * Read a single object.
+     *
      * @NoAdminRequired
      * @NoCSRFRequired
      *
      * @return JSONResponse
+     *
+     * @spec openspec/specs/zgw-related-resources/spec.md#REQ-001
      */
     public function show(string $id): JSONResponse
     {
+        if ($this->userSession->getUser() === null) {
+            return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
+        }
+
         return new JSONResponse(
             ['error' => 'Documenten is not yet implemented.'],
             Http::STATUS_NOT_IMPLEMENTED
@@ -73,13 +97,21 @@ class DocumentenController extends Controller
     }//end show()
 
     /**
+     * Create an object.
+     *
      * @NoAdminRequired
      * @NoCSRFRequired
      *
      * @return JSONResponse
+     *
+     * @spec openspec/specs/zgw-related-resources/spec.md#REQ-002
      */
     public function create(): JSONResponse
     {
+        if ($this->userSession->getUser() === null) {
+            return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
+        }
+
         return new JSONResponse(
             ['error' => 'Documenten is not yet implemented.'],
             Http::STATUS_NOT_IMPLEMENTED
@@ -87,13 +119,21 @@ class DocumentenController extends Controller
     }//end create()
 
     /**
+     * Update an object.
+     *
      * @NoAdminRequired
      * @NoCSRFRequired
      *
      * @return JSONResponse
+     *
+     * @spec openspec/specs/zgw-related-resources/spec.md#REQ-002
      */
     public function update(string $id): JSONResponse
     {
+        if ($this->userSession->getUser() === null) {
+            return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
+        }
+
         return new JSONResponse(
             ['error' => 'Documenten is not yet implemented.'],
             Http::STATUS_NOT_IMPLEMENTED
@@ -101,13 +141,23 @@ class DocumentenController extends Controller
     }//end update()
 
     /**
+     * Delete an object.
+     *
      * @NoAdminRequired
      * @NoCSRFRequired
      *
      * @return JSONResponse
+     *
+     * @spec openspec/specs/zgw-related-resources/spec.md#REQ-002
+     *
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter) — $id is part of the NC route signature.
      */
     public function destroy(string $id): JSONResponse
     {
+        if ($this->userSession->getUser() === null) {
+            return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
+        }
+
         return new JSONResponse(
             ['error' => 'Documenten is not yet implemented.'],
             Http::STATUS_NOT_IMPLEMENTED

--- a/lib/Controller/DocumentenController.php
+++ b/lib/Controller/DocumentenController.php
@@ -2,121 +2,115 @@
 
 namespace OCA\ZaakAfhandelApp\Controller;
 
-use GuzzleHttp\Client;
 use OCP\AppFramework\Controller;
-use OCP\AppFramework\Http\TemplateResponse;
+use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\JSONResponse;
-use OCP\IAppConfig;
+use OCP\AppFramework\Http\TemplateResponse;
 use OCP\IRequest;
 
 /**
- * Geeft invulling aan https://vng-realisatie.github.io/gemma-zaken/standaard/zaken/
+ * Stub controller for the ZGW documenten resource.
+ *
+ * Geeft invulling aan https://vng-realisatie.github.io/gemma-zaken/standaard/documenten/
+ *
+ * Real documenten data has not yet been implemented. All data endpoints
+ * return 501 Not Implemented so that clients never receive fabricated test
+ * data in place of real DRC document records.
+ *
+ * Routes for these endpoints have been removed from appinfo/routes.php until
+ * a real implementation backed by ObjectService is in place.
  */
 class DocumentenController extends Controller
 {
+    public function __construct(
+        string $appName,
+        IRequest $request
+    ) {
+        parent::__construct($appName, $request);
+    }//end __construct()
 
-	/**
-	 * @var IConfig
-	 */
-	private $config;
-
-
-	public function __construct(
-		string $appName,
-		IRequest $request,
-		IAppConfig $config
-	) {
-		parent::__construct($appName, $request);
-		$this->config = $config;
-	}
-
-	/**
-	 * This returns the template of the main app's page
-	 * It adds some data to the template (app version)
-	 *
-	 * @NoAdminRequired
-	 * @NoCSRFRequired
-	 *
-	 * @return TemplateResponse
-	 */
-	public function page(): TemplateResponse
-	{			
+    /**
+     * @NoAdminRequired
+     * @NoCSRFRequired
+     *
+     * @return TemplateResponse
+     */
+    public function page(): TemplateResponse
+    {
         return new TemplateResponse(
-            //Application::APP_ID,
             'zaakafhandelapp',
             'index',
             []
         );
-	}
-	
+    }//end page()
 
     /**
-     * Return (and serach) all objects
-     * 
      * @NoAdminRequired
      * @NoCSRFRequired
-	 *
-	 * @return JSONResponse
+     *
+     * @return JSONResponse
      */
     public function index(): JSONResponse
     {
-        $results = ["results" => self::TEST_ARRAY];
-        return new JSONResponse($results);
-    }
+        return new JSONResponse(
+            ['error' => 'Documenten is not yet implemented.'],
+            Http::STATUS_NOT_IMPLEMENTED
+        );
+    }//end index()
 
     /**
-     * Read a single object
-     * 
      * @NoAdminRequired
      * @NoCSRFRequired
-	 *
-	 * @return JSONResponse
+     *
+     * @return JSONResponse
      */
     public function show(string $id): JSONResponse
     {
-        $result = self::TEST_ARRAY[$id];
-        return new JSONResponse($result);
-    }
-
+        return new JSONResponse(
+            ['error' => 'Documenten is not yet implemented.'],
+            Http::STATUS_NOT_IMPLEMENTED
+        );
+    }//end show()
 
     /**
-     * Creatue an object
-     * 
      * @NoAdminRequired
      * @NoCSRFRequired
-	 *
-	 * @return JSONResponse
+     *
+     * @return JSONResponse
      */
     public function create(): JSONResponse
     {
-        // get post from requests
-        return new JSONResponse([]);
-    }
+        return new JSONResponse(
+            ['error' => 'Documenten is not yet implemented.'],
+            Http::STATUS_NOT_IMPLEMENTED
+        );
+    }//end create()
 
     /**
-     * Update an object
-     * 
      * @NoAdminRequired
      * @NoCSRFRequired
-	 *
-	 * @return JSONResponse
+     *
+     * @return JSONResponse
      */
     public function update(string $id): JSONResponse
     {
-        $result = self::TEST_ARRAY[$id];
-        return new JSONResponse($result);
-    }
+        return new JSONResponse(
+            ['error' => 'Documenten is not yet implemented.'],
+            Http::STATUS_NOT_IMPLEMENTED
+        );
+    }//end update()
 
     /**
-     * Delate an object
-     * 
      * @NoAdminRequired
      * @NoCSRFRequired
-	 *
-	 * @return JSONResponse
+     *
+     * @return JSONResponse
      */
     public function destroy(string $id): JSONResponse
     {
-        return new JSONResponse([]);
-    }
-}
+        return new JSONResponse(
+            ['error' => 'Documenten is not yet implemented.'],
+            Http::STATUS_NOT_IMPLEMENTED
+        );
+    }//end destroy()
+}//end class

--- a/lib/Controller/KlantenController.php
+++ b/lib/Controller/KlantenController.php
@@ -4,16 +4,18 @@ namespace OCA\ZaakAfhandelApp\Controller;
 
 use OCA\ZaakAfhandelApp\Service\ObjectService;
 use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\IRequest;
+use OCP\AppFramework\Http\TemplateResponse;
+use OCP\AppFramework\Http\ContentSecurityPolicy;
+use OCP\IUserSession;
 
 /**
- * Controller for klanten master data.
+ * Controller for handling clients (klanten) operations.
  *
- * Klanten records are used as contact targets in TakenController mail
- * notifications and throughout the zaak lifecycle. Mutations require admin
- * privileges to prevent any authenticated user from injecting arbitrary
- * klant records (see issue #269).
+ * @copyright 2024 Conduction B.V. <info@conduction.nl>
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  */
 class KlantenController extends Controller
 {
@@ -21,20 +23,27 @@ class KlantenController extends Controller
         $appName,
         IRequest $request,
         private readonly ObjectService $objectService,
+        private readonly IUserSession $userSession,
     ) {
         parent::__construct($appName, $request);
     }//end __construct()
 
     /**
-     * Return (and search) all objects.
+     * Return (and serach) all objects
      *
      * @NoAdminRequired
      * @NoCSRFRequired
      *
      * @return JSONResponse
+     *
+     * @spec openspec/specs/zgw-client-interaction/spec.md#REQ-001
      */
     public function index(): JSONResponse
     {
+        if ($this->userSession->getUser() === null) {
+            return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
+        }
+
         // Retrieve all request parameters
         $requestParams = $this->request->getParams();
 
@@ -46,15 +55,62 @@ class KlantenController extends Controller
     }//end index()
 
     /**
-     * Read a single object.
+     * Render no page.
+     *
+     * @param  string|null $getParameter Optional GET parameter
+     * @return TemplateResponse The rendered template response
+     *
+     * @NoAdminRequired
+     * @NoCSRFRequired
+     *
+     * @spec openspec/specs/zgw-client-interaction/spec.md#REQ-004
+     *
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter) — $getParameter is an NC route param
+     *   reserved for future SPA deep-linking; the PHP layer renders a shell template only.
+     */
+    public function page(?string $getParameter): TemplateResponse
+    {
+        try {
+            // Create a new TemplateResponse for the index page
+            $response = new TemplateResponse(
+                $this->appName,
+                'index',
+                []
+            );
+
+            // Set up Content Security Policy
+            $csp = new ContentSecurityPolicy();
+            $csp->addAllowedConnectDomain('*');
+            $response->setContentSecurityPolicy($csp);
+
+            return $response;
+        } catch (\Exception $e) {
+            // Return an error template response if an exception occurs
+            return new TemplateResponse(
+                $this->appName,
+                'error',
+                ['error' => $e->getMessage()],
+                '500'
+            );
+        }//end try
+    }//end page()
+
+    /**
+     * Read a single object
      *
      * @NoAdminRequired
      * @NoCSRFRequired
      *
      * @return JSONResponse
+     *
+     * @spec openspec/specs/zgw-client-interaction/spec.md#REQ-001
      */
     public function show(string $id): JSONResponse
     {
+        if ($this->userSession->getUser() === null) {
+            return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
+        }
+
         // Fetch the catalog object by its ID
         $object = $this->objectService->getObject('klanten', $id);
 
@@ -68,9 +124,15 @@ class KlantenController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse
+     *
+     * @spec openspec/specs/zgw-client-interaction/spec.md#REQ-002
      */
     public function create(): JSONResponse
     {
+        if ($this->userSession->getUser() === null) {
+            return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
+        }
+
         // Get all parameters from the request
         $data = $this->request->getParams();
 
@@ -90,16 +152,25 @@ class KlantenController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse
+     *
+     * @spec openspec/specs/zgw-client-interaction/spec.md#REQ-002
+     *
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter) — $id is part of the NC route signature;
+     *   the full payload is consumed via $this->request->getParams() instead.
      */
     public function update(string $id): JSONResponse
     {
+        if ($this->userSession->getUser() === null) {
+            return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
+        }
+
         // Get all parameters from the request
         $data = $this->request->getParams();
 
-        // Save the updated catalog object
+        // Save the new catalog object
         $object = $this->objectService->saveObject('klanten', $data);
 
-        // Return the updated object as a JSON response
+        // Return the created object as a JSON response
         return new JSONResponse($object);
     }//end update()
 
@@ -109,9 +180,15 @@ class KlantenController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse
+     *
+     * @spec openspec/specs/zgw-client-interaction/spec.md#REQ-002
      */
     public function destroy(string $id): JSONResponse
     {
+        if ($this->userSession->getUser() === null) {
+            return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
+        }
+
         // Delete the catalog object
         $result = $this->objectService->deleteObject('klanten', $id);
 
@@ -120,75 +197,105 @@ class KlantenController extends Controller
     }//end destroy()
 
     /**
-     * Get zaken for a specific klant.
+     * Get zaken for a specific klant
      *
      * @NoAdminRequired
      * @NoCSRFRequired
      *
      * @return JSONResponse
+     *
+     * @spec openspec/specs/zgw-client-interaction/spec.md#REQ-003
      */
     public function getZaken(string $id): JSONResponse
     {
+        if ($this->userSession->getUser() === null) {
+            return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
+        }
+
         $requestParams = ['klant' => $id];
         $zaken         = $this->objectService->getResultArrayForRequest('zaken', $requestParams);
         return new JSONResponse($zaken);
     }//end getZaken()
 
     /**
-     * Get taken for a specific klant.
+     * Get taken for a specific klant
      *
      * @NoAdminRequired
      * @NoCSRFRequired
      *
      * @return JSONResponse
+     *
+     * @spec openspec/specs/zgw-client-interaction/spec.md#REQ-003
      */
     public function getTaken(string $id): JSONResponse
     {
+        if ($this->userSession->getUser() === null) {
+            return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
+        }
+
         $requestParams = ['klant' => $id];
         $taken         = $this->objectService->getResultArrayForRequest('taken', $requestParams);
         return new JSONResponse($taken);
     }//end getTaken()
 
     /**
-     * Get berichten for a specific klant.
+     * Get berichten for a specific klant
      *
      * @NoAdminRequired
      * @NoCSRFRequired
      *
      * @return JSONResponse
+     *
+     * @spec openspec/specs/zgw-client-interaction/spec.md#REQ-003
      */
     public function getBerichten(string $id): JSONResponse
     {
+        if ($this->userSession->getUser() === null) {
+            return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
+        }
+
         $requestParams = ['gebruikerID' => $id];
         $berichten     = $this->objectService->getResultArrayForRequest('klanten', $requestParams);
         return new JSONResponse($berichten);
     }//end getBerichten()
 
     /**
-     * Get contactmomenten for a specific klant.
+     * Get contactmomenten for a specific klant
      *
      * @NoAdminRequired
      * @NoCSRFRequired
      *
      * @return JSONResponse
+     *
+     * @spec openspec/specs/zgw-client-interaction/spec.md#REQ-003
      */
     public function getContactmomenten(string $id): JSONResponse
     {
+        if ($this->userSession->getUser() === null) {
+            return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
+        }
+
         $requestParams   = ['klant' => $id];
         $contactmomenten = $this->objectService->getResultArrayForRequest('contactmomenten', $requestParams);
         return new JSONResponse($contactmomenten);
     }//end getContactmomenten()
 
     /**
-     * Get audit trail for a specific klant.
+     * Get audit trail for a specific klant
      *
      * @NoAdminRequired
      * @NoCSRFRequired
      *
      * @return JSONResponse
+     *
+     * @spec openspec/specs/zgw-client-interaction/spec.md#REQ-004
      */
     public function getAuditTrail(string $id): JSONResponse
     {
+        if ($this->userSession->getUser() === null) {
+            return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
+        }
+
         $auditTrail = $this->objectService->getAuditTrail('klanten', $id);
         return new JSONResponse($auditTrail);
     }//end getAuditTrail()

--- a/lib/Controller/KlantenController.php
+++ b/lib/Controller/KlantenController.php
@@ -7,27 +7,31 @@ use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\IRequest;
 
+/**
+ * Controller for klanten master data.
+ *
+ * Klanten records are used as contact targets in TakenController mail
+ * notifications and throughout the zaak lifecycle. Mutations require admin
+ * privileges to prevent any authenticated user from injecting arbitrary
+ * klant records (see issue #269).
+ */
 class KlantenController extends Controller
 {
-
-    public function __construct
-	(
-		$appName,
-		IRequest $request,
+    public function __construct(
+        $appName,
+        IRequest $request,
         private readonly ObjectService $objectService,
-	)
-    {
+    ) {
         parent::__construct($appName, $request);
-    }
-
+    }//end __construct()
 
     /**
-     * Return (and serach) all objects
+     * Return (and search) all objects.
      *
      * @NoAdminRequired
      * @NoCSRFRequired
-	 *
-	 * @return JSONResponse
+     *
+     * @return JSONResponse
      */
     public function index(): JSONResponse
     {
@@ -39,15 +43,15 @@ class KlantenController extends Controller
 
         // Return JSON response
         return new JSONResponse($data);
-    }
+    }//end index()
 
     /**
-     * Read a single object
+     * Read a single object.
      *
      * @NoAdminRequired
      * @NoCSRFRequired
-	 *
-	 * @return JSONResponse
+     *
+     * @return JSONResponse
      */
     public function show(string $id): JSONResponse
     {
@@ -56,16 +60,14 @@ class KlantenController extends Controller
 
         // Return the catalog as a JSON response
         return new JSONResponse($object);
-    }
-
+    }//end show()
 
     /**
-     * Creatue an object
+     * Create an object. Admin-only: klanten are master data.
      *
-     * @NoAdminRequired
      * @NoCSRFRequired
-	 *
-	 * @return JSONResponse
+     *
+     * @return JSONResponse
      */
     public function create(): JSONResponse
     {
@@ -77,38 +79,36 @@ class KlantenController extends Controller
 
         // Save the new catalog object
         $object = $this->objectService->saveObject('klanten', $data);
-        
+
         // Return the created object as a JSON response
         return new JSONResponse($object);
-    }
+    }//end create()
 
     /**
-     * Update an object
+     * Update an object. Admin-only: klanten are master data.
      *
-     * @NoAdminRequired
      * @NoCSRFRequired
-	 *
-	 * @return JSONResponse
+     *
+     * @return JSONResponse
      */
     public function update(string $id): JSONResponse
     {
         // Get all parameters from the request
         $data = $this->request->getParams();
 
-        // Save the new catalog object
+        // Save the updated catalog object
         $object = $this->objectService->saveObject('klanten', $data);
-        
-        // Return the created object as a JSON response
+
+        // Return the updated object as a JSON response
         return new JSONResponse($object);
-    }
+    }//end update()
 
     /**
-     * Delate an object
+     * Delete an object. Admin-only: klanten are master data.
      *
-     * @NoAdminRequired
      * @NoCSRFRequired
-	 *
-	 * @return JSONResponse
+     *
+     * @return JSONResponse
      */
     public function destroy(string $id): JSONResponse
     {
@@ -116,80 +116,80 @@ class KlantenController extends Controller
         $result = $this->objectService->deleteObject('klanten', $id);
 
         // Return the result as a JSON response
-		return new JSONResponse(['success' => $result], $result === true ? '200' : '404');
-    }
+        return new JSONResponse(['success' => $result], $result === true ? 200 : 404);
+    }//end destroy()
 
     /**
-     * Get zaken for a specific klant
+     * Get zaken for a specific klant.
      *
      * @NoAdminRequired
      * @NoCSRFRequired
-	 *
-	 * @return JSONResponse
+     *
+     * @return JSONResponse
      */
     public function getZaken(string $id): JSONResponse
     {
         $requestParams = ['klant' => $id];
-        $zaken = $this->objectService->getResultArrayForRequest('zaken', $requestParams);
+        $zaken         = $this->objectService->getResultArrayForRequest('zaken', $requestParams);
         return new JSONResponse($zaken);
-    }
+    }//end getZaken()
 
     /**
-     * Get taken for a specific klant
+     * Get taken for a specific klant.
      *
      * @NoAdminRequired
      * @NoCSRFRequired
-	 *
-	 * @return JSONResponse
+     *
+     * @return JSONResponse
      */
     public function getTaken(string $id): JSONResponse
     {
         $requestParams = ['klant' => $id];
-        $taken = $this->objectService->getResultArrayForRequest('taken', $requestParams);
+        $taken         = $this->objectService->getResultArrayForRequest('taken', $requestParams);
         return new JSONResponse($taken);
-    }
+    }//end getTaken()
 
     /**
-     * Get berichten for a specific klant
+     * Get berichten for a specific klant.
      *
      * @NoAdminRequired
      * @NoCSRFRequired
-	 *
-	 * @return JSONResponse
+     *
+     * @return JSONResponse
      */
     public function getBerichten(string $id): JSONResponse
     {
         $requestParams = ['gebruikerID' => $id];
-        $berichten = $this->objectService->getResultArrayForRequest('klanten', $requestParams);
+        $berichten     = $this->objectService->getResultArrayForRequest('klanten', $requestParams);
         return new JSONResponse($berichten);
-    }
+    }//end getBerichten()
 
     /**
-     * Get contactmomenten for a specific klant
+     * Get contactmomenten for a specific klant.
      *
      * @NoAdminRequired
      * @NoCSRFRequired
-	 *
-	 * @return JSONResponse
+     *
+     * @return JSONResponse
      */
     public function getContactmomenten(string $id): JSONResponse
     {
-        $requestParams = ['klant' => $id];
+        $requestParams   = ['klant' => $id];
         $contactmomenten = $this->objectService->getResultArrayForRequest('contactmomenten', $requestParams);
         return new JSONResponse($contactmomenten);
-    }
+    }//end getContactmomenten()
 
     /**
-     * Get audit trail for a specific klant
+     * Get audit trail for a specific klant.
      *
      * @NoAdminRequired
      * @NoCSRFRequired
-	 *
-	 * @return JSONResponse
+     *
+     * @return JSONResponse
      */
     public function getAuditTrail(string $id): JSONResponse
     {
         $auditTrail = $this->objectService->getAuditTrail('klanten', $id);
         return new JSONResponse($auditTrail);
-    }
-}
+    }//end getAuditTrail()
+}//end class

--- a/lib/Controller/ZaakAuditTrailController.php
+++ b/lib/Controller/ZaakAuditTrailController.php
@@ -2,134 +2,113 @@
 
 namespace OCA\ZaakAfhandelApp\Controller;
 
-use GuzzleHttp\Client;
 use OCP\AppFramework\Controller;
-use OCP\AppFramework\Http\TemplateResponse;
+use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\JSONResponse;
-use OCP\IAppConfig;
+use OCP\AppFramework\Http\TemplateResponse;
 use OCP\IRequest;
 
+/**
+ * Stub controller for the ZGW audit-trail resource.
+ *
+ * Real audit-trail data has not yet been implemented. All data endpoints
+ * return 501 Not Implemented so that audit systems and compliance checks
+ * never receive fabricated test data in place of the real evidence trail.
+ *
+ * Routes for these endpoints have been removed from appinfo/routes.php until
+ * a real implementation backed by ObjectService / CallService is in place.
+ */
 class ZaakAuditTrailController extends Controller
 {
-    const TEST_ARRAY = [
-        "5137a1e5-b54d-43ad-abd1-4b5bff5fcd3f" => [
-            "id" => "5137a1e5-b54d-43ad-abd1-4b5bff5fcd3f",
-            "name" => "Zaakt type 1",
-            "summary" => "summary for one"
-        ],
-        "4c3edd34-a90d-4d2a-8894-adb5836ecde8" => [
-            "id" => "4c3edd34-a90d-4d2a-8894-adb5836ecde8",
-            "name" => "Zaakt type 12",
-            "summary" => "summary for two"
-        ],
-        "15551d6f-44e3-43f3-a9d2-59e583c91eb0" => [
-            "id" => "15551d6f-44e3-43f3-a9d2-59e583c91eb0",
-            "name" => "Zaakt type 3",
-            "summary" => "summary for two"
-        ],
-        "0a3a0ffb-dc03-4aae-b207-0ed1502e60da" => [
-            "id" => "0a3a0ffb-dc03-4aae-b207-0ed1502e60da",
-            "name" => "Zaakt type 4",
-            "summary" => "summary for two"
-        ]
-    ];
-
     public function __construct(
-		$appName,
-		IRequest $request,
-		private readonly IAppConfig $config
-	)
-    {
+        $appName,
+        IRequest $request
+    ) {
         parent::__construct($appName, $request);
-    }
+    }//end __construct()
 
-	/**
-	 * This returns the template of the main app's page
-	 * It adds some data to the template (app version)
-	 *
-	 * @NoAdminRequired
-	 * @NoCSRFRequired
-	 *
-	 * @return TemplateResponse
-	 */
-	public function page(): TemplateResponse
-	{			
+    /**
+     * @NoAdminRequired
+     * @NoCSRFRequired
+     *
+     * @return TemplateResponse
+     */
+    public function page(): TemplateResponse
+    {
         return new TemplateResponse(
-            //Application::APP_ID,
             'zaakafhandelapp',
             'index',
             []
         );
-	}
-	
+    }//end page()
 
     /**
-     * Return (and serach) all objects
-     * 
      * @NoAdminRequired
      * @NoCSRFRequired
-	 *
-	 * @return JSONResponse
+     *
+     * @return JSONResponse
      */
     public function index(): JSONResponse
     {
-        $results = ["results" => self::TEST_ARRAY];
-        return new JSONResponse($results);
-    }
+        return new JSONResponse(
+            ['error' => 'Audit trail is not yet implemented.'],
+            Http::STATUS_NOT_IMPLEMENTED
+        );
+    }//end index()
 
     /**
-     * Read a single object
-     * 
      * @NoAdminRequired
      * @NoCSRFRequired
-	 *
-	 * @return JSONResponse
+     *
+     * @return JSONResponse
      */
     public function show(string $id): JSONResponse
     {
-        $result = self::TEST_ARRAY[$id];
-        return new JSONResponse($result);
-    }
-
+        return new JSONResponse(
+            ['error' => 'Audit trail is not yet implemented.'],
+            Http::STATUS_NOT_IMPLEMENTED
+        );
+    }//end show()
 
     /**
-     * Creatue an object
-     * 
      * @NoAdminRequired
      * @NoCSRFRequired
-	 *
-	 * @return JSONResponse
+     *
+     * @return JSONResponse
      */
     public function create(): JSONResponse
     {
-        // get post from requests
-        return new JSONResponse([]);
-    }
+        return new JSONResponse(
+            ['error' => 'Audit trail is not yet implemented.'],
+            Http::STATUS_NOT_IMPLEMENTED
+        );
+    }//end create()
 
     /**
-     * Update an object
-     * 
      * @NoAdminRequired
      * @NoCSRFRequired
-	 *
-	 * @return JSONResponse
+     *
+     * @return JSONResponse
      */
     public function update(string $id): JSONResponse
     {
-        $result = self::TEST_ARRAY[$id];
-        return new JSONResponse($result);
-    }
+        return new JSONResponse(
+            ['error' => 'Audit trail is not yet implemented.'],
+            Http::STATUS_NOT_IMPLEMENTED
+        );
+    }//end update()
 
     /**
-     * Delate an object
-     * 
      * @NoAdminRequired
      * @NoCSRFRequired
-	 *
-	 * @return JSONResponse
+     *
+     * @return JSONResponse
      */
     public function destroy(string $id): JSONResponse
     {
-        return new JSONResponse([]);
-    }
-}
+        return new JSONResponse(
+            ['error' => 'Audit trail is not yet implemented.'],
+            Http::STATUS_NOT_IMPLEMENTED
+        );
+    }//end destroy()
+}//end class

--- a/lib/Controller/ZaakAuditTrailController.php
+++ b/lib/Controller/ZaakAuditTrailController.php
@@ -4,34 +4,42 @@ namespace OCA\ZaakAfhandelApp\Controller;
 
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
-use OCP\AppFramework\Http\JSONResponse;
 use OCP\AppFramework\Http\TemplateResponse;
+use OCP\AppFramework\Http\JSONResponse;
+use OCP\IAppConfig;
 use OCP\IRequest;
+use OCP\IUserSession;
 
 /**
  * Stub controller for the ZGW audit-trail resource.
  *
- * Real audit-trail data has not yet been implemented. All data endpoints
- * return 501 Not Implemented so that audit systems and compliance checks
- * never receive fabricated test data in place of the real evidence trail.
+ * Real audit-trail data has not yet been implemented. All data endpoints return
+ * 501 Not Implemented so that audit systems and Archiefwet compliance checks
+ * never receive fabricated test data in place of the real evidence trail (issue #268).
  *
- * Routes for these endpoints have been removed from appinfo/routes.php until
- * a real implementation backed by ObjectService / CallService is in place.
+ * @copyright 2024 Conduction B.V. <info@conduction.nl>
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  */
 class ZaakAuditTrailController extends Controller
 {
     public function __construct(
         $appName,
-        IRequest $request
+        IRequest $request,
+        private readonly IAppConfig $config,
+        private readonly IUserSession $userSession,
     ) {
         parent::__construct($appName, $request);
     }//end __construct()
 
     /**
+     * This returns the template of the main app's page.
+     *
      * @NoAdminRequired
      * @NoCSRFRequired
      *
      * @return TemplateResponse
+     *
+     * @spec openspec/specs/zgw-zaak-management/spec.md#REQ-005
      */
     public function page(): TemplateResponse
     {
@@ -43,13 +51,21 @@ class ZaakAuditTrailController extends Controller
     }//end page()
 
     /**
+     * Return (and search) all objects.
+     *
      * @NoAdminRequired
      * @NoCSRFRequired
      *
      * @return JSONResponse
+     *
+     * @spec openspec/specs/zgw-zaak-management/spec.md#REQ-005
      */
     public function index(): JSONResponse
     {
+        if ($this->userSession->getUser() === null) {
+            return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
+        }
+
         return new JSONResponse(
             ['error' => 'Audit trail is not yet implemented.'],
             Http::STATUS_NOT_IMPLEMENTED
@@ -57,13 +73,21 @@ class ZaakAuditTrailController extends Controller
     }//end index()
 
     /**
+     * Read a single object.
+     *
      * @NoAdminRequired
      * @NoCSRFRequired
      *
      * @return JSONResponse
+     *
+     * @spec openspec/specs/zgw-zaak-management/spec.md#REQ-005
      */
     public function show(string $id): JSONResponse
     {
+        if ($this->userSession->getUser() === null) {
+            return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
+        }
+
         return new JSONResponse(
             ['error' => 'Audit trail is not yet implemented.'],
             Http::STATUS_NOT_IMPLEMENTED
@@ -71,13 +95,21 @@ class ZaakAuditTrailController extends Controller
     }//end show()
 
     /**
+     * Create an object.
+     *
      * @NoAdminRequired
      * @NoCSRFRequired
      *
      * @return JSONResponse
+     *
+     * @spec openspec/specs/zgw-zaak-management/spec.md#REQ-005
      */
     public function create(): JSONResponse
     {
+        if ($this->userSession->getUser() === null) {
+            return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
+        }
+
         return new JSONResponse(
             ['error' => 'Audit trail is not yet implemented.'],
             Http::STATUS_NOT_IMPLEMENTED
@@ -85,13 +117,21 @@ class ZaakAuditTrailController extends Controller
     }//end create()
 
     /**
+     * Update an object.
+     *
      * @NoAdminRequired
      * @NoCSRFRequired
      *
      * @return JSONResponse
+     *
+     * @spec openspec/specs/zgw-zaak-management/spec.md#REQ-005
      */
     public function update(string $id): JSONResponse
     {
+        if ($this->userSession->getUser() === null) {
+            return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
+        }
+
         return new JSONResponse(
             ['error' => 'Audit trail is not yet implemented.'],
             Http::STATUS_NOT_IMPLEMENTED
@@ -99,13 +139,23 @@ class ZaakAuditTrailController extends Controller
     }//end update()
 
     /**
+     * Delete an object.
+     *
      * @NoAdminRequired
      * @NoCSRFRequired
      *
      * @return JSONResponse
+     *
+     * @spec openspec/specs/zgw-zaak-management/spec.md#REQ-005
+     *
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter) — $id is part of the NC route signature.
      */
     public function destroy(string $id): JSONResponse
     {
+        if ($this->userSession->getUser() === null) {
+            return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
+        }
+
         return new JSONResponse(
             ['error' => 'Audit trail is not yet implemented.'],
             Http::STATUS_NOT_IMPLEMENTED

--- a/lib/Controller/ZaakBesluitenController.php
+++ b/lib/Controller/ZaakBesluitenController.php
@@ -2,134 +2,113 @@
 
 namespace OCA\ZaakAfhandelApp\Controller;
 
-use GuzzleHttp\Client;
 use OCP\AppFramework\Controller;
-use OCP\AppFramework\Http\TemplateResponse;
+use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\JSONResponse;
-use OCP\IAppConfig;
+use OCP\AppFramework\Http\TemplateResponse;
 use OCP\IRequest;
 
+/**
+ * Stub controller for the ZGW zaakbesluiten resource.
+ *
+ * Real zaakbesluiten data has not yet been implemented. All data endpoints
+ * return 501 Not Implemented so that clients never receive fabricated test
+ * data in place of real besluit records.
+ *
+ * Routes for these endpoints have been removed from appinfo/routes.php until
+ * a real implementation backed by ObjectService is in place.
+ */
 class ZaakBesluitenController extends Controller
 {
-    const TEST_ARRAY = [
-        "5137a1e5-b54d-43ad-abd1-4b5bff5fcd3f" => [
-            "id" => "5137a1e5-b54d-43ad-abd1-4b5bff5fcd3f",
-            "name" => "Zaakt type 1",
-            "summary" => "summary for one"
-        ],
-        "4c3edd34-a90d-4d2a-8894-adb5836ecde8" => [
-            "id" => "4c3edd34-a90d-4d2a-8894-adb5836ecde8",
-            "name" => "Zaakt type 12",
-            "summary" => "summary for two"
-        ],
-        "15551d6f-44e3-43f3-a9d2-59e583c91eb0" => [
-            "id" => "15551d6f-44e3-43f3-a9d2-59e583c91eb0",
-            "name" => "Zaakt type 3",
-            "summary" => "summary for two"
-        ],
-        "0a3a0ffb-dc03-4aae-b207-0ed1502e60da" => [
-            "id" => "0a3a0ffb-dc03-4aae-b207-0ed1502e60da",
-            "name" => "Zaakt type 4",
-            "summary" => "summary for two"
-        ]
-    ];
-
     public function __construct(
-		$appName,
-		IRequest $request,
-		private readonly IAppConfig $config
-	)
-    {
+        $appName,
+        IRequest $request
+    ) {
         parent::__construct($appName, $request);
-    }
+    }//end __construct()
 
-	/**
-	 * This returns the template of the main app's page
-	 * It adds some data to the template (app version)
-	 *
-	 * @NoAdminRequired
-	 * @NoCSRFRequired
-	 *
-	 * @return TemplateResponse
-	 */
-	public function page(): TemplateResponse
-	{			
+    /**
+     * @NoAdminRequired
+     * @NoCSRFRequired
+     *
+     * @return TemplateResponse
+     */
+    public function page(): TemplateResponse
+    {
         return new TemplateResponse(
-            //Application::APP_ID,
             'zaakafhandelapp',
             'index',
             []
         );
-	}
-	
+    }//end page()
 
     /**
-     * Return (and serach) all objects
-     * 
      * @NoAdminRequired
      * @NoCSRFRequired
-	 *
-	 * @return JSONResponse
+     *
+     * @return JSONResponse
      */
     public function index(): JSONResponse
     {
-        $results = ["results" => self::TEST_ARRAY];
-        return new JSONResponse($results);
-    }
+        return new JSONResponse(
+            ['error' => 'Zaakbesluiten is not yet implemented.'],
+            Http::STATUS_NOT_IMPLEMENTED
+        );
+    }//end index()
 
     /**
-     * Read a single object
-     * 
      * @NoAdminRequired
      * @NoCSRFRequired
-	 *
-	 * @return JSONResponse
+     *
+     * @return JSONResponse
      */
     public function show(string $id): JSONResponse
     {
-        $result = self::TEST_ARRAY[$id];
-        return new JSONResponse($result);
-    }
-
+        return new JSONResponse(
+            ['error' => 'Zaakbesluiten is not yet implemented.'],
+            Http::STATUS_NOT_IMPLEMENTED
+        );
+    }//end show()
 
     /**
-     * Creatue an object
-     * 
      * @NoAdminRequired
      * @NoCSRFRequired
-	 *
-	 * @return JSONResponse
+     *
+     * @return JSONResponse
      */
     public function create(): JSONResponse
     {
-        // get post from requests
-        return new JSONResponse([]);
-    }
+        return new JSONResponse(
+            ['error' => 'Zaakbesluiten is not yet implemented.'],
+            Http::STATUS_NOT_IMPLEMENTED
+        );
+    }//end create()
 
     /**
-     * Update an object
-     * 
      * @NoAdminRequired
      * @NoCSRFRequired
-	 *
-	 * @return JSONResponse
+     *
+     * @return JSONResponse
      */
     public function update(string $id): JSONResponse
     {
-        $result = self::TEST_ARRAY[$id];
-        return new JSONResponse($result);
-    }
+        return new JSONResponse(
+            ['error' => 'Zaakbesluiten is not yet implemented.'],
+            Http::STATUS_NOT_IMPLEMENTED
+        );
+    }//end update()
 
     /**
-     * Delate an object
-     * 
      * @NoAdminRequired
      * @NoCSRFRequired
-	 *
-	 * @return JSONResponse
+     *
+     * @return JSONResponse
      */
     public function destroy(string $id): JSONResponse
     {
-        return new JSONResponse([]);
-    }
-}
+        return new JSONResponse(
+            ['error' => 'Zaakbesluiten is not yet implemented.'],
+            Http::STATUS_NOT_IMPLEMENTED
+        );
+    }//end destroy()
+}//end class

--- a/lib/Controller/ZaakBesluitenController.php
+++ b/lib/Controller/ZaakBesluitenController.php
@@ -4,34 +4,42 @@ namespace OCA\ZaakAfhandelApp\Controller;
 
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
-use OCP\AppFramework\Http\JSONResponse;
 use OCP\AppFramework\Http\TemplateResponse;
+use OCP\AppFramework\Http\JSONResponse;
+use OCP\IAppConfig;
 use OCP\IRequest;
+use OCP\IUserSession;
 
 /**
  * Stub controller for the ZGW zaakbesluiten resource.
  *
- * Real zaakbesluiten data has not yet been implemented. All data endpoints
- * return 501 Not Implemented so that clients never receive fabricated test
- * data in place of real besluit records.
+ * Real zaakbesluiten data has not yet been implemented. All data endpoints return
+ * 501 Not Implemented so that clients never receive fabricated test data in place
+ * of real besluit records (issue #268).
  *
- * Routes for these endpoints have been removed from appinfo/routes.php until
- * a real implementation backed by ObjectService is in place.
+ * @copyright 2024 Conduction B.V. <info@conduction.nl>
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  */
 class ZaakBesluitenController extends Controller
 {
     public function __construct(
         $appName,
-        IRequest $request
+        IRequest $request,
+        private readonly IAppConfig $config,
+        private readonly IUserSession $userSession,
     ) {
         parent::__construct($appName, $request);
     }//end __construct()
 
     /**
+     * This returns the template of the main app's page.
+     *
      * @NoAdminRequired
      * @NoCSRFRequired
      *
      * @return TemplateResponse
+     *
+     * @spec openspec/specs/zgw-zaak-management/spec.md#REQ-005
      */
     public function page(): TemplateResponse
     {
@@ -43,13 +51,21 @@ class ZaakBesluitenController extends Controller
     }//end page()
 
     /**
+     * Return (and search) all objects.
+     *
      * @NoAdminRequired
      * @NoCSRFRequired
      *
      * @return JSONResponse
+     *
+     * @spec openspec/specs/zgw-zaak-management/spec.md#REQ-005
      */
     public function index(): JSONResponse
     {
+        if ($this->userSession->getUser() === null) {
+            return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
+        }
+
         return new JSONResponse(
             ['error' => 'Zaakbesluiten is not yet implemented.'],
             Http::STATUS_NOT_IMPLEMENTED
@@ -57,13 +73,21 @@ class ZaakBesluitenController extends Controller
     }//end index()
 
     /**
+     * Read a single object.
+     *
      * @NoAdminRequired
      * @NoCSRFRequired
      *
      * @return JSONResponse
+     *
+     * @spec openspec/specs/zgw-zaak-management/spec.md#REQ-005
      */
     public function show(string $id): JSONResponse
     {
+        if ($this->userSession->getUser() === null) {
+            return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
+        }
+
         return new JSONResponse(
             ['error' => 'Zaakbesluiten is not yet implemented.'],
             Http::STATUS_NOT_IMPLEMENTED
@@ -71,13 +95,21 @@ class ZaakBesluitenController extends Controller
     }//end show()
 
     /**
+     * Create an object.
+     *
      * @NoAdminRequired
      * @NoCSRFRequired
      *
      * @return JSONResponse
+     *
+     * @spec openspec/specs/zgw-zaak-management/spec.md#REQ-005
      */
     public function create(): JSONResponse
     {
+        if ($this->userSession->getUser() === null) {
+            return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
+        }
+
         return new JSONResponse(
             ['error' => 'Zaakbesluiten is not yet implemented.'],
             Http::STATUS_NOT_IMPLEMENTED
@@ -85,13 +117,21 @@ class ZaakBesluitenController extends Controller
     }//end create()
 
     /**
+     * Update an object.
+     *
      * @NoAdminRequired
      * @NoCSRFRequired
      *
      * @return JSONResponse
+     *
+     * @spec openspec/specs/zgw-zaak-management/spec.md#REQ-005
      */
     public function update(string $id): JSONResponse
     {
+        if ($this->userSession->getUser() === null) {
+            return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
+        }
+
         return new JSONResponse(
             ['error' => 'Zaakbesluiten is not yet implemented.'],
             Http::STATUS_NOT_IMPLEMENTED
@@ -99,13 +139,23 @@ class ZaakBesluitenController extends Controller
     }//end update()
 
     /**
+     * Delete an object.
+     *
      * @NoAdminRequired
      * @NoCSRFRequired
      *
      * @return JSONResponse
+     *
+     * @spec openspec/specs/zgw-zaak-management/spec.md#REQ-005
+     *
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter) — $id is part of the NC route signature.
      */
     public function destroy(string $id): JSONResponse
     {
+        if ($this->userSession->getUser() === null) {
+            return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
+        }
+
         return new JSONResponse(
             ['error' => 'Zaakbesluiten is not yet implemented.'],
             Http::STATUS_NOT_IMPLEMENTED

--- a/lib/Controller/ZaakTypenController.php
+++ b/lib/Controller/ZaakTypenController.php
@@ -4,16 +4,18 @@ namespace OCA\ZaakAfhandelApp\Controller;
 
 use OCA\ZaakAfhandelApp\Service\ObjectService;
 use OCP\AppFramework\Controller;
+use OCP\AppFramework\Http;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\IRequest;
+use OCP\AppFramework\Http\TemplateResponse;
+use OCP\AppFramework\Http\ContentSecurityPolicy;
+use OCP\IUserSession;
 
 /**
- * Controller for ZTC zaaktypen master data.
+ * Controller for zaaktypen (case types) operations.
  *
- * Zaaktypen define the validation source-of-truth for statustypen,
- * resultaattypen, roltypen, and besluittypen.  Mutations therefore require
- * admin privileges to prevent any authenticated user from subverting zaak
- * lifecycle validation (see issue #269).
+ * @copyright 2024 Conduction B.V. <info@conduction.nl>
+ * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  */
 class ZaakTypenController extends Controller
 {
@@ -21,40 +23,94 @@ class ZaakTypenController extends Controller
         $appName,
         IRequest $request,
         private readonly ObjectService $objectService,
+        private readonly IUserSession $userSession,
     ) {
         parent::__construct($appName, $request);
     }//end __construct()
 
     /**
-     * Return (and search) all objects.
+     * Return (and serach) all objects
      *
      * @NoAdminRequired
      * @NoCSRFRequired
      *
      * @return JSONResponse
+     *
+     * @spec openspec/specs/zgw-related-resources/spec.md#REQ-001
      */
     public function index(): JSONResponse
     {
-        // Retrieve all request parameters
-        $requestParams = $this->request->getParams();
+        if ($this->userSession->getUser() === null) {
+            return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
+        }
 
-        // Fetch catalog objects based on filters and order
-        $data = $this->objectService->getResultArrayForRequest('zaaktypen', $requestParams);
+         // Retrieve all request parameters
+         $requestParams = $this->request->getParams();
 
-        // Return JSON response
-        return new JSONResponse($data);
+         // Fetch catalog objects based on filters and order
+         $data = $this->objectService->getResultArrayForRequest('zaaktypen', $requestParams);
+
+         // Return JSON response
+         return new JSONResponse($data);
     }//end index()
 
     /**
-     * Read a single object.
+     * Render no page.
+     *
+     * @param  string|null $getParameter Optional GET parameter
+     * @return TemplateResponse The rendered template response
+     *
+     * @NoAdminRequired
+     * @NoCSRFRequired
+     *
+     * @spec openspec/specs/zgw-related-resources/spec.md#REQ-003
+     *
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter) — $getParameter is an NC route param
+     *   reserved for future SPA deep-linking; the PHP layer renders a shell template only.
+     */
+    public function page(?string $getParameter): TemplateResponse
+    {
+        try {
+            // Create a new TemplateResponse for the index page
+            $response = new TemplateResponse(
+             $this->appName,
+             'index',
+             []
+            );
+
+            // Set up Content Security Policy
+            $csp = new ContentSecurityPolicy();
+            $csp->addAllowedConnectDomain('*');
+            $response->setContentSecurityPolicy($csp);
+
+            return $response;
+        } catch (\Exception $e) {
+            // Return an error template response if an exception occurs
+            return new TemplateResponse(
+             $this->appName,
+             'error',
+             ['error' => $e->getMessage()],
+             '500'
+            );
+        }//end try
+    }//end page()
+
+    /**
+     * Read a single object
      *
      * @NoAdminRequired
      * @NoCSRFRequired
      *
      * @return JSONResponse
+     *
+     * @spec openspec/specs/zgw-related-resources/spec.md#REQ-001
      */
     public function show(string $id): JSONResponse
     {
+        if ($this->userSession->getUser() === null) {
+            return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
+        }
+
         // Fetch the catalog object by its ID
         $object = $this->objectService->getObject('zaaktypen', $id);
 
@@ -68,9 +124,15 @@ class ZaakTypenController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse
+     *
+     * @spec openspec/specs/zgw-related-resources/spec.md#REQ-002
      */
     public function create(): JSONResponse
     {
+        if ($this->userSession->getUser() === null) {
+            return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
+        }
+
         // Get all parameters from the request
         $data = $this->request->getParams();
 
@@ -90,19 +152,30 @@ class ZaakTypenController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse
+     *
+     * @spec openspec/specs/zgw-related-resources/spec.md#REQ-002
+     *
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter) — $id is part of the NC route signature;
+     *   the full payload is consumed via $this->request->getParams() instead.
      */
     public function update(string $id): JSONResponse
     {
+        if ($this->userSession->getUser() === null) {
+            return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
+        }
+
         // Get all parameters from the request
         $data = $this->request->getParams();
 
-        // Remove the 'id' field if it exists, as we're updating
+        // Remove the 'id' field if it exists, as we're creating a new object
         unset($data['id']);
 
-        // Save the updated catalog object
+        $data['id'] = $id;
+
+        // Save the new catalog object
         $object = $this->objectService->saveObject('zaaktypen', $data);
 
-        // Return the updated object as a JSON response
+        // Return the created object as a JSON response
         return new JSONResponse($object);
     }//end update()
 
@@ -112,9 +185,15 @@ class ZaakTypenController extends Controller
      * @NoCSRFRequired
      *
      * @return JSONResponse
+     *
+     * @spec openspec/specs/zgw-related-resources/spec.md#REQ-002
      */
     public function destroy(string $id): JSONResponse
     {
+        if ($this->userSession->getUser() === null) {
+            return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
+        }
+
         // Delete the catalog object
         $result = $this->objectService->deleteObject('zaaktypen', $id);
 

--- a/lib/Controller/ZaakTypenController.php
+++ b/lib/Controller/ZaakTypenController.php
@@ -7,66 +7,70 @@ use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\IRequest;
 
+/**
+ * Controller for ZTC zaaktypen master data.
+ *
+ * Zaaktypen define the validation source-of-truth for statustypen,
+ * resultaattypen, roltypen, and besluittypen.  Mutations therefore require
+ * admin privileges to prevent any authenticated user from subverting zaak
+ * lifecycle validation (see issue #269).
+ */
 class ZaakTypenController extends Controller
 {
     public function __construct(
-		$appName,
-		IRequest $request,
+        $appName,
+        IRequest $request,
         private readonly ObjectService $objectService,
-	)
-    {
+    ) {
         parent::__construct($appName, $request);
-    }
+    }//end __construct()
 
+    /**
+     * Return (and search) all objects.
+     *
+     * @NoAdminRequired
+     * @NoCSRFRequired
+     *
+     * @return JSONResponse
+     */
+    public function index(): JSONResponse
+    {
+        // Retrieve all request parameters
+        $requestParams = $this->request->getParams();
 
-	/**
-	 * Return (and serach) all objects
-	 *
-	 * @NoAdminRequired
-	 * @NoCSRFRequired
-	 *
-	 * @return JSONResponse
-	 */
-	public function index(): JSONResponse
-	{
-		 // Retrieve all request parameters
-		 $requestParams = $this->request->getParams();
+        // Fetch catalog objects based on filters and order
+        $data = $this->objectService->getResultArrayForRequest('zaaktypen', $requestParams);
 
-		 // Fetch catalog objects based on filters and order
-		 $data = $this->objectService->getResultArrayForRequest('zaaktypen', $requestParams);
- 
-		 // Return JSON response
-		 return new JSONResponse($data);
-	}
+        // Return JSON response
+        return new JSONResponse($data);
+    }//end index()
 
-	/**
-	 * Read a single object
-	 *
-	 * @NoAdminRequired
-	 * @NoCSRFRequired
-	 *
-	 * @return JSONResponse
-	 */
-	public function show(string $id): JSONResponse
-	{
+    /**
+     * Read a single object.
+     *
+     * @NoAdminRequired
+     * @NoCSRFRequired
+     *
+     * @return JSONResponse
+     */
+    public function show(string $id): JSONResponse
+    {
         // Fetch the catalog object by its ID
         $object = $this->objectService->getObject('zaaktypen', $id);
 
         // Return the catalog as a JSON response
         return new JSONResponse($object);
-	}
+    }//end show()
 
-
-	/**
-	 * Creatue an object
-	 *
-	 * @NoAdminRequired
-	 * @NoCSRFRequired
-	 *
-	 * @return JSONResponse
-	 */
-	public function create(): JSONResponse
-	{
+    /**
+     * Create an object. Admin-only: zaaktypen are validation master data.
+     *
+     * @NoCSRFRequired
+     *
+     * @return JSONResponse
+     */
+    public function create(): JSONResponse
+    {
         // Get all parameters from the request
         $data = $this->request->getParams();
 
@@ -75,48 +79,46 @@ class ZaakTypenController extends Controller
 
         // Save the new catalog object
         $object = $this->objectService->saveObject('zaaktypen', $data);
-        
+
         // Return the created object as a JSON response
         return new JSONResponse($object);
-	}
+    }//end create()
 
-	/**
-	 * Update an object
-	 *
-	 * @NoAdminRequired
-	 * @NoCSRFRequired
-	 *
-	 * @return JSONResponse
-	 */
-	public function update(string $id): JSONResponse
-	{
+    /**
+     * Update an object. Admin-only: zaaktypen are validation master data.
+     *
+     * @NoCSRFRequired
+     *
+     * @return JSONResponse
+     */
+    public function update(string $id): JSONResponse
+    {
         // Get all parameters from the request
         $data = $this->request->getParams();
 
-        // Remove the 'id' field if it exists, as we're creating a new object
+        // Remove the 'id' field if it exists, as we're updating
         unset($data['id']);
 
-        // Save the new catalog object
+        // Save the updated catalog object
         $object = $this->objectService->saveObject('zaaktypen', $data);
-        
-        // Return the created object as a JSON response
-        return new JSONResponse($object);
-	}
 
-	/**
-	 * Delate an object
-	 *
-	 * @NoAdminRequired
-	 * @NoCSRFRequired
-	 *
-	 * @return JSONResponse
-	 */
-	public function destroy(string $id): JSONResponse
-	{
+        // Return the updated object as a JSON response
+        return new JSONResponse($object);
+    }//end update()
+
+    /**
+     * Delete an object. Admin-only: zaaktypen are validation master data.
+     *
+     * @NoCSRFRequired
+     *
+     * @return JSONResponse
+     */
+    public function destroy(string $id): JSONResponse
+    {
         // Delete the catalog object
         $result = $this->objectService->deleteObject('zaaktypen', $id);
 
         // Return the result as a JSON response
-		return new JSONResponse(['success' => $result], $result === true ? '200' : '404');
-	}
-}
+        return new JSONResponse(['success' => $result], $result === true ? 200 : 404);
+    }//end destroy()
+}//end class


### PR DESCRIPTION
## Summary

Fixes three P0-CRITICAL security issues found in the deep team-reviewer pass (2026-05-27).

### #267 - Credential exfiltration via @NoAdminRequired ConfigurationController

- Dropped @NoAdminRequired from both GET and POST /api/configuration. Both endpoints now require admin.
- Added CREDENTIAL_KEYS constant; all *Key/*Secret fields are redacted to *** in GET and POST responses.
- Added WRITABLE_KEYS allow-list; POST silently ignores any key not on the list, preventing blind setValueString injection.

**MANDATORY KEY-ROTATION:** Any environment where a non-admin Nextcloud user existed while this app was active should be treated as compromised. Rotate all ZGW service-account keys (drcKey, orcKey, zrcKey, ztcKey, brcKey, klantenKey, elasticKey, mongodbKey) and any clientSecret values immediately. Re-seed via the admin-only endpoint after rotation.

### #268 - Hardcoded TEST_ARRAY stubs in AuditTrail, ZaakBesluiten, Documenten

- Removed TEST_ARRAY constants and canned-data responses from ZaakAuditTrailController, ZaakBesluitenController, and DocumentenController.
- All data endpoints now return 501 Not Implemented with a clear error message.
- Removed zaakbesluiten, zaakaudittrail, and documenten resource routes from appinfo/routes.php to prevent false-positive ZGW/Archiefwet compliance checks. Routes will be restored when real OR-backed implementations land.

### #269 - Zaaktypen catalog and klanten writable by any authenticated user

- ZaakTypenController: create/update/destroy drop @NoAdminRequired. Index/show retain it (reads stay open). Zaaktypen are the validation source-of-truth for isEindStatus, createZaakBesluit, and checkProductenOfDiensten.
- KlantenController: create/update/destroy drop @NoAdminRequired. All read and sub-resource methods (getZaken, getTaken, getBerichten, getContactmomenten, getAuditTrail) retain @NoAdminRequired.
- MedewerkersController does not exist in this codebase.

### Additional fixes

- Pre-existing phpstan type errors: string '200'/'404' status codes corrected to integers in ZaakTypenController and KlantenController.
- Response::STATUS_NOT_IMPLEMENTED replaced with Http::STATUS_NOT_IMPLEMENTED (correct OCP class).
- Unused IAppConfig injection removed from stub controllers.

## Quality gates

- phpstan: 0 errors (level 5)
- phpcs: 0 errors (legacy-debt docblock/named-param warnings only, tracked in #201)
- PHP syntax lint: all 7 modified files pass
- No PHP tests exist in this repo (confirmed by find tests/*.php = 0 results)

## Test plan

- [ ] Non-admin user: GET /api/configuration returns 403
- [ ] Admin: GET /api/configuration returns config with *** for all key fields
- [ ] Admin: POST /api/configuration saves a key and echoes ***
- [ ] GET /api/zrc/zaken/{uuid}/audit_trail returns 501
- [ ] GET /api/zrc/zaken/{uuid}/besluiten returns 501
- [ ] Non-admin: POST /api/ztc/zaaktypen returns 403
- [ ] Non-admin: DELETE /api/klanten/{id} returns 403
- [ ] Rotate all ZGW keys on any affected environment