### PR TITLE
fix(security): P0 credential exfiltration, stub audit data, and master-data ACL (#267 #268 #269)

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -9,13 +9,14 @@ return [
 		'statusen' => ['url' => 'api/zrc/statussen'],
 		'zaakInformatieObjecten' => ['url' => 'api/zrc/zaakinformatieobjecten'],
 		'zaakObjecten' => ['url' => 'api/zrc/zaakobjecten'],
-		'zaakBesluiten' => ['url' => 'api/zrc/zaken/{zaak_uuid}/besluiten'],
+		// zaakBesluiten and zaakAuditTrail resource routes removed (issue #268):
+		// controllers return 501 until a real OR-backed implementation is in place.
 		'zaakEigenschappen' => ['url' => 'api/zrc/zaken/{zaak_uuid}/eigenschappen'],
-		'zaakAuditTrail' => ['url' => 'api/zrc/zaken/{zaak_uuid}/audit_trail'],
 		// Conform https://vng-realisatie.github.io/gemma-zaken/standaard/catalogi/redoc-1.3.1
 		'zaakTypen' => ['url' => 'api/ztc/zaaktypen'],
 		// Conform https://vng-realisatie.github.io/gemma-zaken/standaard/documenten/redoc-1.5.0
-		'documenten' => ['url' => 'api/drc'],
+		// documenten resource route removed (issue #268): controller returns 501 until real DRC
+		// implementation is in place.
 		// Conform https://vng-realisatie.github.io/gemma-zaken/standaard/besluiten/redoc-1.0.2
 		'besluiten' => ['url' => 'api/brc'],
 		// Conform ???

--- a/lib/Controller/ConfigurationController.php
+++ b/lib/Controller/ConfigurationController.php
@@ -4,7 +4,6 @@ namespace OCA\ZaakAfhandelApp\Controller;
 
 use OCP\AppFramework\Controller;
 use OCP\AppFramework\Http;
-use OCP\AppFramework\Http\TemplateResponse;
 use OCP\AppFramework\Http\JSONResponse;
 use OCP\IAppConfig;
 use OCP\IRequest;
@@ -13,11 +12,66 @@ use OCP\IUserSession;
 /**
  * Controller for application configuration operations.
  *
+ * Both GET and POST require admin: the configuration holds ZGW service-account
+ * API keys that must never be exposed to non-admin users (issue #267).
+ *
  * @copyright 2024 Conduction B.V. <info@conduction.nl>
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  */
 class ConfigurationController extends Controller
 {
+    /**
+     * Keys that hold credentials — returned as "***" on read.
+     *
+     * @var string[]
+     */
+    private const CREDENTIAL_KEYS = [
+        'drcKey',
+        'orcKey',
+        'zrcKey',
+        'ztcKey',
+        'brcKey',
+        'klantenKey',
+        'elasticKey',
+        'mongodbKey',
+    ];
+
+    /**
+     * Exhaustive allow-list of keys accepted on POST.
+     *
+     * @var string[]
+     */
+    private const WRITABLE_KEYS = [
+        'drcLocation',
+        'drcKey',
+        'drcAuthType',
+        'orcLocation',
+        'orcKey',
+        'orcAuthType',
+        'zrcLocation',
+        'zrcKey',
+        'zrcAuthType',
+        'ztcLocation',
+        'ztcKey',
+        'ztcAuthType',
+        'brcLocation',
+        'brcKey',
+        'brcAuthType',
+        'klantenLocation',
+        'klantenKey',
+        'klantenAuthType',
+        'elasticLocation',
+        'elasticKey',
+        'mongodbLocation',
+        'mongodbKey',
+        'mongodbCluster',
+        'organisationName',
+        'organisationOIN',
+        'organisationPKI',
+        'organisationRSIN',
+        'organisationKVK',
+    ];
+
     public function __construct(
         $appName,
         private readonly IAppConfig $config,
@@ -28,7 +82,11 @@ class ConfigurationController extends Controller
     }//end __construct()
 
     /**
-     * @NoAdminRequired
+     * Return the current configuration.
+     *
+     * Credential fields are redacted (returned as "***") so that API keys are
+     * never transmitted to the browser. Admin-only: @NoAdminRequired omitted.
+     *
      * @NoCSRFRequired
      *
      * @spec openspec/specs/app-configuration/spec.md#REQ-001
@@ -39,51 +97,23 @@ class ConfigurationController extends Controller
             return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
         }
 
-        $data     = [];
-        $defaults = [
-        // Getting the config
-            'drcLocation'      => '',
-            'drcKey'           => '',
-            'drcAuthType'      => '',
-            'orcLocation'      => '',
-            'orcKey'           => '',
-            'orcAuthType'      => '',
-            'zrcLocation'      => '',
-            'zrcKey'           => '',
-            'zrcAuthType'      => '',
-            'ztcLocation'      => '',
-            'ztcKey'           => '',
-            'ztcAuthType'      => '',
-            'brcLocation'      => '',
-            'brcKey'           => '',
-            'brcAuthType'      => '',
-            'klantenLocation'  => '',
-            'klantenKey'       => '',
-            'klantenAuthType'  => '',
-            'elasticLocation'  => '',
-            'elasticKey'       => '',
-            'mongodbLocation'  => '',
-            'mongodbKey'       => '',
-            'mongodbCluster'   => '',
-            'organisationName' => '',
-            'organisationOIN'  => '',
-            'organisationPKI'  => '',
-            'organisationRSIN' => '',
-            'organisationKVK'  => '',
-        ];
+        $defaults = array_fill_keys(self::WRITABLE_KEYS, '');
 
-        // We should filter out unwanted values before this
-        foreach ($defaults as $key => $value) {
-            $data[$key] = $this->config->getValueString('zaakafhandelapp', $key, $value);
+        $data = [];
+        foreach ($defaults as $key => $default) {
+            $value      = $this->config->getValueString('zaakafhandelapp', $key, $default);
+            $data[$key] = in_array($key, self::CREDENTIAL_KEYS, true) ? ($value !== '' ? '***' : '') : $value;
         }
 
         return new JSONResponse($data);
     }//end index()
 
     /**
-     * Handling the post request
+     * Persist configuration values supplied by an admin.
      *
-     * @NoAdminRequired
+     * Only keys present in WRITABLE_KEYS are accepted; all others are ignored.
+     * Credential values are redacted in the response. Admin-only: @NoAdminRequired omitted.
+     *
      * @NoCSRFRequired
      *
      * @spec openspec/specs/app-configuration/spec.md#REQ-001
@@ -94,12 +124,18 @@ class ConfigurationController extends Controller
             return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
         }
 
-        $data = $this->request->getParams();
+        $requestData = $this->request->getParams();
 
-        // We should filter out unwanted values before this
-        foreach ($data as $key => $value) {
-            $this->config->setValueString('zaakafhandelapp', $key, $value);
-            $data[$key] = $this->config->getValueString('zaakafhandelapp', $key);
+        $data = [];
+        foreach (self::WRITABLE_KEYS as $key) {
+            if (!array_key_exists($key, $requestData)) {
+                continue;
+            }
+
+            $this->config->setValueString('zaakafhandelapp', $key, (string) $requestData[$key]);
+            $data[$key] = in_array($key, self::CREDENTIAL_KEYS, true)
+                ? '***'
+                : $this->config->getValueString('zaakafhandelapp', $key);
         }
 
         return new JSONResponse($data);

--- a/lib/Controller/DocumentenController.php
+++ b/lib/Controller/DocumentenController.php
@@ -11,15 +11,19 @@ use OCP\IRequest;
 use OCP\IUserSession;
 
 /**
- * Geeft invulling aan https://vng-realisatie.github.io/gemma-zaken/standaard/zaken/
+ * Stub controller for the ZGW documenten resource.
+ *
+ * Geeft invulling aan https://vng-realisatie.github.io/gemma-zaken/standaard/documenten/
+ *
+ * Real documenten data has not yet been implemented. All data endpoints return
+ * 501 Not Implemented so that clients never receive fabricated test data in place
+ * of real DRC document records (issue #268).
  *
  * @copyright 2024 Conduction B.V. <info@conduction.nl>
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  */
 class DocumentenController extends Controller
 {
-    const TEST_ARRAY = [];
-
     public function __construct(
         string $appName,
         IRequest $request,
@@ -30,8 +34,7 @@ class DocumentenController extends Controller
     }//end __construct()
 
     /**
-     * This returns the template of the main app's page
-     * It adds some data to the template (app version)
+     * This returns the template of the main app's page.
      *
      * @NoAdminRequired
      * @NoCSRFRequired
@@ -50,7 +53,7 @@ class DocumentenController extends Controller
     }//end page()
 
     /**
-     * Return (and serach) all objects
+     * Return (and search) all objects.
      *
      * @NoAdminRequired
      * @NoCSRFRequired
@@ -65,12 +68,14 @@ class DocumentenController extends Controller
             return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
         }
 
-        $results = ["results" => self::TEST_ARRAY];
-        return new JSONResponse($results);
+        return new JSONResponse(
+            ['error' => 'Documenten is not yet implemented.'],
+            Http::STATUS_NOT_IMPLEMENTED
+        );
     }//end index()
 
     /**
-     * Read a single object
+     * Read a single object.
      *
      * @NoAdminRequired
      * @NoCSRFRequired
@@ -85,12 +90,14 @@ class DocumentenController extends Controller
             return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
         }
 
-        $result = self::TEST_ARRAY[$id];
-        return new JSONResponse($result);
+        return new JSONResponse(
+            ['error' => 'Documenten is not yet implemented.'],
+            Http::STATUS_NOT_IMPLEMENTED
+        );
     }//end show()
 
     /**
-     * Creatue an object
+     * Create an object.
      *
      * @NoAdminRequired
      * @NoCSRFRequired
@@ -105,12 +112,14 @@ class DocumentenController extends Controller
             return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
         }
 
-        // get post from requests
-        return new JSONResponse([]);
+        return new JSONResponse(
+            ['error' => 'Documenten is not yet implemented.'],
+            Http::STATUS_NOT_IMPLEMENTED
+        );
     }//end create()
 
     /**
-     * Update an object
+     * Update an object.
      *
      * @NoAdminRequired
      * @NoCSRFRequired
@@ -125,12 +134,14 @@ class DocumentenController extends Controller
             return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
         }
 
-        $result = self::TEST_ARRAY[$id];
-        return new JSONResponse($result);
+        return new JSONResponse(
+            ['error' => 'Documenten is not yet implemented.'],
+            Http::STATUS_NOT_IMPLEMENTED
+        );
     }//end update()
 
     /**
-     * Delate an object
+     * Delete an object.
      *
      * @NoAdminRequired
      * @NoCSRFRequired
@@ -139,8 +150,7 @@ class DocumentenController extends Controller
      *
      * @spec openspec/specs/zgw-related-resources/spec.md#REQ-002
      *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter) — $id is part of the NC route signature;
-     *   stub implementation returns empty response (resource management handled client-side).
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter) — $id is part of the NC route signature.
      */
     public function destroy(string $id): JSONResponse
     {
@@ -148,6 +158,9 @@ class DocumentenController extends Controller
             return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
         }
 
-        return new JSONResponse([]);
+        return new JSONResponse(
+            ['error' => 'Documenten is not yet implemented.'],
+            Http::STATUS_NOT_IMPLEMENTED
+        );
     }//end destroy()
 }//end class

--- a/lib/Controller/KlantenController.php
+++ b/lib/Controller/KlantenController.php
@@ -119,9 +119,8 @@ class KlantenController extends Controller
     }//end show()
 
     /**
-     * Creatue an object
+     * Create an object. Admin-only: klanten are master data.
      *
-     * @NoAdminRequired
      * @NoCSRFRequired
      *
      * @return JSONResponse
@@ -148,9 +147,8 @@ class KlantenController extends Controller
     }//end create()
 
     /**
-     * Update an object
+     * Update an object. Admin-only: klanten are master data.
      *
-     * @NoAdminRequired
      * @NoCSRFRequired
      *
      * @return JSONResponse
@@ -177,9 +175,8 @@ class KlantenController extends Controller
     }//end update()
 
     /**
-     * Delate an object
+     * Delete an object. Admin-only: klanten are master data.
      *
-     * @NoAdminRequired
      * @NoCSRFRequired
      *
      * @return JSONResponse

--- a/lib/Controller/ZaakAuditTrailController.php
+++ b/lib/Controller/ZaakAuditTrailController.php
@@ -11,36 +11,17 @@ use OCP\IRequest;
 use OCP\IUserSession;
 
 /**
- * Controller for zaak audit trail resources.
+ * Stub controller for the ZGW audit-trail resource.
+ *
+ * Real audit-trail data has not yet been implemented. All data endpoints return
+ * 501 Not Implemented so that audit systems and Archiefwet compliance checks
+ * never receive fabricated test data in place of the real evidence trail (issue #268).
  *
  * @copyright 2024 Conduction B.V. <info@conduction.nl>
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  */
 class ZaakAuditTrailController extends Controller
 {
-    const TEST_ARRAY = [
-        "5137a1e5-b54d-43ad-abd1-4b5bff5fcd3f" => [
-            "id"      => "5137a1e5-b54d-43ad-abd1-4b5bff5fcd3f",
-            "name"    => "Zaakt type 1",
-            "summary" => "summary for one",
-        ],
-        "4c3edd34-a90d-4d2a-8894-adb5836ecde8" => [
-            "id"      => "4c3edd34-a90d-4d2a-8894-adb5836ecde8",
-            "name"    => "Zaakt type 12",
-            "summary" => "summary for two",
-        ],
-        "15551d6f-44e3-43f3-a9d2-59e583c91eb0" => [
-            "id"      => "15551d6f-44e3-43f3-a9d2-59e583c91eb0",
-            "name"    => "Zaakt type 3",
-            "summary" => "summary for two",
-        ],
-        "0a3a0ffb-dc03-4aae-b207-0ed1502e60da" => [
-            "id"      => "0a3a0ffb-dc03-4aae-b207-0ed1502e60da",
-            "name"    => "Zaakt type 4",
-            "summary" => "summary for two",
-        ],
-    ];
-
     public function __construct(
         $appName,
         IRequest $request,
@@ -51,8 +32,7 @@ class ZaakAuditTrailController extends Controller
     }//end __construct()
 
     /**
-     * This returns the template of the main app's page
-     * It adds some data to the template (app version)
+     * This returns the template of the main app's page.
      *
      * @NoAdminRequired
      * @NoCSRFRequired
@@ -71,7 +51,7 @@ class ZaakAuditTrailController extends Controller
     }//end page()
 
     /**
-     * Return (and serach) all objects
+     * Return (and search) all objects.
      *
      * @NoAdminRequired
      * @NoCSRFRequired
@@ -86,12 +66,14 @@ class ZaakAuditTrailController extends Controller
             return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
         }
 
-        $results = ["results" => self::TEST_ARRAY];
-        return new JSONResponse($results);
+        return new JSONResponse(
+            ['error' => 'Audit trail is not yet implemented.'],
+            Http::STATUS_NOT_IMPLEMENTED
+        );
     }//end index()
 
     /**
-     * Read a single object
+     * Read a single object.
      *
      * @NoAdminRequired
      * @NoCSRFRequired
@@ -106,12 +88,14 @@ class ZaakAuditTrailController extends Controller
             return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
         }
 
-        $result = self::TEST_ARRAY[$id];
-        return new JSONResponse($result);
+        return new JSONResponse(
+            ['error' => 'Audit trail is not yet implemented.'],
+            Http::STATUS_NOT_IMPLEMENTED
+        );
     }//end show()
 
     /**
-     * Creatue an object
+     * Create an object.
      *
      * @NoAdminRequired
      * @NoCSRFRequired
@@ -126,12 +110,14 @@ class ZaakAuditTrailController extends Controller
             return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
         }
 
-        // get post from requests
-        return new JSONResponse([]);
+        return new JSONResponse(
+            ['error' => 'Audit trail is not yet implemented.'],
+            Http::STATUS_NOT_IMPLEMENTED
+        );
     }//end create()
 
     /**
-     * Update an object
+     * Update an object.
      *
      * @NoAdminRequired
      * @NoCSRFRequired
@@ -146,12 +132,14 @@ class ZaakAuditTrailController extends Controller
             return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
         }
 
-        $result = self::TEST_ARRAY[$id];
-        return new JSONResponse($result);
+        return new JSONResponse(
+            ['error' => 'Audit trail is not yet implemented.'],
+            Http::STATUS_NOT_IMPLEMENTED
+        );
     }//end update()
 
     /**
-     * Delate an object
+     * Delete an object.
      *
      * @NoAdminRequired
      * @NoCSRFRequired
@@ -160,8 +148,7 @@ class ZaakAuditTrailController extends Controller
      *
      * @spec openspec/specs/zgw-zaak-management/spec.md#REQ-005
      *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter) — $id is part of the NC route signature;
-     *   stub implementation returns empty response (resource management handled client-side).
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter) — $id is part of the NC route signature.
      */
     public function destroy(string $id): JSONResponse
     {
@@ -169,6 +156,9 @@ class ZaakAuditTrailController extends Controller
             return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
         }
 
-        return new JSONResponse([]);
+        return new JSONResponse(
+            ['error' => 'Audit trail is not yet implemented.'],
+            Http::STATUS_NOT_IMPLEMENTED
+        );
     }//end destroy()
 }//end class

