### PR TITLE
refactor(quality): fix eigenschap findAll scope, CallService double-url, IMailer template, route naming

### DIFF
--- a/appinfo/routes.php
+++ b/appinfo/routes.php
@@ -43,7 +43,7 @@ return [
 		// Page routes
 		['name' => 'dashboard#page', 'url' => '/', 'verb' => 'GET'],
 		['name' => 'configuration#index', 'url' => '/api/configuration', 'verb' => 'GET'],
-		['name' => 'configuration#create', 'url' => '/api/configuration', 'verb' => 'POST'],
+		['name' => 'configuration#save', 'url' => '/api/configuration', 'verb' => 'POST'],
 		['name' => 'contactMomenten#page', 'url' => '/contactmomenten', 'verb' => 'GET'],
 		['name' => 'contactMomenten#page', 'postfix' => 'details', 'url' => '/contactmomenten/{id}', 'verb' => 'GET'],
 		['name' => 'zaken#page', 'url' => '/zaken', 'verb' => 'GET'],

--- a/lib/Controller/ConfigurationController.php
+++ b/lib/Controller/ConfigurationController.php
@@ -109,16 +109,19 @@ class ConfigurationController extends Controller
     }//end index()
 
     /**
-     * Persist configuration values supplied by an admin.
+     * Persist (upsert) configuration values supplied by an admin.
      *
      * Only keys present in WRITABLE_KEYS are accepted; all others are ignored.
      * Credential values are redacted in the response. Admin-only: @NoAdminRequired omitted.
+     *
+     * The method is named "save" rather than "create" because it behaves as an upsert —
+     * it creates or updates configuration keys in a single idempotent POST (L3).
      *
      * @NoCSRFRequired
      *
      * @spec openspec/specs/app-configuration/spec.md#REQ-001
      */
-    public function create(): JSONResponse
+    public function save(): JSONResponse
     {
         if ($this->userSession->getUser() === null) {
             return new JSONResponse(['error' => 'Not authenticated'], Http::STATUS_UNAUTHORIZED);
@@ -139,5 +142,5 @@ class ConfigurationController extends Controller
         }
 
         return new JSONResponse($data);
-    }//end create()
+    }//end save()
 }//end class

--- a/lib/EventListener/ZaakRegisterEventListener.php
+++ b/lib/EventListener/ZaakRegisterEventListener.php
@@ -74,6 +74,11 @@ class ZaakRegisterEventListener implements IEventListener
             // Re-open or close the zaak now that the status record is confirmed persisted.
             // closeZaak MUST run in ObjectCreated (not ObjectCreating) so the zaak is only
             // mutated when the triggering status write is known-successful — fixes #274.
+            //
+            // No double-dispatch risk (M4): closeZaak and reopenZaak are mutually exclusive
+            // via their isEindStatus() guard. closeZaak is a no-op when the status is not an
+            // eindstatus; reopenZaak is a no-op when the status IS an eindstatus. Both methods
+            // check isEindStatus independently, so only one path executes per status event.
             $this->lifecycleService->closeZaak($obj);
             $this->lifecycleService->reopenZaak($obj);
         }

--- a/lib/Service/CallService.php
+++ b/lib/Service/CallService.php
@@ -141,8 +141,10 @@ class CallService
             'query'   => $query,
         ];
 
-        // Setuo the client & make the call
-        $returnData = $this->getClient(source: $source, config: $config)->get($this->config->getValueString('zaakafhandelapp', "{$source}Location")."/$endpoint/$id");
+        // Use a relative path so Guzzle appends it to the base_uri configured in getConfig().
+        // Previously the full absolute URL was constructed here, duplicating the base_uri that
+        // getClient() already sets — causing double-prefixing on the request (M2).
+        $returnData = $this->getClient(source: $source, config: $config)->get("$endpoint/$id");
 
         return $this->decodeJson($returnData->getBody()->getContents());
     }//end show()

--- a/lib/Service/MailService.php
+++ b/lib/Service/MailService.php
@@ -64,24 +64,26 @@ class MailService
             return $newObject;
         }
 
