### PR TITLE
fix(security): mass-assignment guard + IDOR sweep on audit-trail endpoints

### DIFF
--- a/lib/Controller/BerichtenController.php
+++ b/lib/Controller/BerichtenController.php
@@ -218,6 +218,12 @@ class BerichtenController extends Controller
             return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
         }
 
+        // IDOR guard: verify the object exists and is accessible before returning its audit trail.
+        $object = $this->objectService->getObject('berichten', $id);
+        if ($object === null) {
+            return new JSONResponse(['error' => 'Not found'], Http::STATUS_NOT_FOUND);
+        }
+
         $auditTrail = $this->objectService->getAuditTrail('berichten', $id);
         return new JSONResponse($auditTrail);
     }//end getAuditTrail()

--- a/lib/Controller/ContactMomentenController.php
+++ b/lib/Controller/ContactMomentenController.php
@@ -156,9 +156,6 @@ class ContactMomentenController extends Controller
      * @return JSONResponse
      *
      * @spec openspec/specs/zgw-client-interaction/spec.md#REQ-002
-     *
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter) — $id is part of the NC route signature;
-     *   the full payload is consumed via $this->request->getParams() instead.
      */
     public function update(string $id): JSONResponse
     {
@@ -168,6 +165,9 @@ class ContactMomentenController extends Controller
 
         // Get all parameters from the request
         $data = $this->request->getParams();
+
+        // Ensure the URL id is authoritative to prevent IDOR (client cannot override which record is updated).
+        $data['id'] = $id;
 
         // Save the updated contact moment
         $object = $this->objectService->saveObject('contactmomenten', $data);

--- a/lib/Controller/KlantenController.php
+++ b/lib/Controller/KlantenController.php
@@ -299,6 +299,12 @@ class KlantenController extends Controller
             return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
         }
 
+        // IDOR guard: verify the object exists and is accessible before returning its audit trail.
+        $object = $this->objectService->getObject('klanten', $id);
+        if ($object === null) {
+            return new JSONResponse(['error' => 'Not found'], Http::STATUS_NOT_FOUND);
+        }
+
         $auditTrail = $this->objectService->getAuditTrail('klanten', $id);
         return new JSONResponse($auditTrail);
     }//end getAuditTrail()