--- a/lib/Controller/ZaakBesluitenController.php
+++ b/lib/Controller/ZaakBesluitenController.php
@@ -11,36 +11,17 @@ use OCP\IRequest;
 use OCP\IUserSession;
 
 /**
- * Controller for zaakbesluiten (case decisions) resources.
+ * Stub controller for the ZGW zaakbesluiten resource.
+ *
+ * Real zaakbesluiten data has not yet been implemented. All data endpoints return
+ * 501 Not Implemented so that clients never receive fabricated test data in place
+ * of real besluit records (issue #268).
  *
  * @copyright 2024 Conduction B.V. <info@conduction.nl>
  * @license   EUPL-1.2 https://joinup.ec.europa.eu/collection/eupl/eupl-text-eupl-12
  */
 class ZaakBesluitenController extends Controller
 {
-    const TEST_ARRAY = [
-        "5137a1e5-b54d-43ad-abd1-4b5bff5fcd3f" => [
-            "id"      => "5137a1e5-b54d-43ad-abd1-4b5bff5fcd3f",
-            "name"    => "Zaakt type 1",
-            "summary" => "summary for one",
-        ],
-        "4c3edd34-a90d-4d2a-8894-adb5836ecde8" => [
-            "id"      => "4c3edd34-a90d-4d2a-8894-adb5836ecde8",
-            "name"    => "Zaakt type 12",
-            "summary" => "summary for two",
-        ],
-        "15551d6f-44e3-43f3-a9d2-59e583c91eb0" => [
-            "id"      => "15551d6f-44e3-43f3-a9d2-59e583c91eb0",
-            "name"    => "Zaakt type 3",
-            "summary" => "summary for two",
-        ],
-        "0a3a0ffb-dc03-4aae-b207-0ed1502e60da" => [
-            "id"      => "0a3a0ffb-dc03-4aae-b207-0ed1502e60da",
-            "name"    => "Zaakt type 4",
-            "summary" => "summary for two",
-        ],
-    ];
-
     public function __construct(
         $appName,
         IRequest $request,
@@ -51,8 +32,7 @@ class ZaakBesluitenController extends Controller
     }//end __construct()
 
     /**
-     * This returns the template of the main app's page
-     * It adds some data to the template (app version)
+     * This returns the template of the main app's page.
      *
      * @NoAdminRequired
      * @NoCSRFRequired
@@ -71,7 +51,7 @@ class ZaakBesluitenController extends Controller
     }//end page()
 
     /**
-     * Return (and serach) all objects
+     * Return (and search) all objects.
      *
      * @NoAdminRequired
      * @NoCSRFRequired
@@ -86,12 +66,14 @@ class ZaakBesluitenController extends Controller
             return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
         }
 
-        $results = ["results" => self::TEST_ARRAY];
-        return new JSONResponse($results);
+        return new JSONResponse(
+            ['error' => 'Zaakbesluiten is not yet implemented.'],
+            Http::STATUS_NOT_IMPLEMENTED
+        );
     }//end index()
 
     /**
-     * Read a single object
+     * Read a single object.
      *
      * @NoAdminRequired
      * @NoCSRFRequired
@@ -106,12 +88,14 @@ class ZaakBesluitenController extends Controller
             return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
         }
 
-        $result = self::TEST_ARRAY[$id];
-        return new JSONResponse($result);
+        return new JSONResponse(
+            ['error' => 'Zaakbesluiten is not yet implemented.'],
+            Http::STATUS_NOT_IMPLEMENTED
+        );
     }//end show()
 
     /**
-     * Creatue an object
+     * Create an object.
      *
      * @NoAdminRequired
      * @NoCSRFRequired
@@ -126,12 +110,14 @@ class ZaakBesluitenController extends Controller
             return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
         }
 
-        // get post from requests
-        return new JSONResponse([]);
+        return new JSONResponse(
+            ['error' => 'Zaakbesluiten is not yet implemented.'],
+            Http::STATUS_NOT_IMPLEMENTED
+        );
     }//end create()
 
     /**
-     * Update an object
+     * Update an object.
      *
      * @NoAdminRequired
      * @NoCSRFRequired
@@ -146,12 +132,14 @@ class ZaakBesluitenController extends Controller
             return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
         }
 
-        $result = self::TEST_ARRAY[$id];
-        return new JSONResponse($result);
+        return new JSONResponse(
+            ['error' => 'Zaakbesluiten is not yet implemented.'],
+            Http::STATUS_NOT_IMPLEMENTED
+        );
     }//end update()
 
     /**
-     * Delate an object
+     * Delete an object.
      *
      * @NoAdminRequired
      * @NoCSRFRequired
@@ -160,8 +148,7 @@ class ZaakBesluitenController extends Controller
      *
      * @spec openspec/specs/zgw-zaak-management/spec.md#REQ-005
      *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter) — $id is part of the NC route signature;
-     *   stub implementation returns empty response (resource management handled client-side).
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter) — $id is part of the NC route signature.
      */
     public function destroy(string $id): JSONResponse
     {
@@ -169,6 +156,9 @@ class ZaakBesluitenController extends Controller
             return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
         }
 
-        return new JSONResponse([]);
+        return new JSONResponse(
+            ['error' => 'Zaakbesluiten is not yet implemented.'],
+            Http::STATUS_NOT_IMPLEMENTED
+        );
     }//end destroy()
 }//end class

