### PR TITLE
fix(security): IDOR, mass-assignment and unvalidated objectType (#271 #275 #276 #282-1)

### DIFF
--- a/lib/Controller/BerichtenController.php
+++ b/lib/Controller/BerichtenController.php
@@ -156,9 +156,6 @@ class BerichtenController extends Controller
      * @return JSONResponse
      *
      * @spec openspec/specs/zgw-client-interaction/spec.md#REQ-002
-     *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter) — $id is part of the NC route signature;
-     *   the full payload is consumed via $this->request->getParams() instead.
      */
     public function update(string $id): JSONResponse
     {
@@ -169,7 +166,13 @@ class BerichtenController extends Controller
         // Get all parameters from the request
         $data = $this->request->getParams();
 
-        // Save the new catalog object
+        // Pin the ID from the URL to prevent IDOR: body-supplied id must not override path id.
+        $data['id'] = $id;
+
+        // Strip server-managed fields that callers must not overwrite directly.
+        unset($data['created'], $data['updated']);
+
+        // Save the updated object
         $object = $this->objectService->saveObject('berichten', $data);
 
         // Return the created object as a JSON response

--- a/lib/Controller/KlantenController.php
+++ b/lib/Controller/KlantenController.php
@@ -154,9 +154,6 @@ class KlantenController extends Controller
      * @return JSONResponse
      *
      * @spec openspec/specs/zgw-client-interaction/spec.md#REQ-002
-     *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter) — $id is part of the NC route signature;
-     *   the full payload is consumed via $this->request->getParams() instead.
      */
     public function update(string $id): JSONResponse
     {
@@ -167,7 +164,13 @@ class KlantenController extends Controller
         // Get all parameters from the request
         $data = $this->request->getParams();
 
-        // Save the new catalog object
+        // Pin the ID from the URL to prevent IDOR: body-supplied id must not override path id.
+        $data['id'] = $id;
+
+        // Strip server-managed fields that callers must not overwrite directly.
+        unset($data['created'], $data['updated']);
+
+        // Save the updated object
         $object = $this->objectService->saveObject('klanten', $data);
 
         // Return the created object as a JSON response
@@ -255,7 +258,7 @@ class KlantenController extends Controller
         }
 
         $requestParams = ['gebruikerID' => $id];
-        $berichten     = $this->objectService->getResultArrayForRequest('klanten', $requestParams);
+        $berichten     = $this->objectService->getResultArrayForRequest('berichten', $requestParams);
         return new JSONResponse($berichten);
     }//end getBerichten()
 

--- a/lib/Controller/MedewerkersController.php
+++ b/lib/Controller/MedewerkersController.php
@@ -156,9 +156,6 @@ class MedewerkersController extends Controller
      * @return JSONResponse
      *
      * @spec openspec/specs/zgw-client-interaction/spec.md#REQ-002
