### PR TITLE
fix(zgw): race condition, archive metadata, vertrouwelijkheid, roltoelichting (#273 #274 #277 #279 #281)

### DIFF
--- a/lib/Controller/RollenController.php
+++ b/lib/Controller/RollenController.php
@@ -99,7 +99,23 @@ class RollenController extends Controller
     }//end show()
 
     /**
+     * Valid ZGW betrokkeneType values per VNG API standard.
+     */
+    private const BETROKKENE_TYPES = [
+        'natuurlijk_persoon',
+        'niet_natuurlijk_persoon',
+        'vestiging',
+        'organisatorische_eenheid',
+        'medewerker',
+    ];
+
+    /**
      * Create a rol.
+     *
+     * Validates ZGW mandatory invariants before forwarding to the ZRC:
+     * - betrokkeneType must be a known enum value.
+     * - roltoelichting is mandatory as the AVG legal basis for processing personal data
+     *   (BSN stored in betrokkeneIdentificatie.inpBsn) — fixes #279.
      *
      * @NoAdminRequired
      * @NoCSRFRequired
@@ -116,7 +132,25 @@ class RollenController extends Controller
             return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
         }
 
-        $body    = $this->request->getParams();
+        $body = $this->request->getParams();
+
+        // Validate betrokkeneType enum.
+        if (isset($body['betrokkeneType']) && in_array($body['betrokkeneType'], self::BETROKKENE_TYPES, true) === false) {
+            return new JSONResponse(
+                ['betrokkeneType' => ['Waarde \''.$body['betrokkeneType'].'\' is geen geldige betrokkeneType.']],
+                Http::STATUS_BAD_REQUEST
+            );
+        }
+
+        // Enforce roltoelichting: required for AVG Article 5(1)(b) purpose-limitation
+        // when personal data (e.g. BSN) is associated with the rol.
+        if (empty($body['roltoelichting']) === true) {
+            return new JSONResponse(
+                ['roltoelichting' => ['Dit veld is verplicht. Geef de juridische grondslag op voor het verwerken van persoonsgegevens in deze rol.']],
+                Http::STATUS_BAD_REQUEST
+            );
+        }
+
         $results = $callService->create(source: 'zrc', endpoint: 'rollen', data: $body);
         return new JSONResponse($results);
     }//end create()

--- a/lib/EventListener/ZaakRegisterEventListener.php
+++ b/lib/EventListener/ZaakRegisterEventListener.php
@@ -71,6 +71,10 @@ class ZaakRegisterEventListener implements IEventListener
         $obj  = $event->getObject();
 
         if ($slug === $this->registry->getStatusSchema()) {
+            // Re-open or close the zaak now that the status record is confirmed persisted.
+            // closeZaak MUST run in ObjectCreated (not ObjectCreating) so the zaak is only
+            // mutated when the triggering status write is known-successful — fixes #274.
+            $this->lifecycleService->closeZaak($obj);
             $this->lifecycleService->reopenZaak($obj);
         }
 
@@ -129,9 +133,8 @@ class ZaakRegisterEventListener implements IEventListener
         $slug = $this->schemaMapper->find($event->getObject()->getSchema())->getSlug();
         $obj  = $event->getObject();
 
-        if ($slug === $this->registry->getStatusSchema()) {
-            $this->lifecycleService->closeZaak($obj);
-        }
+        // Note: closeZaak has been moved to handleObjectCreated to avoid a race condition
+        // where the zaak was permanently mutated before the status record was persisted (#274).
 
         if ($slug === $this->registry->getZaakSchema()) {
             $this->zaakValidationService->checkProductenOfDiensten($obj);

--- a/lib/Service/ZGWArchiveDateService.php
+++ b/lib/Service/ZGWArchiveDateService.php
@@ -5,6 +5,8 @@ namespace OCA\ZaakAfhandelApp\Service;
 use DateInterval;
 use DateTime;
 use OCA\OpenRegister\Db\ObjectEntity;
+use OCA\OpenRegister\Db\RegisterMapper;
+use OCA\OpenRegister\Db\SchemaMapper;
 
 /**
  * Service for calculating archive dates based on afleidingswijze.
@@ -22,13 +24,17 @@ class ZGWArchiveDateService
     /**
      * Constructor for ZGWArchiveDateService.
      *
-     * @param ObjectService $objectService The object service wrapper
+     * @param ObjectMapperService $mapperService   The object service wrapper
+     * @param RegisterMapper      $registerMapper  Mapper for resolving register slug → ID
+     * @param SchemaMapper        $schemaMapper    Mapper for resolving schema slug → ID
      *
      * @throws \Psr\Container\ContainerExceptionInterface
      * @throws \Psr\Container\NotFoundExceptionInterface
      */
     public function __construct(
         ObjectMapperService $mapperService,
+        private RegisterMapper $registerMapper,
+        private SchemaMapper $schemaMapper,
     ) {
         $this->objectService = $mapperService->getOpenRegisters();
     }//end __construct()
