### PR TITLE
fix(correctness): null-derefs, ZIO URL validation, besluittypen, CallService robustness (#278 #280 #282)

### DIFF
--- a/lib/Controller/ZaakInformatieObjectenController.php
+++ b/lib/Controller/ZaakInformatieObjectenController.php
@@ -89,7 +89,16 @@ class ZaakInformatieObjectenController extends Controller
     }//end show()
 
     /**
-     * Creatue an object
+     * Create a ZIO (zaak-informatieobject link).
+     *
+     * Guards (#280):
+     * - Both `zaak` and `informatieobject` URL fields must be present and non-empty.
+     * - Both values must be syntactically valid HTTP(S) URLs.
+     *
+     * Note: full object-level authorization (verify the current user has write access on the
+     * zaak and read access on the informatieobject) requires a ZRC/DRC look-up that is beyond
+     * the scope of this controller. That check is tracked in GitHub issue #280 and should be
+     * implemented once per-object ACLs are available via the configured ZRC/DRC sources.
      *
      * @NoAdminRequired
      * @NoCSRFRequired
@@ -105,7 +114,25 @@ class ZaakInformatieObjectenController extends Controller
         }
 
         // get post from requests
-        $body    = $this->request->getParams();
+        $body = $this->request->getParams();
+
+        // Validate that required URL fields are present and syntactically valid (#280).
+        foreach (['zaak', 'informatieobject'] as $field) {
+            if (empty($body[$field]) === true) {
+                return new JSONResponse(
+                    [$field => ["Het veld $field is verplicht."]],
+                    Http::STATUS_BAD_REQUEST
+                );
+            }
+
+            if (filter_var($body[$field], FILTER_VALIDATE_URL) === false) {
+                return new JSONResponse(
+                    [$field => ["Het veld $field moet een geldige URL zijn."]],
+                    Http::STATUS_BAD_REQUEST
+                );
+            }
+        }
+
         $results = $callService->create(source: 'zrc', endpoint: 'zaakinformatieobjecten', data: $body);
         return new JSONResponse($results);
     }//end create()

--- a/lib/Service/CallService.php
+++ b/lib/Service/CallService.php
@@ -49,9 +49,13 @@ class CallService
     public function getConfig(?string $source=null, array $query=[]): array
     {
         $result = [
-            'base_uri' => $this->config->getValueString('zaakafhandelapp', "{$source}Location"),
-            'query'    => $query,
-            'headers'  => [],
+            'base_uri'    => $this->config->getValueString('zaakafhandelapp', "{$source}Location"),
+            'query'       => $query,
+            'headers'     => [],
+            // Disable Guzzle's default behaviour of throwing on non-2xx responses so that
+            // ZGW backend error bodies (validation details, 404 etc.) are returned to the
+            // caller rather than bubbling as an unhandled GuzzleException → HTTP 500 (#282 bug-4).
+            'http_errors' => false,
         ];
 
         return array_merge_recursive($result, $this->getAuthorization($source));
@@ -74,6 +78,28 @@ class CallService
     }//end getClient()
 
     /**
+     * Decode a Guzzle response body as JSON, returning null on empty or malformed content (#282 bug-4).
+     *
+     * @param string $body The raw response body.
+     *
+     * @return array|null Decoded associative array or null.
+     */
+    private function decodeJson(string $body): ?array
+    {
+        if ($body === '') {
+            return null;
+        }
+
+        $decoded = json_decode($body, associative: true);
+
+        if (json_last_error() !== JSON_ERROR_NONE) {
+            return null;
+        }
+
+        return $decoded;
+    }//end decodeJson()
+
+    /**
      * Finds objects based upon a set of filters.
      *
      * @param array $query The filters to compare the object to.
@@ -93,11 +119,7 @@ class CallService
         // Setuo the client & make the call
         $returnData = $this->getClient(source: $source, config: $config)->get("$endpoint");
 
-        // Turn everything into arrays
-        return json_decode(
-            json: $returnData->getBody()->getContents(),
-            associative: true
-        );
+        return $this->decodeJson($returnData->getBody()->getContents());
     }//end index()
 
     /**
@@ -122,11 +144,7 @@ class CallService
         // Setuo the client & make the call
         $returnData = $this->getClient(source: $source, config: $config)->get($this->config->getValueString('zaakafhandelapp', "{$source}Location")."/$endpoint/$id");
 
-        // Turn everything into arrays
-        return json_decode(
-            json: $returnData->getBody()->getContents(),
-            associative: true
-        );
+        return $this->decodeJson($returnData->getBody()->getContents());
     }//end show()
 
     /**
@@ -145,11 +163,7 @@ class CallService
         // Setuo the client & make the call
         $returnData = $this->getClient(source: $source)->post(uri: "$endpoint", options: ['json' => $data]);
 
-        // Turn everything into arrays
-        return json_decode(
-            json: $returnData->getBody()->getContents(),
-            associative: true
-        );
+        return $this->decodeJson($returnData->getBody()->getContents());
     }//end create()
 
     /**
@@ -169,11 +183,7 @@ class CallService
         // Setuo the client & make the call
         $returnData = $this->getClient(source: $source)->put("$endpoint/$id", options: ['json' => $data]);
 
-        // Turn everything into arrays
-        return json_decode(
-            json: $returnData->getBody()->getContents(),
-            associative: true
-        );
+        return $this->decodeJson($returnData->getBody()->getContents());
     }//end update()
 
     /**
@@ -192,10 +202,6 @@ class CallService
         // Setuo the client & make the call
         $returnData = $this->getClient(source: $source)->delete("$endpoint/$id");
 
-        // Turn everything into arrays
-        return json_decode(
-            json: $returnData->getBody()->getContents(),
-            associative: true
-        );
+        return $this->decodeJson($returnData->getBody()->getContents());
     }//end destroy()
 }//end class

--- a/lib/Service/ZGWArchiveDateService.php
+++ b/lib/Service/ZGWArchiveDateService.php
@@ -74,12 +74,17 @@ class ZGWArchiveDateService
      */
     private function calculateFromHoofdzaak(array $zaakArray): ?string
     {
+        // Guard: hoofdzaak may be null when this zaak is not a deelzaak (#278).
+        if (empty($zaakArray['hoofdzaak']) === true) {
+            return null;
+        }
+
         $hoofdzaakId = explode('/', $zaakArray['hoofdzaak']);
         $hoofdzaakId = end($hoofdzaakId);
         $this->objectService->clearCurrents();
         $hoofdzaak = $this->objectService->find($hoofdzaakId);
 
-        return $hoofdzaak->jsonSerialize()['einddatum'];
+        return $hoofdzaak->jsonSerialize()['einddatum'] ?? null;
     }//end calculateFromHoofdzaak()
 
     /**
@@ -108,9 +113,14 @@ class ZGWArchiveDateService
                 return $eigenschapObject->jsonSerialize()['naam'] === $eigenschap;
             }
         );
-        $eigenschapObject  = array_shift($eigenschapObjects);
+        $eigenschapObject = array_shift($eigenschapObjects);
 
-        return $eigenschapObject->jsonSerialize()['waarde'];
+        // Guard: array_shift returns null when no matching eigenschap was found (#278).
+        if ($eigenschapObject === null) {
+            return null;
+        }
+
+        return $eigenschapObject->jsonSerialize()['waarde'] ?? null;
     }//end calculateFromEigenschap()
 
     /**

--- a/lib/Service/ZGWLogicService.php
+++ b/lib/Service/ZGWLogicService.php
@@ -94,7 +94,8 @@ class ZGWLogicService
         $this->objectService->clearCurrents();
         $besluittype = $this->objectService->find($this->registry->getObjectIdByEndpointUrl($arr['besluittype']));
 
-        if (in_array(needle: $besluittype->jsonSerialize()['omschrijving'], haystack: $zaak->jsonSerialize()['zaaktype']['besluittypen']) === false) {
+        // besluittypen may be null when the zaaktype has no besluittypen configured (#282 bug-2).
+        if (in_array(needle: $besluittype->jsonSerialize()['omschrijving'], haystack: $zaak->jsonSerialize()['zaaktype']['besluittypen'] ?? []) === false) {
             throw new CustomValidationException(
                 'Besluittype niet in zaaktype',
                 [['name' => 'nonFieldErrors', 'code' => 'invalid-besluittype', 'reason' => 'besluittype hoort niet bij het zaaktype van de zaak']]
@@ -214,7 +215,13 @@ class ZGWLogicService
 
         $iots = $this->objectService->findAll(['filters' => ['omschrijving' => $informatieObjectTypeOmschrijving, 'register' => $this->registerMapper->find($this->registry->getZtcRegister())->getId(), 'schema' => $this->schemaMapper->find($this->registry->getIOTSchema())->getId()]]);
 
-        $iot      = array_shift($iots);
+        $iot = array_shift($iots);
+
+        // Guard: array_shift returns null when no informatieobjecttype was found (#282 bug-3).
+        if ($iot === null) {
+            return;
+        }
+
         $iotArray = $iot->jsonSerialize();
 
         $removeZaaktype = $ztIotArray['zaaktype'];

--- a/lib/Service/ZGWZaakLifecycleService.php
+++ b/lib/Service/ZGWZaakLifecycleService.php
@@ -60,13 +60,24 @@ class ZGWZaakLifecycleService
      */
     public function deleteZaak(ObjectEntity $zaak): void
     {
-        $arr  = $this->objectService->renderEntity($zaak);
-        $urls = array_merge($arr['rollen'] ?? [], $arr['eigenschappen'] ?? [], [$arr['resultaat']], $arr['statussen'] ?? [], $arr['deelzaken'] ?? [], $arr['zaakobjecten'] ?? [], [$arr['klantcontact']]);
+        $arr = $this->objectService->renderEntity($zaak);
+
+        // Build the URL list; resultaat and klantcontact are nullable singletons — guard
+        // with array_filter so null entries never reach getObjectIdByEndpointUrl (#278).
+        $singletons = array_filter([$arr['resultaat'] ?? null, $arr['klantcontact'] ?? null]);
+        $urls       = array_merge(
+            $arr['rollen'] ?? [],
+            $arr['eigenschappen'] ?? [],
+            $singletons,
+            $arr['statussen'] ?? [],
+            $arr['deelzaken'] ?? [],
+            $arr['zaakobjecten'] ?? []
+        );
 
         $ids = array_filter(array_map(fn(?string $url) => $url ? $this->registry->getObjectIdByEndpointUrl($url) : null, $urls));
         $this->objectService->deleteObjects($ids);
 
-        foreach ($arr['zaakinformatieobjecten'] as $zioUrl) {
+        foreach ($arr['zaakinformatieobjecten'] ?? [] as $zioUrl) {
             $this->objectService->deleteObject($this->registry->getObjectIdByEndpointUrl($zioUrl));
         }
     }//end deleteZaak()


### PR DESCRIPTION
## Summary

- **#278 null-derefs in lifecycle helpers**:
  - `deleteZaak`: `resultaat` and `klantcontact` are nullable singletons; now collected via `array_filter` so `null` never reaches `getObjectIdByEndpointUrl`.
  - `calculateFromHoofdzaak`: guard for `null` `hoofdzaak` (zaak is not a deelzaak).
  - `calculateFromEigenschap`: guard for `array_shift` returning `null` when no matching eigenschap found — prevents `Fatal: Call to member function on null`.
- **#280 ZIO cross-object URL validation**: `ZaakInformatieObjectenController::create` now validates `zaak` and `informatieobject` are present and are syntactically valid URLs before forwarding to the ZRC. Full per-object ACL check documented as a follow-up.
- **#282 bug-2**: `createZaakBesluit` — added `?? []` fallback on `besluittypen` to avoid PHP 8.3 warning on `in_array(..., null)`.
- **#282 bug-3**: `deleteZaakTypeInformatieObjecttype` — guard for `array_shift` returning `null` when no informatieobjecttype is found; early return instead of fatal dereference.
- **#282 bug-4**: `CallService` — set `http_errors => false` in default Guzzle config so non-2xx backend responses are returned to callers rather than thrown as unhandled `GuzzleException`. Replaced raw `json_decode` with a shared `decodeJson()` helper handling empty bodies and parse errors.

## Test plan

- [ ] Deleting a zaak that has no `resultaat` or `klantcontact` → deletes successfully without 500
- [ ] `POST /api/zrc/zaakinformatieobjecten` without `zaak` field → HTTP 400
- [ ] `POST /api/zrc/zaakinformatieobjecten` with `zaak: "not-a-url"` → HTTP 400
- [ ] Creating a besluit on a zaaktype with no `besluittypen` → validation error, no PHP 8.3 warning
- [ ] ZRC backend returns non-2xx → ZAA returns the backend's error JSON, not HTTP 500 stack trace