-     *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter) — $id is part of the NC route signature;
-     *   the full payload is consumed via $this->request->getParams() instead.
      */
     public function update(string $id): JSONResponse
     {
@@ -168,6 +165,12 @@ class MedewerkersController extends Controller
 
         // Get all parameters from the request
         $data = $this->request->getParams();
+
+        // Pin the ID from the URL to prevent IDOR: body-supplied id must not override path id.
+        $data['id'] = $id;
+
+        // Strip server-managed fields that callers must not overwrite directly.
+        unset($data['created'], $data['updated']);
 
         // Save the updated employee
         $object = $this->objectService->saveObject('medewerkers', $data);

--- a/lib/Controller/ObjectsController.php
+++ b/lib/Controller/ObjectsController.php
@@ -18,6 +18,33 @@ use Exception;
  */
 class ObjectsController extends Controller
 {
+    /**
+     * Explicit allow-list of object types exposed through the generic objects endpoint.
+     * Any objectType not in this list is rejected with HTTP 400 to prevent access to
+     * unintended or internal schemas (#276 — unvalidated objectType).
+     *
+     * Keep in sync with SettingsController::OBJECT_TYPES.
+     */
+    private const ALLOWED_OBJECT_TYPES = [
+        'berichten',
+        'besluiten',
+        'documenten',
+        'klanten',
+        'resultaten',
+        'taken',
+        'informatieobjecten',
+        'organisaties',
+        'personen',
+        'zaken',
+        'rollen',
+        'statusen',
+        'zaakeigenschappen',
+        'zaaktypen',
+        'contactmomenten',
+        'medewerkers',
+        'producten',
+    ];
+
     public function __construct(
         $appName,
         IRequest $request,
@@ -26,6 +53,25 @@ class ObjectsController extends Controller
     ) {
         parent::__construct($appName, $request);
     }//end __construct()
+
+    /**
+     * Validate that the requested objectType is in the known allow-list.
+     *
+     * @param string $objectType The object type from the URL.
+     *
+     * @return JSONResponse|null Returns a 400 response on invalid type, null when valid.
+     */
+    private function validateObjectType(string $objectType): ?JSONResponse
+    {
+        if (in_array($objectType, self::ALLOWED_OBJECT_TYPES, true) === false) {
+            return new JSONResponse(
+                ['error' => "Unknown object type: $objectType"],
+                Http::STATUS_BAD_REQUEST
+            );
+        }
+
+        return null;
+    }//end validateObjectType()
 
     /**
      * Return (and search) all objects
@@ -43,6 +89,11 @@ class ObjectsController extends Controller
     {
         if ($this->userSession->getUser() === null) {
             return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
+        }
+
+        $typeError = $this->validateObjectType($objectType);
+        if ($typeError !== null) {
+            return $typeError;
         }
 
         // Retrieve all request parameters
@@ -72,6 +123,11 @@ class ObjectsController extends Controller
     {
         if ($this->userSession->getUser() === null) {
             return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
+        }
+
+        $typeError = $this->validateObjectType($objectType);
+        if ($typeError !== null) {
+            return $typeError;
         }
 
         try {
@@ -113,6 +169,11 @@ class ObjectsController extends Controller
             return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
         }
 
+        $typeError = $this->validateObjectType($objectType);
+        if ($typeError !== null) {
+            return $typeError;
+        }
+
         try {
             // Get all parameters from the request
             $data = $this->request->getParams();
@@ -147,6 +208,11 @@ class ObjectsController extends Controller
     {
         if ($this->userSession->getUser() === null) {
             return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
+        }
+
+        $typeError = $this->validateObjectType($objectType);
+        if ($typeError !== null) {
+            return $typeError;
         }
 
         try {
@@ -185,6 +251,11 @@ class ObjectsController extends Controller
             return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
         }
 
+        $typeError = $this->validateObjectType($objectType);
+        if ($typeError !== null) {
+            return $typeError;
+        }
+
         try {
             // Delete the object
             $result = $this->objectService->deleteObject($objectType, $id);
@@ -215,6 +286,11 @@ class ObjectsController extends Controller
             return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
         }
 
+        $typeError = $this->validateObjectType($objectType);
+        if ($typeError !== null) {
+            return $typeError;
+        }
+
         try {
             $auditTrail = $this->objectService->getAuditTrail($objectType, $id);
             return new JSONResponse($auditTrail);
@@ -240,6 +316,11 @@ class ObjectsController extends Controller
     {
         if ($this->userSession->getUser() === null) {
             return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
+        }
+
+        $typeError = $this->validateObjectType($objectType);
+        if ($typeError !== null) {
+            return $typeError;
         }
 
         try {
@@ -270,6 +351,11 @@ class ObjectsController extends Controller
     {
         if ($this->userSession->getUser() === null) {
             return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
+        }
+
+        $typeError = $this->validateObjectType($objectType);
+        if ($typeError !== null) {
+            return $typeError;
         }
 
         $uses = $this->objectService->getUses($objectType, $id);

--- a/lib/Controller/ZakenController.php
+++ b/lib/Controller/ZakenController.php
@@ -140,6 +140,9 @@ class ZakenController extends Controller
         // Remove the 'id' field if it exists, as we're creating a new object
         unset($data['id']);
 
+        // Strip system-managed ZGW fields that must be set server-side (ZGW API-principes).
+        unset($data['bronorganisatie'], $data['verantwoordelijkeOrganisatie'], $data['identificatie'], $data['archiefstatus'], $data['created'], $data['updated']);
+
         // Save the new catalog object
         $object = $this->objectService->saveObject('zaken', $data);
 
@@ -156,9 +159,6 @@ class ZakenController extends Controller
      * @return JSONResponse
      *
      * @spec openspec/specs/zgw-zaak-management/spec.md#REQ-003
-     *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter) — $id is part of the NC route signature;
-     *   the full payload is consumed via $this->request->getParams() instead.
      */
     public function update(string $id): JSONResponse
     {
@@ -169,7 +169,13 @@ class ZakenController extends Controller
         // Get all parameters from the request
         $data = $this->request->getParams();
 
-        // Save the new catalog object
+        // Pin the ID from the URL to prevent IDOR: body-supplied id must not override path id.
+        $data['id'] = $id;
+
+        // Strip system-managed ZGW fields that must not be overwritten via the request body.
+        unset($data['bronorganisatie'], $data['verantwoordelijkeOrganisatie'], $data['identificatie'], $data['archiefstatus'], $data['created'], $data['updated']);
+
+        // Save the updated object
         $object = $this->objectService->saveObject('zaken', $data);
 
         // Return the created object as a JSON response


### PR DESCRIPTION
## Summary

- **#271 IDOR in 4 controllers**: `ZakenController`, `KlantenController`, `BerichtenController`, `MedewerkersController` `update()` now pins `$data['id'] = $id` from the URL path so a body-supplied id cannot silently update a different record.
- **#275 Mass assignment of system-managed ZGW fields**: `ZakenController` create/update strips `bronorganisatie`, `verantwoordelijkeOrganisatie`, `identificatie`, `archiefstatus`, `created`, `updated`. Other three controllers strip `created`/`updated`.
- **#276 Unvalidated objectType**: Added `ALLOWED_OBJECT_TYPES` constant and `validateObjectType()` guard on every action in `ObjectsController`. Unknown types return HTTP 400.
- **#282 bug-1 KlantenController::getBerichten wrong register**: Fixed copy-paste bug querying `'klanten'` instead of `'berichten'`.

## Test plan

- [ ] `PUT /api/zaken/{AAA}` with body `{"id":"BBB",...}` updates AAA, not BBB (IDOR fix)
- [ ] `POST /api/zaken` with `bronorganisatie` in body — field absent in saved record
- [ ] `GET /api/objects/nonexistent` → HTTP 400
- [ ] `GET /api/objects/zaken` → still works normally
- [ ] `GET /api/klanten/{id}/berichten` → returns berichten records