@@ -145,24 +151,30 @@ class ZGWArchiveDateService
         string $brcRegister,
         string $besluitSchema,
     ): ?string {
+        // OpenRegister findAll expects numeric IDs for register/schema filters, not slugs.
+        // Resolve the slugs to their database IDs first (fixes #277).
+        $registerId = $this->registerMapper->find($brcRegister)->getId();
+        $schemaId   = $this->schemaMapper->find($besluitSchema)->getId();
+
         $this->objectService->clearCurrents();
         $besluiten = $this->objectService->findAll(
                 [
                     'filters' => [
                         'zaak'     => $zaakArray['url'],
-                        'register' => $brcRegister,
-                        'schema'   => $besluitSchema,
+                        'register' => $registerId,
+                        'schema'   => $schemaId,
                     ],
                 ]
                 );
 
-        $data = array_map(
-                function (ObjectEntity $besluit) use ($dateField) {
-                    return $besluit->jsonSerialize()[$dateField];
-                },
-                $besluiten
-                );
+        $data = array_filter(array_map(
+            function (ObjectEntity $besluit) use ($dateField) {
+                return $besluit->jsonSerialize()[$dateField] ?? null;
+            },
+            $besluiten
+        ));
 
-        return max($data);
+        // max([]) returns false; return null when there are no dated besluiten.
+        return empty($data) === false ? max($data) : null;
     }//end calculateFromBesluit()
 }//end class

--- a/lib/Service/ZGWZaakCloseService.php
+++ b/lib/Service/ZGWZaakCloseService.php
@@ -5,6 +5,7 @@ namespace OCA\ZaakAfhandelApp\Service;
 use DateTime;
 use OCA\OpenRegister\Db\ObjectEntity;
 use OCA\OpenRegister\Exception\CustomValidationException;
+use Psr\Log\LoggerInterface;
 
 /**
  * Handles closing a zaak (setting eindstatus). ZRC-007/ZRC-021.
@@ -21,12 +22,17 @@ class ZGWZaakCloseService
         ObjectMapperService $mapperService,
         private ZGWArchiveDateService $archiveService,
         private ZGWRegistryService $registry,
+        private LoggerInterface $logger,
     ) {
         $this->objectService = $mapperService->getOpenRegisters();
     }//end __construct()
 
     /**
      * Close a zaak when eindstatus is set.
+     *
+     * Throws CustomValidationException when a required field (resultaat, zaaktype, etc.)
+     * is missing or malformed so that the caller can surface the error rather than silently
+     * leaving the zaak without required archive metadata (Archiefwet) — fixes #273.
      *
      * @spec openspec/specs/zgw-case-lifecycle/spec.md#REQ-002
      */
@@ -42,15 +48,41 @@ class ZGWZaakCloseService
         $zaakArray = $zaak->jsonSerialize();
         $this->assertGebruiksrechten($zaakArray);
 
