### PR TITLE
fix(deps): use pre-built beta.108 git-SHA while Actions OIDC is blocked

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
             "license": "EUPL-1.2",
             "dependencies": {
                 "@babel/core": "^7.29.0",
-                "@conduction/nextcloud-vue": "^1.0.0-beta.101",
+                "@conduction/nextcloud-vue": "github:ConductionNL/nextcloud-vue#14572a471fa908e5e7b8070246bb089a7569f36a",
                 "@fortawesome/fontawesome-svg-core": "^6.5.2",
                 "@fortawesome/free-solid-svg-icons": "^6.5.2",
                 "@nextcloud/axios": "~2.5.2",
@@ -2087,9 +2087,9 @@
             }
         },
         "node_modules/@conduction/nextcloud-vue": {
-            "version": "1.0.0-beta.101",
-            "resolved": "https://registry.npmjs.org/@conduction/nextcloud-vue/-/nextcloud-vue-1.0.0-beta.101.tgz",
-            "integrity": "sha512-UVxKWUU7pf6oHr7Oly5HWPC1e8OK3z2lmdS5xgs28+sYZPNj53co9+xs3tb0mqCGXZ8Oqit9NMapI8ir0fy2iA==",
+            "version": "1.0.0-beta.108",
+            "resolved": "git+ssh://git@github.com/ConductionNL/nextcloud-vue.git#14572a471fa908e5e7b8070246bb089a7569f36a",
+            "integrity": "sha512-tVqgxPVNQZ8q9uHSygl3WeDgHT1ppYBDHkoXsYc+2OFsv/rIQaBF+N1xYEC4UzyRJi8AFleNDfOITWXUr1+OpQ==",
             "license": "EUPL-1.2",
             "dependencies": {
                 "@codemirror/autocomplete": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     ],
     "dependencies": {
         "@babel/core": "^7.29.0",
-        "@conduction/nextcloud-vue": "^1.0.0-beta.101",
+        "@conduction/nextcloud-vue": "github:ConductionNL/nextcloud-vue#14572a471fa908e5e7b8070246bb089a7569f36a",
         "@fortawesome/fontawesome-svg-core": "^6.5.2",
         "@fortawesome/free-solid-svg-icons": "^6.5.2",
         "@nextcloud/axios": "~2.5.2",


### PR DESCRIPTION
## Summary

- Points `@conduction/nextcloud-vue` to the pre-built `dist-committed` branch SHA (`14572a47`) on `ConductionNL/nextcloud-vue` which carries the beta.108 fix
- `CnDataTable.effectiveColumns()` now handles string-array columns: `cols.map(c => typeof c === 'string' ? { key: c, label: c } : c)`
- This was blocked because GitHub Actions OIDC is 500-ing on nc-vue, preventing the `v1.0.0-beta.108` npm release from publishing

## When to swap back

Once `v1.0.0-beta.108` publishes to npm properly, replace the git-SHA reference with:
`"@conduction/nextcloud-vue": "^1.0.0-beta.108"`

## Test plan
- [ ] Build passes (`npm run build`)
- [ ] Table views render real data instead of `—`