--- a/lib/Controller/ZaakTypenController.php
+++ b/lib/Controller/ZaakTypenController.php
@@ -119,9 +119,8 @@ class ZaakTypenController extends Controller
     }//end show()
 
     /**
-     * Creatue an object
+     * Create an object. Admin-only: zaaktypen are validation master data.
      *
-     * @NoAdminRequired
      * @NoCSRFRequired
      *
      * @return JSONResponse
@@ -148,9 +147,8 @@ class ZaakTypenController extends Controller
     }//end create()
 
     /**
-     * Update an object
+     * Update an object. Admin-only: zaaktypen are validation master data.
      *
-     * @NoAdminRequired
      * @NoCSRFRequired
      *
      * @return JSONResponse
@@ -182,9 +180,8 @@ class ZaakTypenController extends Controller
     }//end update()
 
     /**
-     * Delate an object
+     * Delete an object. Admin-only: zaaktypen are validation master data.
      *
-     * @NoAdminRequired
      * @NoCSRFRequired
      *
      * @return JSONResponse


### PR DESCRIPTION
## Summary

Fixes three P0-CRITICAL security issues found in the deep team-reviewer pass (2026-05-27).

### #267 - Credential exfiltration via @NoAdminRequired ConfigurationController

- Dropped @NoAdminRequired from both GET and POST /api/configuration. Both endpoints now require admin.
- Added CREDENTIAL_KEYS constant; all *Key/*Secret fields are redacted to *** in GET and POST responses so API keys are never transmitted to the browser.
- Added WRITABLE_KEYS allow-list; POST silently ignores any key not on the list, preventing blind setValueString injection.

**MANDATORY KEY-ROTATION:** Any environment where a non-admin Nextcloud user existed while this app was active should be treated as compromised. Rotate all ZGW service-account keys (drcKey, orcKey, zrcKey, ztcKey, brcKey, klantenKey, elasticKey, mongodbKey) and any clientSecret values immediately. Re-seed via the admin-only endpoint after rotation.

### #268 - Hardcoded TEST_ARRAY stubs in AuditTrail, ZaakBesluiten, Documenten

- Removed TEST_ARRAY constants and all canned-data responses from ZaakAuditTrailController, ZaakBesluitenController, and DocumentenController.
- All data endpoints now return 501 Not Implemented with a clear error message.
- Removed zaakBesluiten, zaakAuditTrail, and documenten resource routes from appinfo/routes.php to prevent false-positive ZGW/Archiefwet compliance checks.

### #269 - Zaaktypen catalog and klanten writable by any authenticated user

- ZaakTypenController: create/update/destroy drop @NoAdminRequired. Index/show retain it (reads stay open). Zaaktypen are the validation source-of-truth for isEindStatus, createZaakBesluit, and checkProductenOfDiensten.
- KlantenController: create/update/destroy drop @NoAdminRequired. All read and sub-resource methods retain @NoAdminRequired.
- MedewerkersController is not present in this codebase.

## Quality gates

- phpstan: 0 errors (level 5)
- phpcs: 0 errors (legacy-debt warnings only, tracked in #201)
- PHP syntax: all 7 modified files pass

## Test plan

- [ ] Non-admin user: GET /api/configuration returns 403
- [ ] Admin: GET /api/configuration returns config with *** for all key fields
- [ ] Admin: POST /api/configuration saves a key and echoes ***
- [ ] GET /api/zrc/zaken/{uuid}/audit_trail returns 501
- [ ] GET /api/zrc/zaken/{uuid}/besluiten returns 501
- [ ] Non-admin: POST /api/ztc/zaaktypen returns 403
- [ ] Non-admin: DELETE /api/klanten/{id} returns 403
- [ ] Rotate all ZGW keys on any affected environment