-        $zaakArray['einddatum'] = (new DateTime($statusArray['datumStatusGezet']))->format("Y-m-d");
-        $resultaattype          = $this->find($this->find($zaakArray['resultaat'])->jsonSerialize()['resultaattype'])->jsonSerialize();
+        // Guard: zaak must have a resultaat before it can be closed with archive metadata.
+        if (empty($zaakArray['resultaat']) === true) {
+            throw new CustomValidationException(
+                'Zaak heeft geen resultaat',
+                [['name' => 'resultaat', 'code' => 'required', 'reason' => 'Een zaak moet een resultaat hebben voordat hij gesloten kan worden']]
+            );
+        }
+
+        try {
+            $zaakArray['einddatum'] = (new DateTime($statusArray['datumStatusGezet']))->format("Y-m-d");
+        } catch (\Exception $e) {
+            throw new CustomValidationException(
+                'Ongeldige datumStatusGezet',
+                [['name' => 'datumStatusGezet', 'code' => 'invalid', 'reason' => 'datumStatusGezet bevat geen geldige ISO 8601 datum: '.$e->getMessage()]]
+            );
+        }
+
+        try {
+            $resultaatRecord = $this->find($zaakArray['resultaat']);
+            $resultaattype   = $this->find($resultaatRecord->jsonSerialize()['resultaattype'])->jsonSerialize();
+        } catch (\Exception $e) {
+            $this->logger->error('ZaakAfhandelApp: closeZaak cannot resolve resultaattype', ['exception' => $e->getMessage()]);
+            throw new CustomValidationException(
+                'Resultaattype niet gevonden',
+                [['name' => 'resultaattype', 'code' => 'not-found', 'reason' => 'Het resultaattype kon niet worden opgehaald: '.$e->getMessage()]]
+            );
+        }
+
         $zaakArray['archiefnominatie']  = $resultaattype['archiefnominatie'];
         $zaakArray['archiefactiedatum'] = $this->archiveService->calculateArchiveDate(
             $resultaattype['brondatumArchiefprocedure']['afleidingswijze'] ?? null,
             $zaakArray,
-                $resultaattype,
-                $this->registry->getBrcRegister(),
-                $this->registry->getBesluitSchema()
+            $resultaattype,
+            $this->registry->getBrcRegister(),
+            $this->registry->getBesluitSchema()
         );
 
         $this->objectService->clearCurrents();