--- a/lib/Controller/ObjectsController.php
+++ b/lib/Controller/ObjectsController.php
@@ -19,6 +19,23 @@ use Exception;
 class ObjectsController extends Controller
 {
     /**
+     * Fields that are system-managed per object type.
+     * These must be stripped from create/update payloads to prevent mass-assignment
+     * of values that are set exclusively by business logic or the platform itself.
+     *
+     * @var array<string,string[]>
+     */
+    private const SYSTEM_MANAGED_FIELDS = [
+        'zaken'      => ['bronorganisatie', 'verantwoordelijkeOrganisatie', 'identificatie', 'archiefstatus', 'created', 'updated'],
+        'klanten'    => ['created', 'updated'],
+        'berichten'  => ['created', 'updated'],
+        'taken'      => ['created', 'updated'],
+        'resultaten' => ['created', 'updated'],
+        'statusen'   => ['created', 'updated'],
+        'besluiten'  => ['created', 'updated'],
+    ];
+
+    /**
      * Explicit allow-list of object types exposed through the generic objects endpoint.
      * Any objectType not in this list is rejected with HTTP 400 to prevent access to
      * unintended or internal schemas (#276 — unvalidated objectType).
@@ -72,6 +89,28 @@ class ObjectsController extends Controller
 
         return null;
     }//end validateObjectType()
+
+    /**
+     * Strip system-managed fields from a write payload.
+     *
+     * Removes fields listed in SYSTEM_MANAGED_FIELDS for the given objectType so that
+     * callers cannot mass-assign values that are set exclusively by business logic or
+     * the platform itself (e.g. bronorganisatie, archiefstatus, created/updated).
+     *
+     * @param string $objectType The object type being written.
+     * @param array  $data       The raw request payload.
+     *
+     * @return array The payload with system-managed fields removed.
+     */
+    private function stripSystemManagedFields(string $objectType, array $data): array
+    {
+        $protected = self::SYSTEM_MANAGED_FIELDS[$objectType] ?? [];
+        foreach ($protected as $field) {
+            unset($data[$field]);
+        }
+
+        return $data;
+    }//end stripSystemManagedFields()
 
     /**
      * Return (and search) all objects
@@ -181,6 +220,9 @@ class ObjectsController extends Controller
             // Remove the 'id' field if it exists, as we're creating a new object
             unset($data['id']);
 
+            // Strip system-managed fields to prevent mass-assignment of platform-controlled values.
+            $data = $this->stripSystemManagedFields($objectType, $data);
+
             // Save the new object
             $object = $this->objectService->saveObject($objectType, $data);
 
@@ -221,6 +263,9 @@ class ObjectsController extends Controller
 
             // Ensure ID in data matches URL parameter
             $data['id'] = $id;
+
+            // Strip system-managed fields to prevent mass-assignment of platform-controlled values.
+            $data = $this->stripSystemManagedFields($objectType, $data);
 
             // Save the updated object
             $object = $this->objectService->saveObject($objectType, $data);
@@ -292,6 +337,14 @@ class ObjectsController extends Controller
         }
 
         try {
+            // IDOR guard: verify the object exists (and that the current user has read access
+            // via OR's RBAC) before returning its audit trail. A null return means the object
+            // does not exist or is not accessible to the caller.
+            $object = $this->objectService->getObject($objectType, $id);
+            if ($object === null) {
+                return new JSONResponse(['error' => 'Not found'], Http::STATUS_NOT_FOUND);
+            }
+
             $auditTrail = $this->objectService->getAuditTrail($objectType, $id);
             return new JSONResponse($auditTrail);
         } catch (Exception $e) {

--- a/lib/Controller/TakenController.php
+++ b/lib/Controller/TakenController.php
@@ -237,6 +237,12 @@ class TakenController extends Controller
             return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
         }
 
+        // IDOR guard: verify the object exists and is accessible before returning its audit trail.
+        $object = $this->objectService->getObject('taken', $id);
+        if ($object === null) {
+            return new JSONResponse(['error' => 'Not found'], Http::STATUS_NOT_FOUND);
+        }
+
         $auditTrail = $this->objectService->getAuditTrail('taken', $id);
         return new JSONResponse($auditTrail);
     }//end getAuditTrail()

--- a/lib/Controller/ZaakAuditTrailController.php
+++ b/lib/Controller/ZaakAuditTrailController.php
@@ -119,12 +119,16 @@ class ZaakAuditTrailController extends Controller
     /**
      * Update an object.
      *
+     * $id is part of the NC route signature; this stub returns 501 Not Implemented.
+     *
      * @NoAdminRequired
      * @NoCSRFRequired
      *
      * @return JSONResponse
      *
      * @spec openspec/specs/zgw-zaak-management/spec.md#REQ-005
+     *
+     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
      */
     public function update(string $id): JSONResponse
     {

--- a/lib/Controller/ZaakInformatieObjectenController.php
+++ b/lib/Controller/ZaakInformatieObjectenController.php
@@ -89,6 +89,37 @@ class ZaakInformatieObjectenController extends Controller
     }//end show()
 
     /**
+     * Validate that the `zaak` and `informatieobject` URL fields are present and syntactically valid.
+     *
+     * Shared by both create and update so that the same hardening applied in #289 is enforced
+     * on partial updates as well.
+     *
+     * @param array $body The request payload.
+     *
+     * @return JSONResponse|null A 400 response on the first invalid field, null when all fields are valid.
+     */
+    private function validateZioUrls(array $body): ?JSONResponse
+    {
+        foreach (['zaak', 'informatieobject'] as $field) {
+            if (empty($body[$field]) === true) {
+                return new JSONResponse(
+                    [$field => ["Het veld $field is verplicht."]],
+                    Http::STATUS_BAD_REQUEST
+                );
+            }
+
+            if (filter_var($body[$field], FILTER_VALIDATE_URL) === false) {
+                return new JSONResponse(
+                    [$field => ["Het veld $field moet een geldige URL zijn."]],
+                    Http::STATUS_BAD_REQUEST
+                );
+            }
+        }
+
+        return null;
+    }//end validateZioUrls()
+
+    /**
      * Create a ZIO (zaak-informatieobject link).
      *
      * Guards (#280):
@@ -117,20 +148,9 @@ class ZaakInformatieObjectenController extends Controller
         $body = $this->request->getParams();
 
         // Validate that required URL fields are present and syntactically valid (#280).
-        foreach (['zaak', 'informatieobject'] as $field) {
-            if (empty($body[$field]) === true) {
-                return new JSONResponse(
-                    [$field => ["Het veld $field is verplicht."]],
-                    Http::STATUS_BAD_REQUEST
-                );
-            }
-
-            if (filter_var($body[$field], FILTER_VALIDATE_URL) === false) {
-                return new JSONResponse(
-                    [$field => ["Het veld $field moet een geldige URL zijn."]],
-                    Http::STATUS_BAD_REQUEST
-                );
-            }
+        $urlError = $this->validateZioUrls($body);
+        if ($urlError !== null) {
+            return $urlError;
         }
 
         $results = $callService->create(source: 'zrc', endpoint: 'zaakinformatieobjecten', data: $body);
@@ -139,6 +159,10 @@ class ZaakInformatieObjectenController extends Controller
 
     /**
      * Update an object
+     *
+     * Applies the same URL-field validation as create (#289 hardening) so that
+     * update payloads with invalid zaak/informatieobject URLs are rejected before
+     * they reach the ZRC backend.
      *
      * @NoAdminRequired
      * @NoCSRFRequired
@@ -153,7 +177,14 @@ class ZaakInformatieObjectenController extends Controller
             return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
         }
 
-        $body    = $this->request->getParams();
+        $body = $this->request->getParams();
+
+        // Validate URL fields on update as well as create (#289).
+        $urlError = $this->validateZioUrls($body);
+        if ($urlError !== null) {
+            return $urlError;
+        }
+
         $results = $callService->update(source: 'zrc', endpoint: 'zaakinformatieobjecten', data: $body, id: $id);
         return new JSONResponse($results);
     }//end update()

--- a/lib/Controller/ZakenController.php
+++ b/lib/Controller/ZakenController.php
@@ -221,6 +221,12 @@ class ZakenController extends Controller
             return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
         }
 
+        // IDOR guard: verify the object exists and is accessible before returning its audit trail.
+        $object = $this->objectService->getObject('zaken', $id);
+        if ($object === null) {
+            return new JSONResponse(['error' => 'Not found'], Http::STATUS_NOT_FOUND);
+        }
+
         $auditTrail = $this->objectService->getAuditTrail('zaken', $id);
         return new JSONResponse($auditTrail);
     }//end getAuditTrail()

--- a/lib/Service/ZGWArchiveDateService.php
+++ b/lib/Service/ZGWArchiveDateService.php
@@ -36,7 +36,12 @@ class ZGWArchiveDateService
         private RegisterMapper $registerMapper,
         private SchemaMapper $schemaMapper,
     ) {
-        $this->objectService = $mapperService->getOpenRegisters();
+        $objectService = $mapperService->getOpenRegisters();
+        if ($objectService === null) {
+            throw new \RuntimeException('ZGWArchiveDateService requires the OpenRegister app to be installed and enabled.');
+        }
+
+        $this->objectService = $objectService;
     }//end __construct()
 
     /**

--- a/lib/Service/ZGWLogicService.php
+++ b/lib/Service/ZGWLogicService.php
@@ -33,7 +33,12 @@ class ZGWLogicService
         private SchemaMapper $schemaMapper,
         private ZGWRegistryService $registry,
     ) {
-        $this->objectService = $mapperService->getOpenRegisters();
+        $objectService = $mapperService->getOpenRegisters();
+        if ($objectService === null) {
+            throw new \RuntimeException('ZGWLogicService requires the OpenRegister app to be installed and enabled.');
+        }
+
+        $this->objectService = $objectService;
     }//end __construct()
 
     /**

--- a/lib/Service/ZGWValidationService.php
+++ b/lib/Service/ZGWValidationService.php
@@ -25,7 +25,12 @@ class ZGWValidationService
      */
     public function __construct(ObjectMapperService $mapperService)
     {
-        $this->objectService = $mapperService->getOpenRegisters();
+        $objectService = $mapperService->getOpenRegisters();
+        if ($objectService === null) {
+            throw new \RuntimeException('ZGWValidationService requires the OpenRegister app to be installed and enabled.');
+        }
+
+        $this->objectService = $objectService;
     }//end __construct()
 
     /**

--- a/lib/Service/ZGWZaakCloseService.php
+++ b/lib/Service/ZGWZaakCloseService.php
@@ -24,7 +24,12 @@ class ZGWZaakCloseService
         private ZGWRegistryService $registry,
         private LoggerInterface $logger,
     ) {
-        $this->objectService = $mapperService->getOpenRegisters();
+        $objectService = $mapperService->getOpenRegisters();
+        if ($objectService === null) {
+            throw new \RuntimeException('ZGWZaakCloseService requires the OpenRegister app to be installed and enabled.');
+        }
+
+        $this->objectService = $objectService;
     }//end __construct()
 
     /**
@@ -97,9 +102,18 @@ class ZGWZaakCloseService
      */
     public function isEindStatus(array $statusArray): bool
     {
-        $statustype = $this->find($statusArray['statustype'], ['_extend.zaaktype' => 'zaaktype', '_extend.statustypen' => 'zaaktype.statustypen']);
-        $statusData = $statustype->jsonSerialize();
-        $max        = max(array_map(fn(array $statusItem) => $statusItem['volgnummer'], $statusData['_extend']['zaaktype']['_extend']['statustypen']));
+        $statustype  = $this->find($statusArray['statustype'], ['_extend.zaaktype' => 'zaaktype', '_extend.statustypen' => 'zaaktype.statustypen']);
+        $statusData  = $statustype->jsonSerialize();
+        $statustypen = $statusData['_extend']['zaaktype']['_extend']['statustypen'] ?? [];
+
+        if (empty($statustypen) === true) {
+            throw new CustomValidationException(
+                'Zaaktype heeft geen statustypen',
+                [['name' => 'statustype', 'code' => 'no-statustypen', 'reason' => 'Het zaaktype heeft geen statustypen; kan niet bepalen of dit een eindstatus is.']]
+            );
+        }
+
+        $max = max(array_map(fn(array $statusItem) => $statusItem['volgnummer'], $statustypen));
         return $statusData['volgnummer'] === $max;
     }//end isEindStatus()
 

--- a/lib/Service/ZGWZaakLifecycleService.php
+++ b/lib/Service/ZGWZaakLifecycleService.php
@@ -21,7 +21,12 @@ class ZGWZaakLifecycleService
         private ZGWZaakCloseService $closeService,
         private ZGWRegistryService $registry,
     ) {
-        $this->objectService = $mapperService->getOpenRegisters();
+        $objectService = $mapperService->getOpenRegisters();
+        if ($objectService === null) {
+            throw new \RuntimeException('ZGWZaakLifecycleService requires the OpenRegister app to be installed and enabled.');
+        }
+
+        $this->objectService = $objectService;
     }//end __construct()
 
     /**

--- a/lib/Service/ZGWZaakValidationService.php
+++ b/lib/Service/ZGWZaakValidationService.php
@@ -18,7 +18,12 @@ class ZGWZaakValidationService
 
     public function __construct(ObjectMapperService $mapperService)
     {
-        $this->objectService = $mapperService->getOpenRegisters();
+        $objectService = $mapperService->getOpenRegisters();
+        if ($objectService === null) {
+            throw new \RuntimeException('ZGWZaakValidationService requires the OpenRegister app to be installed and enabled.');
+        }
+
+        $this->objectService = $objectService;
     }//end __construct()
 
     /**


### PR DESCRIPTION
## Summary

- **C1**: Introduce `SYSTEM_MANAGED_FIELDS` map in `ObjectsController` and strip platform-controlled fields (`bronorganisatie`, `archiefstatus`, `created`, `updated`, etc.) from create/update payloads.
- **H1**: `ContactMomentenController::update` — enforce URL `$id` over any client-supplied id (IDOR fix); drop stale `@SuppressWarnings(UnusedFormalParameter)`.
- **H2**: `ZaakInformatieObjectenController` — extract `validateZioUrls()` helper and call it from both `update()` and `create()`.
- **H4**: Add IDOR guard to `getAuditTrail()` in `ZakenController`, `KlantenController`, `BerichtenController`, `TakenController`, and `ObjectsController`.
- **L1**: `ZGWZaakCloseService::isEindStatus` — throw `CustomValidationException` instead of `max([])` on empty statustypen.
- **L2**: `ZaakAuditTrailController::update` — add `@SuppressWarnings(PHPMD.UnusedFormalParameter)`.
- **L4**: Add `RuntimeException` null-guards in all six ZGW service constructors that call `getOpenRegisters()`.