-        // HTML-escape task data before interpolation to prevent stored-HTML injection (#272).
-        $taskId    = htmlspecialchars((string) ($newObject['id'] ?? ''), ENT_QUOTES | ENT_HTML5, 'UTF-8');
-        $taskTitle = htmlspecialchars((string) ($newObject['title'] ?? 'taak'), ENT_QUOTES | ENT_HTML5, 'UTF-8');
-        $baseUrl   = htmlspecialchars($this->urlGenerator->getBaseUrl(), ENT_QUOTES | ENT_HTML5, 'UTF-8');
+        $taskId    = (string) ($newObject['id'] ?? '');
+        $taskTitle = (string) ($newObject['title'] ?? 'taak');
+        $taskUrl   = $this->urlGenerator->getBaseUrl().'/apps/zaakafhandelapp/taken/'.rawurlencode($taskId);
+
+        // Use the NC-themed email template builder for auto-escaping and consistent theming (M3).
+        $emailTemplate = $this->mailer->createEMailTemplate('zaakafhandelapp.TaskAssigned');
+        $emailTemplate->setSubject('KISS: Er is een taak aan u toegewezen');
+        $emailTemplate->addBodyText(
+            'Er is een taak (<strong>'.htmlspecialchars($taskTitle, ENT_QUOTES | ENT_HTML5, 'UTF-8').'</strong>) aan u toegewezen.',
+            "Er is een taak ($taskTitle) aan u toegewezen."
+        );
+        $emailTemplate->addBodyButton(
+            'Ga naar de taak',
+            $taskUrl
+        );
 
         $message = $this->mailer->createMessage();
         $message->setSubject('KISS: Er is een taak aan u toegewezen');
         $message->setTo([$email]);
-        $message->setHtmlBody(
-            body: "<!doctype html>
-<html lang='nl'>
-<body>
-<p>Er is een taak (<strong>$taskTitle</strong>) aan u toegewezen. Klik
-<a href='$baseUrl/apps/zaakafhandelapp/taken/$taskId'>hier</a>
-om naar de taak te gaan.</p>
-</body>
-</html>"
-        );
+        $message->useTemplate($emailTemplate);
 
         $this->mailer->send($message);
 

--- a/lib/Service/ZGWArchiveDateService.php
+++ b/lib/Service/ZGWArchiveDateService.php
@@ -116,8 +116,15 @@ class ZGWArchiveDateService
                 },
                 $zaakArray['eigenschappen']
                 );
+
+        // Guard: an empty ids array would cause findAll to return ALL objects (M1).
+        // Return null immediately when the zaak has no eigenschappen.
+        if (empty($eigenschapIds) === true) {
+            return null;
+        }
+
         $this->objectService->clearCurrents();
-        $eigenschappen     = $this->objectService->findAll(['ids' => $eigenschapIds]);
+        $eigenschappen = $this->objectService->findAll(['ids' => $eigenschapIds]);
         $eigenschapObjects = array_filter(
             $eigenschappen,
             function (ObjectEntity $eigenschapObject) use ($eigenschap) {


### PR DESCRIPTION
## Summary

- **M1**: `ZGWArchiveDateService::calculateFromEigenschap` — early-return null when the zaak has no eigenschappen, preventing `findAll(["ids"=>[]])` from returning ALL objects.
- **M2**: `CallService::show` — use relative path `"$endpoint/$id"` so Guzzle appends to base_uri; removes double-prefixing of the location URL.
- **M3**: `MailService::sendMail` — migrate from manual HTML body to `IMailer::createEMailTemplate` for NC-themed rendering and framework escaping.
- **M4**: Document that `closeZaak` and `reopenZaak` are mutually exclusive via `isEindStatus()` — confirms no double-dispatch risk.
- **L3**: Rename `ConfigurationController::create` → `save` and update route name from `configuration#create` → `configuration#save` to reflect upsert semantics.

## Test plan

- [ ] `SKIP_PLATFORM_CHECK=1 php vendor/bin/phpstan analyse lib/ --no-progress` — 22 errors (all pre-existing)
- [ ] `POST /api/configuration` still works (route URL unchanged, only the NC route name changed)
- [ ] Task assignment email renders with NC theme
- [ ] `GET /api/objects/zaken?type=zaak` with zaak that has no eigenschappen does not trigger a full-table findAll