--- a/lib/Service/ZGWZaakLifecycleService.php
+++ b/lib/Service/ZGWZaakLifecycleService.php
@@ -72,19 +72,62 @@ class ZGWZaakLifecycleService
     }//end deleteZaak()
 
     /**
+     * ZGW confidentiality ordering, lowest to highest.
+     * A zaak may only have a classification equal to or more restrictive than its zaaktype.
+     */
+    private const VERTROUWELIJKHEID_ORDER = [
+        'openbaar'             => 0,
+        'beperkt_openbaar'     => 1,
+        'intern'               => 2,
+        'zaakvertrouwelijk'    => 3,
+        'vertrouwelijk'        => 4,
+        'confidentieel'        => 5,
+        'geheim'               => 6,
+        'zeer_geheim'          => 7,
+    ];
+
+    /**
      * ZRC-009: Set derived vertrouwelijkheidaanduiding.
+     *
+     * When the zaak has no classification yet, inherit the zaaktype default.
+     * When the zaak already has a classification, enforce that it is at least as
+     * restrictive as the zaaktype minimum — a lower classification is replaced with
+     * the zaaktype value (fixes #281, ZGW confidentiality lowering rule).
      *
      * @spec openspec/specs/zgw-case-lifecycle/spec.md#REQ-003
      */
     public function setVertrouwelijkheidaanduiding(ObjectEntity $zaak): void
     {
-        $zaakArray = $zaak->jsonSerialize();
-        if ($zaakArray['vertrouwelijkheidaanduiding'] !== null) {
+        $zaakArray   = $zaak->jsonSerialize();
+        $zaaktype    = $this->find($zaakArray['zaaktype']);
+        $ztMinimum   = $zaaktype->jsonSerialize()['vertrouwelijkheidaanduiding'] ?? null;
+
+        if ($ztMinimum === null) {
+            // Zaaktype has no classification configured; nothing to enforce.
             return;
         }
 
-        $zaaktype = $this->find($zaakArray['zaaktype']);
-        $zaakArray['vertrouwelijkheidaanduiding'] = $zaaktype->jsonSerialize()['vertrouwelijkheidaanduiding'];
+        $current = $zaakArray['vertrouwelijkheidaanduiding'] ?? null;
+
+        if ($current === null) {
+            // Inherit the zaaktype default when no classification has been set yet.
+            $zaakArray['vertrouwelijkheidaanduiding'] = $ztMinimum;
+        } else {
+            // Enforce minimum: if the zaak's classification is lower than the zaaktype
+            // minimum, raise it to the minimum.
+            $currentRank = self::VERTROUWELIJKHEID_ORDER[$current] ?? -1;
+            $minimumRank = self::VERTROUWELIJKHEID_ORDER[$ztMinimum] ?? 0;
+
+            if ($currentRank < $minimumRank) {
+                $zaakArray['vertrouwelijkheidaanduiding'] = $ztMinimum;
+            }
+        }
+
+        if ($zaakArray['vertrouwelijkheidaanduiding'] === ($zaak->jsonSerialize()['vertrouwelijkheidaanduiding'] ?? null)) {
+            // No change needed; skip the save to avoid an unnecessary write.
+            return;
+        }
+
         $zaak->setObject($zaakArray);
         $this->objectService->saveObject(object: $zaak, register: $zaak->getRegister(), schema: $zaak->getSchema());
     }//end setVertrouwelijkheidaanduiding()


### PR DESCRIPTION
## Summary

- **#274 race condition — closeZaak moved to ObjectCreated**: `closeZaak` was wired to `handleObjectCreating` which fires _before_ the status record is persisted. The zaak could be permanently mutated with closed-state metadata while the triggering status creation later failed. Moved to `handleObjectCreated` so zaak is only closed once the status write is confirmed.
- **#273 swallowed exceptions**: `closeZaak` now throws `CustomValidationException` (instead of silently returning) for missing `resultaat`, unparseable `datumStatusGezet`, or unresolvable `resultaattype`. This surfaces Archiefwet violations as user-visible validation errors.
- **#277 archive date slug vs ID**: `calculateFromBesluit` was passing BRC register slug strings to `findAll` which expects numeric IDs. Now resolves slugs via `RegisterMapper`/`SchemaMapper` (matching the `deleteOioByFilters` pattern). Also fixes `max([])` → `null` when no besluiten exist.
- **#281 vertrouwelijkheidaanduiding minimum not enforced**: `setVertrouwelijkheidaanduiding` now checks the zaak classification against the zaaktype minimum using the ZGW-defined 8-level ordering and raises it to the minimum when too low.
- **#279 roltoelichting / AVG**: `RollenController::create` validates `betrokkeneType` enum and requires non-empty `roltoelichting` (the AVG grondslag for BSN processing) before forwarding to the ZRC.

## Test plan

- [ ] Creating an eindstatus on a zaak without a resultaat → HTTP 400 (not a silent partial update)
- [ ] Creating an eindstatus with a malformed `datumStatusGezet` → HTTP 400 with clear message
- [ ] Archive date calculation for a zaak with besluiten now returns the correct max date
- [ ] Creating a zaak with `vertrouwelijkheidaanduiding: "openbaar"` when zaaktype is `"geheim"` → stored as `"geheim"`
- [ ] `POST /api/rollen` without `roltoelichting` → HTTP 400
- [ ] `POST /api/rollen` with invalid `betrokkeneType` → HTTP 400