### PR TITLE
fix(security): path injection/SSRF and mail open relay (#270 #272)

### DIFF
--- a/lib/Controller/ZaakEigenschappenController.php
+++ b/lib/Controller/ZaakEigenschappenController.php
@@ -48,6 +48,29 @@ class ZaakEigenschappenController extends Controller
         );
     }//end page()
 
+    /** UUID v4 pattern used to validate path segments before interpolation into URLs. */
+    private const UUID_PATTERN = '/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i';
+
+    /**
+     * Validate that $value is a strict UUID to prevent path-traversal / SSRF (#270).
+     *
+     * @param string $value The value to validate.
+     * @param string $field The field name for the error message.
+     *
+     * @return JSONResponse|null Returns a 400 response when invalid, null when valid.
+     */
+    private function assertUuid(string $value, string $field): ?JSONResponse
+    {
+        if (preg_match(self::UUID_PATTERN, $value) !== 1) {
+            return new JSONResponse(
+                ['error' => "$field must be a valid UUID"],
+                Http::STATUS_BAD_REQUEST
+            );
+        }
+
+        return null;
+    }//end assertUuid()
+
     /**
      * Return (and serach) all objects
      *
@@ -62,6 +85,11 @@ class ZaakEigenschappenController extends Controller
     {
         if ($this->userSession->getUser() === null) {
             return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
+        }
+
+        $uuidError = $this->assertUuid($zaakId, 'zaakId');
+        if ($uuidError !== null) {
+            return $uuidError;
         }
 
         $results = $callService->index(source: 'zrc', endpoint: "zaken/$zaakId/zaakeigenschappen");
@@ -84,6 +112,11 @@ class ZaakEigenschappenController extends Controller
             return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
         }
 
+        $uuidError = $this->assertUuid($zaakId, 'zaakId');
+        if ($uuidError !== null) {
+            return $uuidError;
+        }
+
         $results = $callService->show(source: 'zrc', endpoint: "zaken/$zaakId/zaakeigenschappen", id: $id);
         return new JSONResponse($results);
     }//end show()
@@ -102,6 +135,11 @@ class ZaakEigenschappenController extends Controller
     {
         if ($this->userSession->getUser() === null) {
             return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
+        }
+
+        $uuidError = $this->assertUuid($zaakId, 'zaakId');
+        if ($uuidError !== null) {
+            return $uuidError;
         }
 
         // get post from requests
@@ -126,6 +164,11 @@ class ZaakEigenschappenController extends Controller
             return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
         }
 
+        $uuidError = $this->assertUuid($zaakId, 'zaakId');
+        if ($uuidError !== null) {
+            return $uuidError;
+        }
+
         $body    = $this->request->getParams();
         $results = $callService->update(source: 'zrc', endpoint: "zaken/$zaakId/zaakeigenschappen", data: $body, id: $id);
         return new JSONResponse($results);
@@ -145,6 +188,11 @@ class ZaakEigenschappenController extends Controller
     {
         if ($this->userSession->getUser() === null) {
             return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
+        }
+
+        $uuidError = $this->assertUuid($zaakId, 'zaakId');
+        if ($uuidError !== null) {
+            return $uuidError;
         }
 
         $callService->destroy(source: 'zrc', endpoint: "zaken/$zaakId/zaakeigenschappen", id: $id);

--- a/lib/Service/MailService.php
+++ b/lib/Service/MailService.php
@@ -27,6 +27,14 @@ class MailService
     /**
      * Sends an e-mail when a task is connected to an employee.
      *
+     * Security notes:
+     * - medewerker is validated as a well-formed e-mail address before use as To address to
+     *   prevent open-relay / spam-primitive abuse (#272).
+     * - The deep-equality guard now compares the medewerker field specifically rather than
+     *   using === on full object arrays (distinct PHP arrays are never ===; the old guard
+     *   was never true and mail was sent on every update regardless of change — #272).
+     * - User-supplied values are HTML-escaped before interpolation into the mail body (#272).
+     *
      * @param array $oldObject The previous version of the object (to check if the field changes)
      * @param array $newObject The current version of the object.
      *
@@ -39,27 +47,40 @@ class MailService
     {
         if (isset($newObject['medewerker']) === false) {
             return $newObject;
-        } else if (isset($oldObject['medewerker']) === true && $oldObject === $newObject) {
+        }
+
+        // Skip if the medewerker field has not changed compared to the previous version.
+        if (isset($oldObject['medewerker']) === true && $oldObject['medewerker'] === $newObject['medewerker']) {
             return $newObject;
         }
 
         $email = $newObject['medewerker'];
 
+        // Validate that the medewerker value is a properly-formatted e-mail address before
+        // using it as the To address, to prevent open-relay abuse (#272).
+        if (filter_var($email, FILTER_VALIDATE_EMAIL) === false) {
+            // Not a valid e-mail; skip silently to avoid leaking validation errors in the
+            // object response, but do not send the message.
+            return $newObject;
+        }
+
+        // HTML-escape task data before interpolation to prevent stored-HTML injection (#272).
+        $taskId    = htmlspecialchars((string) ($newObject['id'] ?? ''), ENT_QUOTES | ENT_HTML5, 'UTF-8');
+        $taskTitle = htmlspecialchars((string) ($newObject['title'] ?? 'taak'), ENT_QUOTES | ENT_HTML5, 'UTF-8');
+        $baseUrl   = htmlspecialchars($this->urlGenerator->getBaseUrl(), ENT_QUOTES | ENT_HTML5, 'UTF-8');
+
         $message = $this->mailer->createMessage();
         $message->setSubject('KISS: Er is een taak aan u toegewezen');
         $message->setTo([$email]);
         $message->setHtmlBody(
-          body: "
-				<!doctype html>
-				<html lang='nl'>
-					<body>
-						Er is een taak aan u toegewezen. Klik
-						<a href='".$this->urlGenerator->getBaseUrl()."/apps/zaakafhandelapp/taken/{$newObject["id"]}'>
-							hier
-						</a>
-						om naar de taak te gaan.
-					</body>
-				</html>"
+            body: "<!doctype html>
+<html lang='nl'>
+<body>
+<p>Er is een taak (<strong>$taskTitle</strong>) aan u toegewezen. Klik
+<a href='$baseUrl/apps/zaakafhandelapp/taken/$taskId'>hier</a>
+om naar de taak te gaan.</p>
+</body>
+</html>"
         );
 
         $this->mailer->send($message);


### PR DESCRIPTION
## Summary

- **#270 Path injection / SSRF in eigenschappen endpoint**: `ZaakEigenschappenController` now validates `$zaakId` against a strict UUID regex (`/^[0-9a-f]{8}-[0-9a-f]{4}-..$/i`) on all five actions before interpolating it into the Guzzle endpoint URL. Crafted values with path-traversal sequences (`..%2F...`) are rejected HTTP 400 before any outbound ZRC call is made.
- **#272 Mail open relay / HTML injection** — Three fixes in `MailService::sendMail`:
  1. `medewerker` validated with `filter_var(FILTER_VALIDATE_EMAIL)` before use as the To address; invalid values skip the send silently.
  2. Deep-equality guard fixed from `$oldObject === $newObject` (always false for distinct PHP arrays — mail was always sent) to `$oldObject['medewerker'] === $newObject['medewerker']` (mail only on actual assignment change).
  3. `taskId`, `taskTitle`, and base URL are `htmlspecialchars()`-escaped before interpolation into the HTML body, preventing stored HTML/script injection via user-controlled fields.

## Test plan

- [ ] `GET /api/zaken/..%2Frollen%2F{uuid}/eigenschappen` → HTTP 400 (no outbound ZRC call made)
- [ ] `GET /api/zaken/{valid-uuid}/eigenschappen` → still works normally
- [ ] `POST /api/taken` with `medewerker: "not-an-email"` → no mail sent
- [ ] `PUT /api/taken/{id}` with the same `medewerker` as before → no mail sent (field unchanged)
- [ ] `PUT /api/taken/{id}` with a new valid `medewerker` email → mail sent once
- [ ] `POST /api/taken` with `title: "<script>alert(1)</script>"` → mail body contains escaped `&lt;script&gt;`