### PR TITLE
fix: stop OpenRegister stub shadowing the runtime classmap (openregister#2036)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,8 +26,7 @@
 	},
 	"autoload-dev": {
 		"psr-4": {
-			"OCA\\ZaakAfhandelApp\\Tests\\": "tests/",
-			"OCA\\OpenRegister\\": "tests/Stubs/"
+			"OCA\\ZaakAfhandelApp\\Tests\\": "tests/"
 		}
 	},
 	"scripts": {

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -56,10 +56,18 @@ if ($autoloader !== null && is_dir(__DIR__.'/../vendor/nextcloud/ocp/OCP') === t
 // nextcloud/ocp stub package registered above, and the OpenRegister classes the
 // ZGW services type-hint (ObjectEntity, ObjectService, RegisterMapper,
 // SchemaMapper, Schema, CustomValidationException) are resolved from the
-// lightweight, signature-matching stubs under tests/Stubs/. The autoload-dev
-// PSR-4 entry in composer.json already maps OCA\OpenRegister\ to tests/Stubs/;
-// the explicit registration below is a belt-and-braces fallback for runs where
-// the optimised classmap has not been regenerated.
-if ($autoloader !== null && class_exists(\OCA\OpenRegister\Db\ObjectEntity::class) === false) {
+// lightweight, signature-matching stubs under tests/Stubs/.
+//
+// The OCA\OpenRegister\ => tests/Stubs/ PSR-4 mapping deliberately lives ONLY
+// here (test-time) and NOT in composer.json autoload-dev: a dev-built vendor/
+// (the shared dev instance builds with dev) would otherwise fold the stubs into
+// the runtime classmap and SHADOW the real OpenRegister classes instance-wide,
+// 500ing every app. See openregister#2036 / hermiq#21. Registering on the
+// loader here is lazy (findFile only resolves when a class is actually
+// requested), so ordering vs the OCP registration above is fine. We register
+// unconditionally — do NOT guard with class_exists(): a failed class_exists()
+// probe against another registered autoloader (e.g. phpstan's PharAutoloader)
+// poisons resolution so a subsequent addPsr4() no longer takes effect.
+if ($autoloader !== null) {
     $autoloader->addPsr4('OCA\\OpenRegister\\', __DIR__.'/Stubs/');
 }


### PR DESCRIPTION
## The bug

The `OCA\OpenRegister\ => tests/Stubs/` PSR-4 entry lived under composer.json **`autoload-dev`**. When `vendor/` is built WITH dev (the shared dev instance does), that mapping enters the optimized runtime classmap and the lightweight signature-only test stubs **shadow the real OpenRegister classes instance-wide → 500s everywhere**. Releases (`--no-dev`) were unaffected. Same class of bug as openregister#2036 / hermiq#21 (proven on decidesk #349).

## The fix

- **composer.json** — drop the `OCA\OpenRegister\` stub entry from `autoload-dev`. The legit `OCA\ZaakAfhandelApp\Tests\ => tests/` mapping stays.
- **tests/bootstrap.php** — register the stub namespace on the composer loader at test-time via `addPsr4()`. Registered **unconditionally**: the pre-existing `class_exists(...) === false` guard actually *poisoned* autoload once the composer mapping was gone — a failed `class_exists()` probe against another registered autoloader (phpstan's `PharAutoloader`) stops a subsequent `addPsr4()` from taking effect. The comment now references openregister#2036.

## Verification (dev-built vendor, PHP 8.4, nextcloud container)

- **composer.json** valid JSON.
- **PROOF 1 (shadow gone)** — after `composer dump-autoload --dev`, `vendor/composer/autoload_classmap.php` and `autoload_psr4.php` carry **0** `OpenRegister` refs (baseline deployed vendor had 6 + 1). Composer emits "does not comply with psr-4 ... Skipping" for each stub, confirming they are no longer folded into the runtime classmap.
- **PROOF 2 (tests still load stubs)** — unit suite **99/99 green** on both `phpunit-unit.xml` and `phpunit.xml`. No pre-existing failures.

Do not merge without orchestrator sign-off; Codeberg mirror handled separately.